### PR TITLE
Bump minimum version to PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,33 +3,24 @@ language: php
 dist: trusty
 
 php:
-  - "5.4"
-  - "5.5"
-  - "5.6"
-  - "7.0"
-  - "7.1"
-  - "7.2"
-  - "hhvm-3.12"
-  - "hhvm-3.18"
-  - "hhvm-3.24"
-  - "nightly"
+  - 7.1
+  - 7.2
+  - 7.3
+  - nightly
 
 matrix:
   fast_finish: true
   allow_failures:
-    - php: "nightly"
+    - php: nightly
   include:
-    - php: "7.2"
+    - php: 7.2
       env: DOCS=yes
-    - php: "7.1"
+    - php: 7.1
       env: REQUIRE="phpmyadmin/motranslator:^3.0"
-    - dist: precise
-      php: "5.3"
 
 sudo: false
 
 install:
-  - if [ $(php -r "echo PHP_MAJOR_VERSION;") -lt 7 ] ; then sed -i '/sami/D' composer.json ; fi
   - if [ -n "$REQUIRE" ] ; then composer require "$REQUIRE" ; fi
   - composer install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Drop support for PHP 5.3, PHP 5.4, PHP 5.5, PHP 5.6, PHP 7.0 and HHVM
+
 ## [4.3.1] - 2019-01-05
 
 * Fixed incorrect error thrown on DEFAULT keyword in ALTER statement (#218)
@@ -333,4 +335,3 @@ __Breaking changes:__
 ## [1.0.0] - 2015-08-20
 
 * First release of this library.
-

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         "source": "https://github.com/phpmyadmin/sql-parser"
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": "^7.1",
         "symfony/polyfill-mbstring": "^1.3"
     },
     "require-dev": {
         "sami/sami": "^4.0",
         "phpunit/php-code-coverage": "*",
-        "phpunit/phpunit": "~4.8 || ~5.7 || ~6.5"
+        "phpunit/phpunit": "^7.4"
     },
     "conflict": {
         "phpmyadmin/motranslator": "<3.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,8 +9,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <logging>
         <log type="coverage-clover" target="coverage.xml" />
     </logging>


### PR DESCRIPTION
Drop support for PHP 5.3, PHP 5.4, PHP 5.5, PHP 5.6, PHP 7.0 and HHVM

Since phpMyAdmin requires PHP 7.1, it makes sense to require PHP 7.1 for sql-parser as well.