### PR TITLE
Cs fix phpdoc add missing param annotation

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -14,6 +14,7 @@ return PhpCsFixer\Config::create()
         'array_syntax' => array('syntax' => 'long'),
         'concat_space' => array('spacing' => true),
         'no_trailing_whitespace' => true,
+        'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_order' => true,
     ))
     ->setFinder($finder)

--- a/src/Components/UnionKeyword.php
+++ b/src/Components/UnionKeyword.php
@@ -7,7 +7,6 @@
 namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
-use PhpMyAdmin\SqlParser\Statements\SelectStatement;
 
 /**
  * `UNION` keyword builder.

--- a/src/Utils/Query.php
+++ b/src/Utils/Query.php
@@ -277,6 +277,7 @@ class Query
         if (!empty($statement->join)) {
             $flags['join'] = true;
         }
+
         return $flags;
     }
 

--- a/tests/Components/ArrayObjTest.php
+++ b/tests/Components/ArrayObjTest.php
@@ -38,6 +38,7 @@ class ArrayObjTest extends TestCase
 
     /**
      * @dataProvider testParseProvider
+     * @param mixed $test
      */
     public function testParse($test)
     {

--- a/tests/Components/ExpressionTest.php
+++ b/tests/Components/ExpressionTest.php
@@ -21,6 +21,8 @@ class ExpressionTest extends TestCase
 
     /**
      * @dataProvider testParseErrProvider
+     * @param mixed $expr
+     * @param mixed $error
      */
     public function testParseErr($expr, $error)
     {

--- a/tests/Components/LimitTest.php
+++ b/tests/Components/LimitTest.php
@@ -22,6 +22,7 @@ class LimitTest extends TestCase
 
     /**
      * @dataProvider testParseProvider
+     * @param mixed $test
      */
     public function testParse($test)
     {

--- a/tests/Lexer/LexerTest.php
+++ b/tests/Lexer/LexerTest.php
@@ -48,6 +48,7 @@ class LexerTest extends TestCase
 
     /**
      * @dataProvider testLexProvider
+     * @param mixed $test
      */
     public function testLex($test)
     {

--- a/tests/Misc/BugsTest.php
+++ b/tests/Misc/BugsTest.php
@@ -8,6 +8,7 @@ class BugsTest extends TestCase
 {
     /**
      * @dataProvider testBugProvider
+     * @param mixed $test
      */
     public function testBug($test)
     {

--- a/tests/Parser/AlterStatementTest.php
+++ b/tests/Parser/AlterStatementTest.php
@@ -8,6 +8,7 @@ class AlterStatementTest extends TestCase
 {
     /**
      * @dataProvider testAlterProvider
+     * @param mixed $test
      */
     public function testAlter($test)
     {

--- a/tests/Parser/CallStatementTest.php
+++ b/tests/Parser/CallStatementTest.php
@@ -8,6 +8,7 @@ class CallStatementTest extends TestCase
 {
     /**
      * @dataProvider testCallProvider
+     * @param mixed $test
      */
     public function testCall($test)
     {

--- a/tests/Parser/CreateStatementTest.php
+++ b/tests/Parser/CreateStatementTest.php
@@ -8,6 +8,7 @@ class CreateStatementTest extends TestCase
 {
     /**
      * @dataProvider testCreateProvider
+     * @param mixed $test
      */
     public function testCreate($test)
     {

--- a/tests/Parser/DeleteStatementTest.php
+++ b/tests/Parser/DeleteStatementTest.php
@@ -8,6 +8,7 @@ class DeleteStatementTest extends TestCase
 {
     /**
      * @dataProvider testDeleteProvider
+     * @param mixed $test
      */
     public function testDelete($test)
     {

--- a/tests/Parser/ExplainStatement.php
+++ b/tests/Parser/ExplainStatement.php
@@ -8,6 +8,7 @@ class ExplainStatementTest extends TestCase
 {
     /**
      * @dataProvider testExplainProvider
+     * @param mixed $test
      */
     public function testExplain($test)
     {

--- a/tests/Parser/InsertStatementTest.php
+++ b/tests/Parser/InsertStatementTest.php
@@ -8,6 +8,7 @@ class InsertStatementTest extends TestCase
 {
     /**
      * @dataProvider testInsertProvider
+     * @param mixed $test
      */
     public function testInsert($test)
     {

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -12,6 +12,7 @@ class ParserTest extends TestCase
 {
     /**
      * @dataProvider testParseProvider
+     * @param mixed $test
      */
     public function testParse($test)
     {

--- a/tests/Parser/RenameStatementTest.php
+++ b/tests/Parser/RenameStatementTest.php
@@ -8,6 +8,7 @@ class RenameStatementTest extends TestCase
 {
     /**
      * @dataProvider testRenameProvider
+     * @param mixed $test
      */
     public function testRename($test)
     {

--- a/tests/Parser/ReplaceStatementTest.php
+++ b/tests/Parser/ReplaceStatementTest.php
@@ -8,6 +8,7 @@ class ReplaceStatementTest extends TestCase
 {
     /**
      * @dataProvider testReplaceProvider
+     * @param mixed $test
      */
     public function testReplace($test)
     {

--- a/tests/Parser/RestoreStatementTest.php
+++ b/tests/Parser/RestoreStatementTest.php
@@ -8,6 +8,7 @@ class RestoreStatementTest extends TestCase
 {
     /**
      * @dataProvider testRestoreProvider
+     * @param mixed $test
      */
     public function testRestore($test)
     {

--- a/tests/Parser/SelectStatementTest.php
+++ b/tests/Parser/SelectStatementTest.php
@@ -17,6 +17,7 @@ class SelectStatementTest extends TestCase
 
     /**
      * @dataProvider testSelectProvider
+     * @param mixed $test
      */
     public function testSelect($test)
     {

--- a/tests/Parser/SetStatementTest.php
+++ b/tests/Parser/SetStatementTest.php
@@ -8,6 +8,7 @@ class SetStatementTest extends TestCase
 {
     /**
      * @dataProvider testSetProvider
+     * @param mixed $test
      */
     public function testSet($test)
     {

--- a/tests/Parser/TransactionStatementTest.php
+++ b/tests/Parser/TransactionStatementTest.php
@@ -8,6 +8,7 @@ class TransactionStatementTest extends TestCase
 {
     /**
      * @dataProvider testTransactionProvider
+     * @param mixed $test
      */
     public function testTransaction($test)
     {

--- a/tests/Parser/UpdateStatementTest.php
+++ b/tests/Parser/UpdateStatementTest.php
@@ -8,6 +8,7 @@ class UpdateStatementTest extends TestCase
 {
     /**
      * @dataProvider testUpdateProvider
+     * @param mixed $test
      */
     public function testUpdate($test)
     {

--- a/tests/Utils/BufferedQueryTest.php
+++ b/tests/Utils/BufferedQueryTest.php
@@ -9,6 +9,8 @@ class BufferedQueryTest extends TestCase
 {
     /**
      * @dataProvider testExtractProvider
+     * @param mixed $query
+     * @param mixed $chunkSize
      */
     public function testExtract(
         $query,

--- a/tests/Utils/CLITest.php
+++ b/tests/Utils/CLITest.php
@@ -30,6 +30,9 @@ class CLITest extends TestCase
 
     /**
      * @dataProvider highlightParams
+     * @param mixed $getopt
+     * @param mixed $output
+     * @param mixed $result
      */
     public function testRunHighlight($getopt, $output, $result)
     {
@@ -88,6 +91,9 @@ class CLITest extends TestCase
 
     /**
      * @dataProvider lintParams
+     * @param mixed $getopt
+     * @param mixed $output
+     * @param mixed $result
      */
     public function testRunLint($getopt, $output, $result)
     {

--- a/tests/Utils/FormatterTest.php
+++ b/tests/Utils/FormatterTest.php
@@ -9,6 +9,9 @@ class FormatTest extends TestCase
 {
     /**
      * @dataProvider mergeFormats
+     * @param mixed $default
+     * @param mixed $overriding
+     * @param mixed $expected
      */
     public function testMergeFormats($default, $overriding, $expected)
     {
@@ -231,6 +234,10 @@ class FormatTest extends TestCase
 
     /**
      * @dataProvider formatQueries
+     * @param mixed $query
+     * @param mixed $text
+     * @param mixed $cli
+     * @param mixed $html
      */
     public function testFormat($query, $text, $cli, $html, array $options = array())
     {

--- a/tests/Utils/MiscTest.php
+++ b/tests/Utils/MiscTest.php
@@ -10,6 +10,8 @@ class MiscTest extends TestCase
 {
     /**
      * @dataProvider getAliasesProvider
+     * @param mixed $query
+     * @param mixed $db
      */
     public function testGetAliases($query, $db, array $expected)
     {

--- a/tests/Utils/QueryTest.php
+++ b/tests/Utils/QueryTest.php
@@ -10,6 +10,8 @@ class QueryTest extends TestCase
 {
     /**
      * @dataProvider testGetFlagsProvider
+     * @param mixed $query
+     * @param mixed $expected
      */
     public function testGetFlags($query, $expected)
     {
@@ -347,6 +349,8 @@ class QueryTest extends TestCase
 
     /**
      * @dataProvider testGetTablesProvider
+     * @param mixed $query
+     * @param mixed $expected
      */
     public function testGetTables($query, $expected)
     {

--- a/tests/Utils/RoutineTest.php
+++ b/tests/Utils/RoutineTest.php
@@ -10,6 +10,7 @@ class RoutineTest extends TestCase
 {
     /**
      * @dataProvider getReturnTypeProvider
+     * @param mixed $def
      */
     public function testGetReturnType($def, array $expected)
     {
@@ -49,6 +50,7 @@ class RoutineTest extends TestCase
 
     /**
      * @dataProvider getParameterProvider
+     * @param mixed $def
      */
     public function testGetParameter($def, array $expected)
     {
@@ -88,6 +90,7 @@ class RoutineTest extends TestCase
 
     /**
      * @dataProvider getParametersProvider
+     * @param mixed $query
      */
     public function testGetParameters($query, array $expected)
     {

--- a/tests/Utils/TableTest.php
+++ b/tests/Utils/TableTest.php
@@ -10,6 +10,7 @@ class TableTest extends TestCase
 {
     /**
      * @dataProvider getForeignKeysProvider
+     * @param mixed $query
      */
     public function testGetForeignKeys($query, array $expected)
     {
@@ -110,6 +111,7 @@ class TableTest extends TestCase
 
     /**
      * @dataProvider getFieldsProvider
+     * @param mixed $query
      */
     public function testGetFields($query, array $expected)
     {

--- a/tests/Utils/TokensTest.php
+++ b/tests/Utils/TokensTest.php
@@ -10,6 +10,10 @@ class TokensTest extends TestCase
 {
     /**
      * @dataProvider replaceTokensProvider
+     * @param mixed $list
+     * @param mixed $find
+     * @param mixed $replace
+     * @param mixed $expected
      */
     public function testReplaceTokens($list, $find, $replace, $expected)
     {
@@ -36,6 +40,9 @@ class TokensTest extends TestCase
 
     /**
      * @dataProvider matchProvider
+     * @param mixed $token
+     * @param mixed $pattern
+     * @param mixed $expected
      */
     public function testMatch($token, $pattern, $expected)
     {

--- a/tools/TestGenerator.php
+++ b/tools/TestGenerator.php
@@ -130,8 +130,9 @@ class TestGenerator
     /**
      * Generates recursively all tests preserving the directory structure.
      *
-     * @param string $input  the input directory
-     * @param string $output the output directory
+     * @param string     $input  the input directory
+     * @param string     $output the output directory
+     * @param null|mixed $debug
      */
     public static function buildAll($input, $output, $debug = null)
     {


### PR DESCRIPTION
Extracted from #134 
Based on #135 

Add missing `param` annotation