### PR TITLE
Minor PHPDoc fix

### DIFF
--- a/src/Statements/InsertStatement.php
+++ b/src/Statements/InsertStatement.php
@@ -81,7 +81,7 @@ class InsertStatement extends Statement
     /**
      * Values to be inserted.
      *
-     * @var Array2d
+     * @var ArrayObj[]|null
      */
     public $values;
 


### PR DESCRIPTION
I've noticed that both when the property is written to or read from, an array of ArrayObj is expected.