### PR TITLE
Create or replace view query not working issue solved

### DIFF
--- a/src/Statements/CreateStatement.php
+++ b/src/Statements/CreateStatement.php
@@ -37,7 +37,7 @@ class CreateStatement extends Statement
         'TEMPORARY' => 1,
 
         // CREATE VIEW
-        'OR REPLACE' => array(2, 'var='),
+        'OR REPLACE' => 2,
         'ALGORITHM' => array(3, 'var='),
         // `DEFINER` is also used for `CREATE FUNCTION / PROCEDURE`
         'DEFINER' => array(4, 'expr='),


### PR DESCRIPTION
The following query was not working. It showed error at the '=' token in 'ALGORITHM=UNDEFINED'.

CREATE OR REPLACE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v_today`  AS  select curdate() AS `today` ;

The issue was that the parser was expecting a value for 'OR REPLACE'. 

Signed-off-by: Aswani Prakash <aswani15prakash@gmail.com>