### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Components/Array2dTest.php
+++ b/tests/Components/Array2dTest.php
@@ -44,9 +44,9 @@ class Array2dTest extends TestCase
     {
         $parser = new Parser();
         Array2d::parse($parser, $this->getTokensList(')'));
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($parser->errors)
+            $parser->errors
         );
         $this->assertEquals(
             'An opening bracket followed by a set of values was expected.',
@@ -58,9 +58,9 @@ class Array2dTest extends TestCase
     {
         $parser = new Parser();
         Array2d::parse($parser, $this->getTokensList('TABLE'));
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($parser->errors)
+            $parser->errors
         );
         $this->assertEquals(
             'An opening bracket followed by a set of values was expected.',
@@ -72,9 +72,9 @@ class Array2dTest extends TestCase
     {
         $parser = new Parser();
         Array2d::parse($parser, $this->getTokensList('(1, 2),'));
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($parser->errors)
+            $parser->errors
         );
         $this->assertEquals(
             'An opening bracket followed by a set of values was expected.',
@@ -86,9 +86,9 @@ class Array2dTest extends TestCase
     {
         $parser = new Parser();
         Array2d::parse($parser, $this->getTokensList('(1, 2),(3)'));
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($parser->errors)
+            $parser->errors
         );
         $this->assertEquals(
             '2 values were expected, but found 1.',

--- a/tests/Components/CreateDefinitionTest.php
+++ b/tests/Components/CreateDefinitionTest.php
@@ -27,7 +27,7 @@ class CreateDefinitionTest extends TestCase
             $parser,
             $this->getTokensList('(str TEXT, FULLTEXT INDEX indx (str)')
         );
-        $this->assertEquals(2, count($component));
+        $this->assertCount(2, $component);
 
         $this->assertEquals(
             'A closing bracket was expected.',

--- a/tests/Components/ExpressionArrayTest.php
+++ b/tests/Components/ExpressionArrayTest.php
@@ -29,7 +29,7 @@ class ExpressionArrayTest extends TestCase
                 'parenthesesDelimited' => true,
             )
         );
-        $this->assertEquals(1, count($component));
+        $this->assertCount(1, $component);
         $this->assertEquals('(expr)', $component[0]->expr);
     }
 }

--- a/tests/Components/JoinKeywordTest.php
+++ b/tests/Components/JoinKeywordTest.php
@@ -11,18 +11,18 @@ class JoinKeywordTest extends TestCase
     public function testParseIncomplete()
     {
         $component = JoinKeyword::parse(new Parser(), $this->getTokensList('JOIN a'));
-        $this->assertEquals(1, count($component));
+        $this->assertCount(1, $component);
         $this->assertEquals('a', $component[0]->expr->expr);
-        $this->assertEquals(null, $component[0]->on);
-        $this->assertEquals(null, $component[0]->using);
+        $this->assertNull($component[0]->on);
+        $this->assertNull($component[0]->using);
     }
 
     public function testParseIncompleteUsing()
     {
         $component = JoinKeyword::parse(new Parser(), $this->getTokensList('JOIN table2 USING (id)'));
-        $this->assertEquals(1, count($component));
+        $this->assertCount(1, $component);
         $this->assertEquals('table2', $component[0]->expr->expr);
-        $this->assertEquals(null, $component[0]->on);
+        $this->assertNull($component[0]->on);
         $this->assertEquals(array('id'), $component[0]->using->values);
     }
 

--- a/tests/Components/KeyTest.php
+++ b/tests/Components/KeyTest.php
@@ -14,6 +14,6 @@ class KeyTest extends TestCase
             new Parser(),
             $this->getTokensList('')
         );
-        $this->assertEquals(null, $component->name);
+        $this->assertNull($component->name);
     }
 }

--- a/tests/Lexer/ContextTest.php
+++ b/tests/Lexer/ContextTest.php
@@ -11,14 +11,14 @@ class ContextTest extends TestCase
     {
         // Default context is 5.7.0.
         $this->assertEquals('\\PhpMyAdmin\\SqlParser\\Contexts\\ContextMySql50700', Context::$loadedContext);
-        $this->assertTrue(isset(Context::$KEYWORDS['STORED']));
-        $this->assertFalse(isset(Context::$KEYWORDS['AUTHORS']));
+        $this->assertArrayHasKey('STORED', Context::$KEYWORDS);
+        $this->assertArrayNotHasKey('AUTHORS', Context::$KEYWORDS);
 
         // Restoring context.
         Context::load('');
         $this->assertEquals('\\PhpMyAdmin\\SqlParser\\Contexts\\ContextMySql50700', Context::$defaultContext);
-        $this->assertTrue(isset(Context::$KEYWORDS['STORED']));
-        $this->assertFalse(isset(Context::$KEYWORDS['AUTHORS']));
+        $this->assertArrayHasKey('STORED', Context::$KEYWORDS);
+        $this->assertArrayNotHasKey('AUTHORS', Context::$KEYWORDS);
     }
 
     /**

--- a/tests/Lexer/IsMethodsTest.php
+++ b/tests/Lexer/IsMethodsTest.php
@@ -24,10 +24,10 @@ class IsMethodsTest extends TestCase
         );
 
         $this->assertEquals(1 | Token::FLAG_KEYWORD_RESERVED, Context::isKeyword('FROM', true));
-        $this->assertEquals(null, Context::isKeyword('MODIFY', true));
+        $this->assertNull(Context::isKeyword('MODIFY', true));
 
-        $this->assertEquals(null, Context::isKeyword('foo'));
-        $this->assertEquals(null, Context::isKeyword('bar baz'));
+        $this->assertNull(Context::isKeyword('foo'));
+        $this->assertNull(Context::isKeyword('bar baz'));
     }
 
     public function testIsOperator()
@@ -40,7 +40,7 @@ class IsMethodsTest extends TestCase
         $this->assertEquals(Token::FLAG_OPERATOR_ASSIGNMENT, Context::isOperator(':='));
         $this->assertEquals(Token::FLAG_OPERATOR_SQL, Context::isOperator(','));
 
-        $this->assertEquals(Context::isOperator('a'), null);
+        $this->assertNull(Context::isOperator('a'));
     }
 
     public function testIsWhitespace()
@@ -68,7 +68,7 @@ class IsMethodsTest extends TestCase
         $this->assertEquals(Token::FLAG_COMMENT_C, Context::isComment('/*comment */'));
         $this->assertEquals(Token::FLAG_COMMENT_SQL, Context::isComment('-- my comment'));
 
