### PR TITLE
Cs fix no useless return

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -14,6 +14,7 @@ return PhpCsFixer\Config::create()
         'array_syntax' => array('syntax' => 'long'),
         'concat_space' => array('spacing' => true),
         'no_trailing_whitespace' => true,
+        'no_useless_return' => true,
         'phpdoc_order' => true,
     ))
     ->setFinder($finder)

--- a/src/Components/UnionKeyword.php
+++ b/src/Components/UnionKeyword.php
@@ -7,7 +7,6 @@
 namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
-use PhpMyAdmin\SqlParser\Statements\SelectStatement;
 
 /**
  * `UNION` keyword builder.

--- a/src/Utils/Query.php
+++ b/src/Utils/Query.php
@@ -277,6 +277,7 @@ class Query
         if (!empty($statement->join)) {
             $flags['join'] = true;
         }
+
         return $flags;
     }
 


### PR DESCRIPTION
Extracted from #134 
Based on #135 

Remove useless `return`