### PR TITLE
Add tests for builder of CREATE or REPLACE VIEW statement

### DIFF
--- a/tests/Builder/CreateStatementTest.php
+++ b/tests/Builder/CreateStatementTest.php
@@ -271,6 +271,18 @@ EOT
             'SELECT id, first_name FROM employee WHERE id = 1 ',
             $stmt->build()
         );
+
+        $parser = new Parser(
+            'CREATE OR REPLACE VIEW myView (vid, vfirstname) AS ' .
+            'SELECT id, first_name FROM employee WHERE id = 1'
+        );
+        $stmt = $parser->statements[0];
+
+        $this->assertEquals(
+            'CREATE OR REPLACE VIEW myView (vid, vfirstname) AS  ' .
+            'SELECT id, first_name FROM employee WHERE id = 1 ',
+            $stmt->build()
+        );
     }
 
     public function testBuilderTrigger()


### PR DESCRIPTION
Issue #204 seems to point a breakage in building of Create or Replace View. I did not find it, but thought if I could add a test, I would provide it as a reference to close the issue.

Signed-off-by: Deven Bansod <devenbansod.bits@gmail.com>