-        $this->assertEquals(null, Context::isComment('--not a comment'));
+        $this->assertNull(Context::isComment('--not a comment'));
     }
 
     public function testIsBool()

--- a/tests/Lexer/TokensListTest.php
+++ b/tests/Lexer/TokensListTest.php
@@ -54,7 +54,7 @@ class TokensListTest extends TestCase
         $this->assertEquals($this->tokens[2], $list->getNext());
         $this->assertEquals($this->tokens[4], $list->getNext());
         $this->assertEquals($this->tokens[6], $list->getNext());
-        $this->assertEquals(null, $list->getNext());
+        $this->assertNull($list->getNext());
     }
 
     public function testGetNextOfType()
@@ -62,14 +62,14 @@ class TokensListTest extends TestCase
         $list = new TokensList($this->tokens);
         $this->assertEquals($this->tokens[0], $list->getNextOfType(Token::TYPE_KEYWORD));
         $this->assertEquals($this->tokens[4], $list->getNextOfType(Token::TYPE_KEYWORD));
-        $this->assertEquals(null, $list->getNextOfType(Token::TYPE_KEYWORD));
+        $this->assertNull($list->getNextOfType(Token::TYPE_KEYWORD));
     }
 
     public function testGetNextOfTypeAndValue()
     {
         $list = new TokensList($this->tokens);
         $this->assertEquals($this->tokens[0], $list->getNextOfTypeAndValue(Token::TYPE_KEYWORD, 'SELECT'));
-        $this->assertEquals(null, $list->getNextOfTypeAndValue(Token::TYPE_KEYWORD, 'SELECT'));
+        $this->assertNull($list->getNextOfTypeAndValue(Token::TYPE_KEYWORD, 'SELECT'));
     }
 
     public function testArrayAccess()
@@ -90,8 +90,8 @@ class TokensListTest extends TestCase
         }
 
         // offsetExists($offset)
-        $this->assertTrue(isset($list[2]));
-        $this->assertFalse(isset($list[8]));
+        $this->assertArrayHasKey(2, $list);
+        $this->assertArrayNotHasKey(8, $list);
 
         // offsetUnset($offset)
         unset($list[2]);

--- a/tests/Misc/UtfStringTest.php
+++ b/tests/Misc/UtfStringTest.php
@@ -26,14 +26,14 @@ class UtfStringTest extends TestCase
         $str = new UtfString(static::TEST_PHRASE);
 
         // offsetExists
-        $this->assertTrue(isset($str[static::TEST_PHRASE_LEN - 1]));
-        $this->assertFalse(isset($str[-1]));
-        $this->assertFalse(isset($str[static::TEST_PHRASE_LEN]));
+        $this->assertArrayHasKey(static::TEST_PHRASE_LEN - 1, $str);
+        $this->assertArrayNotHasKey(-1, $str);
+        $this->assertArrayNotHasKey(static::TEST_PHRASE_LEN, $str);
 
         // offsetGet
         $this->assertEquals('.', $str[static::TEST_PHRASE_LEN - 1]);
-        $this->assertEquals(null, $str[-1]);
-        $this->assertEquals(null, $str[static::TEST_PHRASE_LEN]);
+        $this->assertNull($str[-1]);
+        $this->assertNull($str[static::TEST_PHRASE_LEN]);
     }
 
     /**

--- a/tests/Utils/QueryTest.php
+++ b/tests/Utils/QueryTest.php
@@ -540,7 +540,7 @@ class QueryTest extends TestCase
         $delimiter = null;
         list($statement, $query, $delimiter) =
             Query::getFirstStatement($query, $delimiter);
-        $this->assertEquals(null, $statement);
+        $this->assertNull($statement);
         $this->assertEquals('USE saki', $query);
 
         $query = 'USE sakila; ' .


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertArrayHasKey` and `assertArrayHasKey` instead of `isset` function;
- `assertNull` instead of comparison with `null` keyword.