### PR TITLE
Add support for PHP 5.3 [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "source": "https://github.com/phpmyadmin/sql-parser"
     },
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.3.0",
         "ext-mbstring": "*"
     },
     "require-dev": {

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -122,49 +122,49 @@ class Formatter
                         'type'      => Token::TYPE_KEYWORD,
                         'flags'     => Token::FLAG_KEYWORD_RESERVED,
                         'html'      => 'class="sql-reserved"',
-                        'cli'       => "\e[35m",
+                        'cli'       => "\x1b[35m",
                         'function'  => 'strtoupper',
                     ),
                     array(
                         'type'      => Token::TYPE_KEYWORD,
                         'flags'     => 0,
                         'html'      => 'class="sql-keyword"',
-                        'cli'       => "\e[95m",
+                        'cli'       => "\x1b[95m",
                         'function'  => 'strtoupper',
                     ),
                     array(
                         'type'      => Token::TYPE_COMMENT,
                         'flags'     => 0,
                         'html'      => 'class="sql-comment"',
-                        'cli'       => "\e[37m",
+                        'cli'       => "\x1b[37m",
                         'function'  => '',
                     ),
                     array(
                         'type'      => Token::TYPE_BOOL,
                         'flags'     => 0,
                         'html'      => 'class="sql-atom"',
-                        'cli'       => "\e[36m",
+                        'cli'       => "\x1b[36m",
                         'function'  => 'strtoupper',
                     ),
                     array(
                         'type'      => Token::TYPE_NUMBER,
                         'flags'     => 0,
                         'html'      => 'class="sql-number"',
-                        'cli'       => "\e[92m",
+                        'cli'       => "\x1b[92m",
                         'function'  => 'strtolower',
                     ),
                     array(
                         'type'      => Token::TYPE_STRING,
                         'flags'     => 0,
                         'html'      => 'class="sql-string"',
-                        'cli'       => "\e[91m",
+                        'cli'       => "\x1b[91m",
                         'function'  => '',
                     ),
                     array(
                         'type'      => Token::TYPE_SYMBOL,
                         'flags'     => 0,
                         'html'      => 'class="sql-variable"',
-                        'cli'       => "\e[36m",
+                        'cli'       => "\x1b[36m",
                         'function'  => '',
                     ),
                 )
@@ -420,7 +420,7 @@ class Formatter
         }
 
         if ($this->options['type'] === 'cli') {
-            return $ret . "\e[0m";
+            return $ret . "\x1b[0m";
         }
 
         return $ret;
@@ -459,7 +459,7 @@ class Formatter
         }
 
         if ($this->options['type'] === 'cli') {
-            return "\e[39m" . $text;
+            return "\x1b[39m" . $text;
         }
         return $text;
     }

--- a/tests/Utils/FormatterTest.php
+++ b/tests/Utils/FormatterTest.php
@@ -75,7 +75,7 @@ class FormatTest extends TestCase
             ),
             array(
                 'SELECT 1',
-                "\x1b[35mSELECT\n  \x1b[92m1\e[0m",
+                "\x1b[35mSELECT\n  \x1b[92m1\x1b[0m",
                 'cli'
             ),
             array(


### PR DESCRIPTION
There [seem to be users](https://github.com/versionpress/versionpress) who still support PHP 5.3 and can not use latest SQL parser due to our raised dependency to 5.4.

There was no particular reason in removing old PHP versions, see a0233937.