### PR TITLE
Made motranslator vendor optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,30 @@ $query2 = $statement->build();
 var_dump($query2); // outputs string(19) "SELECT  * FROM "b" "
 ```
 
+## Localization
+
+You can localize error messages installing `phpmyadmin/motranslator` version `3.0` or newer:
+```sh
+composer require phpmyadmin/motranslator:^3.0
+```
+
+The locale is automatically detected from your enrivonment, you can also set a different locale
+
+**From cli**:
+```sh
+LC_ALL=pl ./vendor/bin/lint-query --query "SELECT 1"
+```
+
+**From php**:
+```php
+require __DIR__."/vendor/autoload.php";
+
+$GLOBALS['lang'] = 'pl';
+
+$query1 = "select * from a";
+$parser = new PhpMyAdmin\SqlParser\Parser($query1);
+```
+
 ## More information
 
 This library was originally created during the Google Summer of Code 2015 and has been used by phpMyAdmin since version 4.5.

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,16 @@
         "php": ">=5.3.0",
         "ext-mbstring": "*"
     },
+    "require-dev": {
+        "phpmyadmin/motranslator": "~3.0",
+        "phpunit/php-code-coverage": "~2.0 || ~3.0",
+        "phpunit/phpunit": "~4.8 || ~5.1"
+    },
     "conflict": {
         "phpmyadmin/motranslator": "<3.0"
     },
     "suggest": {
         "phpmyadmin/motranslator": "Translate messages to your favorite locale"
-    },
-    "require-dev": {
-        "phpunit/php-code-coverage": "~2.0 || ~3.0",
-        "phpunit/phpunit": "~4.8 || ~5.1"
     },
     "bin": [
         "bin/highlight-query",

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,13 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "phpmyadmin/motranslator": "~3.0",
         "ext-mbstring": "*"
+    },
+    "conflict": {
+        "phpmyadmin/motranslator": "<3.0"
+    },
+    "suggest": {
+        "phpmyadmin/motranslator": "Translate messages to your favorite locale"
     },
     "require-dev": {
         "phpunit/php-code-coverage": "~2.0 || ~3.0",

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -58,6 +58,10 @@ class Translator
      */
     public static function gettext($msgid)
     {
+        if (!class_exists('\PhpMyAdmin\MoTranslator\Loader', true)) {
+            return $msgid;
+        }
+
         self::load();
 
         return self::$translator->gettext($msgid);


### PR DESCRIPTION
Suggest installing `phpmyadmin/mostranslator` instead of requiring it.

Close https://github.com/phpmyadmin/sql-parser/issues/129