### PR TITLE
Fix issue with parsing TRUNCATE statements, Issue #221

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -320,11 +320,15 @@ abstract class Statement
             }
 
             // Checking if this is the beginning of a clause.
-            if (! empty(Parser::$KEYWORD_PARSERS[$token->value]) && $list->idx < $list->count) {
-                $class = Parser::$KEYWORD_PARSERS[$token->value]['class'];
-                $field = Parser::$KEYWORD_PARSERS[$token->value]['field'];
-                if (! empty(Parser::$KEYWORD_PARSERS[$token->value]['options'])) {
-                    $options = Parser::$KEYWORD_PARSERS[$token->value]['options'];
+            // Fix Issue #221: As `truncate` is not a keyword
+            // but it might be the beginning of a statement of truncate,
+            // so let the value use the keyword field for truncate type.
+            $token_value = in_array($token->keyword, ['TRUNCATE']) ? $token->keyword : $token->value;
+            if (! empty(Parser::$KEYWORD_PARSERS[$token_value]) && $list->idx < $list->count) {
+                $class = Parser::$KEYWORD_PARSERS[$token_value]['class'];
+                $field = Parser::$KEYWORD_PARSERS[$token_value]['field'];
+                if (! empty(Parser::$KEYWORD_PARSERS[$token_value]['options'])) {
+                    $options = Parser::$KEYWORD_PARSERS[$token_value]['options'];
                 }
             }
 

--- a/src/Statements/TruncateStatement.php
+++ b/src/Statements/TruncateStatement.php
@@ -33,4 +33,14 @@ class TruncateStatement extends Statement
      * @var Expression
      */
     public $table;
+
+    /**
+     * Special build method for truncate statement as Statement::build would return empty string.
+     *
+     * @return string
+     */
+    public function build()
+    {
+        return 'TRUNCATE TABLE ' . $this->table . ';';
+    }
 }


### PR DESCRIPTION
Make the following SQL parsable, which is mentioned in issue #221 

`truncate table `a`.`b`;truncate c;select truncate from truncate;`