### PR TITLE
fix default options in Formater constructor

### DIFF
--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -73,7 +73,7 @@ class Formatter
                  *
                  * @var string
                  */
-                'line_ending' => $this->options['type'] == 'html' ? '<br/>' : "\n",
+                'line_ending' => NULL,
 
                 /**
                  * The string used for indentation.
@@ -171,6 +171,10 @@ class Formatter
             ),
             $options
         );
+
+        if (is_null($this->options['line_ending'])) {
+            $this->options['line_ending'] = $this->options['type'] == 'html' ? '<br/>' : "\n";
+        }
 
         // `parts_newline` requires `clause_newline`
         $this->options['parts_newline'] &= $this->options['clause_newline'];

--- a/tests/Utils/CLITest.php
+++ b/tests/Utils/CLITest.php
@@ -43,7 +43,7 @@ class CLITest extends TestCase
             ),
             array(
                 array('q' => 'SELECT 1', 'f' => 'html'),
-                '<span class="sql-reserved">SELECT</span>' . "\n" .
+                '<span class="sql-reserved">SELECT</span>' . '<br/>' .
                 '  <span class="sql-number">1</span>' . "\n",
                 0,
             ),

--- a/tests/Utils/FormatterTest.php
+++ b/tests/Utils/FormatterTest.php
@@ -24,50 +24,50 @@ class FormatTest extends TestCase
         return array(
             array(
                 'SELECT 1',
-                '<span class="sql-reserved">SELECT</span>' . "\n" .
+                '<span class="sql-reserved">SELECT</span>' . '<br/>' .
                 '  <span class="sql-number">1</span>',
                 array('type' => 'html')
             ),
             array(
                 'SELECT 1 # Comment',
-                '<span class="sql-reserved">SELECT</span>' . "\n" .
+                '<span class="sql-reserved">SELECT</span>' . '<br/>' .
                 '  <span class="sql-number">1</span> <span class="sql-comment"># Comment' . "\n" .
                 '</span>',
                 array('type' => 'html')
             ),
             array(
                 'SELECT HEX("1")',
-                '<span class="sql-reserved">SELECT</span>' . "\n" .
+                '<span class="sql-reserved">SELECT</span>' . '<br/>' .
                 '  <span class="sql-keyword">HEX</span>(<span class="sql-string">"1"</span>)',
                 array('type' => 'html')
             ),
             array(
                 'SELECT * FROM foo WHERE bar=1',
-                '<span class="sql-reserved">SELECT</span>' . "\n" .
-                '  *' . "\n" .
-                '<span class="sql-reserved">FROM</span>' . "\n" .
-                '  foo' . "\n" .
-                '<span class="sql-reserved">WHERE</span>' . "\n" .
+                '<span class="sql-reserved">SELECT</span>' . '<br/>' .
+                '  *' . '<br/>' .
+                '<span class="sql-reserved">FROM</span>' . '<br/>' .
+                '  foo' . '<br/>' .
+                '<span class="sql-reserved">WHERE</span>' . '<br/>' .
                 '  bar = <span class="sql-number">1</span>',
                 array('type' => 'html')
             ),
             array(
                 'CREATE PROCEDURE SPTEST() BEGIN FROM a SELECT *; END',
-                '<span class="sql-reserved">CREATE</span>' . "\n" .
-                '<span class="sql-reserved">PROCEDURE</span> SPTEST()' . "\n" .
-                '<span class="sql-keyword">BEGIN</span>' . "\n" .
-                '<span class="sql-reserved">FROM</span>' . "\n" .
-                '  a' . "\n" .
-                '<span class="sql-reserved">SELECT</span>' . "\n" .
-                '  *;' . "\n" .
+                '<span class="sql-reserved">CREATE</span>' . '<br/>' .
+                '<span class="sql-reserved">PROCEDURE</span> SPTEST()' . '<br/>' .
+                '<span class="sql-keyword">BEGIN</span>' . '<br/>' .
+                '<span class="sql-reserved">FROM</span>' . '<br/>' .
+                '  a' . '<br/>' .
+                '<span class="sql-reserved">SELECT</span>' . '<br/>' .
+                '  *;' . '<br/>' .
                 '<span class="sql-keyword">END</span>',
                 array('type' => 'html')
             ),
             array(
                 'INSERT INTO foo VALUES (0, 0, 0), (1, 1, 1)',
-                '<span class="sql-reserved">INSERT</span>' . "\n" .
-                '<span class="sql-reserved">INTO</span>' . "\n" .
-                '  foo' . "\n" .
+                '<span class="sql-reserved">INSERT</span>' . '<br/>' .
+                '<span class="sql-reserved">INTO</span>' . '<br/>' .
+                '  foo' . '<br/>' .
                 '<span class="sql-reserved">VALUES</span>' .
                 '(<span class="sql-number">0</span>, <span class="sql-number">0</span>, <span class="sql-number">0</span>),' .
                 '(<span class="sql-number">1</span>, <span class="sql-number">1</span>, <span class="sql-number">1</span>)',
@@ -85,27 +85,27 @@ class FormatTest extends TestCase
             ),
             array(
                 'SELECT coditm AS Item, descripcion AS Descripcion, contenedores AS Contenedores, IF(suspendido = 1, Si, NO) AS Suspendido FROM `DW_articulos` WHERE superado = 0',
-                '<span class="sql-reserved">SELECT</span>' . "\n" .
-                '  coditm <span class="sql-reserved">AS</span> Item,' . "\n" .
-                '  descripcion <span class="sql-reserved">AS</span> Descripcion,' . "\n" .
-                '  contenedores <span class="sql-reserved">AS</span> Contenedores,' . "\n" .
-                '  <span class="sql-reserved">IF</span>(suspendido = <span class="sql-number">1</span>, Si, <span class="sql-keyword">NO</span>) <span class="sql-reserved">AS</span> Suspendido' . "\n" .
-                '<span class="sql-reserved">FROM</span>' . "\n" .
-                '  <span class="sql-variable">`DW_articulos`</span>' . "\n" .
-                '<span class="sql-reserved">WHERE</span>' . "\n" .
+                '<span class="sql-reserved">SELECT</span>' . '<br/>' .
+                '  coditm <span class="sql-reserved">AS</span> Item,' . '<br/>' .
+                '  descripcion <span class="sql-reserved">AS</span> Descripcion,' . '<br/>' .
+                '  contenedores <span class="sql-reserved">AS</span> Contenedores,' . '<br/>' .
+                '  <span class="sql-reserved">IF</span>(suspendido = <span class="sql-number">1</span>, Si, <span class="sql-keyword">NO</span>) <span class="sql-reserved">AS</span> Suspendido' . '<br/>' .
+                '<span class="sql-reserved">FROM</span>' . '<br/>' .
+                '  <span class="sql-variable">`DW_articulos`</span>' . '<br/>' .
+                '<span class="sql-reserved">WHERE</span>' . '<br/>' .
                 '  superado = <span class="sql-number">0</span>',
                 array('type' => 'html'),
             ),
             array(
                 'SELECT 1 -- comment',
-                '<span class="sql-reserved">SELECT</span>' . "\n" .
+                '<span class="sql-reserved">SELECT</span>' . '<br/>' .
                 '  <span class="sql-number">1</span> <span class="sql-comment">-- comment' . "\n" .
                 '</span>',
                 array('type' => 'html'),
             ),
             array(
                 'SELECT 1 -- comment',
-                '<span class="sql-reserved">SELECT</span>' . "\n" .
+                '<span class="sql-reserved">SELECT</span>' . '<br/>' .
                 '  <span class="sql-number">1</span>',
                 array('type' => 'html', 'remove_comments' => true),
             ),
@@ -117,12 +117,12 @@ class FormatTest extends TestCase
                 '  `label` varchar(255) COLLATE utf8_general_ci NOT NULL default "",' . "\n" .
                 '  `query` text NOT NULL,' . "\n" .
                 '  PRIMARY KEY  (`id`)' . "\n",
-                '<span class="sql-reserved">CREATE</span> <span class="sql-reserved">TABLE</span> <span class="sql-reserved">IF NOT EXISTS</span> <span class="sql-variable">`pma__bookmark`</span>(' . "\n" .
-                '  <span class="sql-variable">`id`</span> <span class="sql-reserved">INT</span>(<span class="sql-number">11</span>) <span class="sql-reserved">NOT NULL</span> <span class="sql-keyword">AUTO_INCREMENT</span>,' . "\n" .
-                '  <span class="sql-variable">`dbase`</span> <span class="sql-reserved">VARCHAR</span>(<span class="sql-number">255</span>) <span class="sql-reserved">NOT NULL</span> <span class="sql-reserved">DEFAULT</span> <span class="sql-string">""</span>,' . "\n" .
-                '  <span class="sql-variable">`user`</span> <span class="sql-reserved">VARCHAR</span>(<span class="sql-number">255</span>) <span class="sql-reserved">NOT NULL</span> <span class="sql-reserved">DEFAULT</span> <span class="sql-string">""</span>,' . "\n" .
-                '  <span class="sql-variable">`label`</span> <span class="sql-reserved">VARCHAR</span>(<span class="sql-number">255</span>) <span class="sql-reserved">COLLATE</span> utf8_general_ci <span class="sql-reserved">NOT NULL</span> <span class="sql-reserved">DEFAULT</span> <span class="sql-string">""</span>,' . "\n" .
-                '  <span class="sql-variable">`query`</span> <span class="sql-keyword">TEXT</span> <span class="sql-reserved">NOT NULL</span>,' . "\n" .
+                '<span class="sql-reserved">CREATE</span> <span class="sql-reserved">TABLE</span> <span class="sql-reserved">IF NOT EXISTS</span> <span class="sql-variable">`pma__bookmark`</span>(' . '<br/>' .
+                '  <span class="sql-variable">`id`</span> <span class="sql-reserved">INT</span>(<span class="sql-number">11</span>) <span class="sql-reserved">NOT NULL</span> <span class="sql-keyword">AUTO_INCREMENT</span>,' . '<br/>' .
+                '  <span class="sql-variable">`dbase`</span> <span class="sql-reserved">VARCHAR</span>(<span class="sql-number">255</span>) <span class="sql-reserved">NOT NULL</span> <span class="sql-reserved">DEFAULT</span> <span class="sql-string">""</span>,' . '<br/>' .
+                '  <span class="sql-variable">`user`</span> <span class="sql-reserved">VARCHAR</span>(<span class="sql-number">255</span>) <span class="sql-reserved">NOT NULL</span> <span class="sql-reserved">DEFAULT</span> <span class="sql-string">""</span>,' . '<br/>' .
+                '  <span class="sql-variable">`label`</span> <span class="sql-reserved">VARCHAR</span>(<span class="sql-number">255</span>) <span class="sql-reserved">COLLATE</span> utf8_general_ci <span class="sql-reserved">NOT NULL</span> <span class="sql-reserved">DEFAULT</span> <span class="sql-string">""</span>,' . '<br/>' .
+                '  <span class="sql-variable">`query`</span> <span class="sql-keyword">TEXT</span> <span class="sql-reserved">NOT NULL</span>,' . '<br/>' .
                 '  <span class="sql-reserved">PRIMARY KEY</span>(<span class="sql-variable">`id`</span>)',
                 array('type' => 'html'),
             ),


### PR DESCRIPTION
In the construction, default value for 'line_ending' doesn't work, as $this->options['type']  cannot be tested at this point (not yet set).

So for "html", default value still "\n", as shown in the test suite.
This fix should give the expected (documented) behavior.
