### PR TITLE
Fix redundant whitespaces - Issue #227

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -173,12 +173,12 @@ abstract class Statement
 
             // Checking if the name of the clause should be added.
             if ($type & 2) {
-                $query .= $name . ' ';
+                $query = trim($query) . ' ' . $name;
             }
 
             // Checking if the result of the builder should be added.
             if ($type & 1) {
-                $query .= $class::build($this->$field) . ' ';
+                $query = trim($query) . ' ' . $class::build($this->$field);
             }
         }
 

--- a/src/Statements/InsertStatement.php
+++ b/src/Statements/InsertStatement.php
@@ -110,8 +110,8 @@ class InsertStatement extends Statement
      */
     public function build()
     {
-        $ret = 'INSERT ' . $this->options
-            . 'INTO ' . $this->into;
+        $ret = 'INSERT ' . $this->options;
+        $ret = trim($ret) . ' INTO ' . $this->into;
 
         if (! is_null($this->values) && count($this->values) > 0) {
             $ret .= ' VALUES ' . Array2d::build($this->values);

--- a/src/Statements/InsertStatement.php
+++ b/src/Statements/InsertStatement.php
@@ -111,7 +111,7 @@ class InsertStatement extends Statement
     public function build()
     {
         $ret = 'INSERT ' . $this->options
-            . ' INTO ' . $this->into;
+            . 'INTO ' . $this->into;
 
         if (! is_null($this->values) && count($this->values) > 0) {
             $ret .= ' VALUES ' . Array2d::build($this->values);

--- a/src/Statements/ReplaceStatement.php
+++ b/src/Statements/ReplaceStatement.php
@@ -87,7 +87,8 @@ class ReplaceStatement extends Statement
      */
     public function build()
     {
-        $ret = 'REPLACE ' . $this->options . 'INTO ' . $this->into;
+        $ret = 'REPLACE ' . $this->options;
+        $ret = trim($ret) . ' INTO ' . $this->into;
 
         if (! is_null($this->values) && count($this->values) > 0) {
             $ret .= ' VALUES ' . Array2d::build($this->values);

--- a/src/Statements/ReplaceStatement.php
+++ b/src/Statements/ReplaceStatement.php
@@ -87,7 +87,7 @@ class ReplaceStatement extends Statement
      */
     public function build()
     {
-        $ret = 'REPLACE ' . $this->options . ' INTO ' . $this->into;
+        $ret = 'REPLACE ' . $this->options . 'INTO ' . $this->into;
 
         if (! is_null($this->values) && count($this->values) > 0) {
             $ret .= ' VALUES ' . Array2d::build($this->values);

--- a/tests/Builder/CreateStatementTest.php
+++ b/tests/Builder/CreateStatementTest.php
@@ -334,7 +334,7 @@ EOT
             'CREATE TABLE new_tbl SELECT * FROM orig_tbl'
         );
         $this->assertEquals(
-            'CREATE TABLE new_tbl SELECT  * FROM orig_tbl ',
+            'CREATE TABLE new_tbl SELECT * FROM orig_tbl',
             $parser->statements[0]->build()
         );
     }

--- a/tests/Builder/InsertStatementTest.php
+++ b/tests/Builder/InsertStatementTest.php
@@ -63,5 +63,16 @@ class InsertStatementTest extends TestCase
             'INSERT INTO tbl SELECT * FROM bar ON DUPLICATE KEY UPDATE baz = 1',
             $stmt->build()
         );
+
+        /* Assertion 6 */
+        /* INSERT [OPTIONS] INTO ... */
+        $parser = new Parser(
+            'INSERT DELAYED IGNORE INTO tbl SELECT * FROM bar'
+        );
+        $stmt = $parser->statements[0];
+        $this->assertEquals(
+            'INSERT DELAYED IGNORE INTO tbl SELECT * FROM bar',
+            $stmt->build()
+        );
     }
 }

--- a/tests/Builder/InsertStatementTest.php
+++ b/tests/Builder/InsertStatementTest.php
@@ -16,7 +16,7 @@ class InsertStatementTest extends TestCase
         );
         $stmt = $parser->statements[0];
         $this->assertEquals(
-            'INSERT  INTO tbl(`col1`, `col2`, `col3`) VALUES (1, "str", 3.14)',
+            'INSERT INTO tbl(`col1`, `col2`, `col3`) VALUES (1, "str", 3.14)',
             $stmt->build()
         );
 
@@ -27,7 +27,7 @@ class InsertStatementTest extends TestCase
         );
         $stmt = $parser->statements[0];
         $this->assertEquals(
-            'INSERT  INTO tbl(`order`) VALUES (1)',
+            'INSERT INTO tbl(`order`) VALUES (1)',
             $stmt->build()
         );
 
@@ -38,7 +38,7 @@ class InsertStatementTest extends TestCase
         );
         $stmt = $parser->statements[0];
         $this->assertEquals(
-            'INSERT  INTO tbl SET FOO = 1',
+            'INSERT INTO tbl SET FOO = 1',
             $stmt->build()
         );
 
@@ -49,7 +49,7 @@ class InsertStatementTest extends TestCase
         );
         $stmt = $parser->statements[0];
         $this->assertEquals(
-            'INSERT  INTO tbl SELECT  * FROM bar ',
+            'INSERT INTO tbl SELECT * FROM bar',
             $stmt->build()
         );
 
@@ -60,7 +60,7 @@ class InsertStatementTest extends TestCase
         );
         $stmt = $parser->statements[0];
         $this->assertEquals(
-            'INSERT  INTO tbl SELECT  * FROM bar  ON DUPLICATE KEY UPDATE baz = 1',
+            'INSERT INTO tbl SELECT * FROM bar ON DUPLICATE KEY UPDATE baz = 1',
             $stmt->build()
         );
     }

--- a/tests/Builder/ReplaceStatementTest.php
+++ b/tests/Builder/ReplaceStatementTest.php
@@ -43,4 +43,16 @@ class ReplaceStatementTest extends TestCase
             $stmt->build()
         );
     }
+
+    public function testBuilderSelectDelayed()
+    {
+        $parser = new Parser(
+            'REPLACE DELAYED INTO tbl(col1, col2, col3) SELECT col1, col2, col3 FROM tbl2'
+        );
+        $stmt = $parser->statements[0];
+        $this->assertEquals(
+            'REPLACE DELAYED INTO tbl(`col1`, `col2`, `col3`) SELECT col1, col2, col3 FROM tbl2',
+            $stmt->build()
+        );
+    }
 }

--- a/tests/Builder/ReplaceStatementTest.php
+++ b/tests/Builder/ReplaceStatementTest.php
@@ -15,7 +15,7 @@ class ReplaceStatementTest extends TestCase
         );
         $stmt = $parser->statements[0];
         $this->assertEquals(
-            'REPLACE  INTO tbl(`col1`, `col2`, `col3`) VALUES (1, "str", 3.14)',
+            'REPLACE INTO tbl(`col1`, `col2`, `col3`) VALUES (1, "str", 3.14)',
             $stmt->build()
         );
     }
@@ -27,7 +27,7 @@ class ReplaceStatementTest extends TestCase
         );
         $stmt = $parser->statements[0];
         $this->assertEquals(
-            'REPLACE  INTO tbl(`col1`, `col2`, `col3`) SET col1 = 1, col2 = "str", col3 = 3.14',
+            'REPLACE INTO tbl(`col1`, `col2`, `col3`) SET col1 = 1, col2 = "str", col3 = 3.14',
             $stmt->build()
         );
     }
@@ -39,7 +39,7 @@ class ReplaceStatementTest extends TestCase
         );
         $stmt = $parser->statements[0];
         $this->assertEquals(
-            'REPLACE  INTO tbl(`col1`, `col2`, `col3`) SELECT  col1, col2, col3 FROM tbl2 ',
+            'REPLACE INTO tbl(`col1`, `col2`, `col3`) SELECT col1, col2, col3 FROM tbl2',
             $stmt->build()
         );
     }

--- a/tests/Builder/SelectStatementTest.php
+++ b/tests/Builder/SelectStatementTest.php
@@ -17,8 +17,8 @@ class SelectStatementTest extends TestCase
         $stmt = $parser->statements[0];
 
         $this->assertEquals(
-            'SELECT  * FROM t1 LEFT JOIN (t2, t3, t4) '
-            . 'ON (t2.a=t1.a AND t3.b=t1.b AND t4.c=t1.c) ',
+            'SELECT * FROM t1 LEFT JOIN (t2, t3, t4) '
+            . 'ON (t2.a=t1.a AND t3.b=t1.b AND t4.c=t1.c)',
             $stmt->build()
         );
     }
@@ -29,7 +29,7 @@ class SelectStatementTest extends TestCase
         $stmt = $parser->statements[0];
 
         $this->assertEquals(
-            'SELECT  1 UNION SELECT  2  ',
+            'SELECT 1 UNION SELECT 2',
             $stmt->build()
         );
     }
@@ -45,10 +45,10 @@ class SelectStatementTest extends TestCase
         $stmt = $parser->statements[0];
 
         $this->assertEquals(
-            'SELECT  sgu.id, sgu.email_address FROM `sf_guard_user` AS `sgu` '
+            'SELECT sgu.id, sgu.email_address FROM `sf_guard_user` AS `sgu` '
             . 'RIGHT JOIN `student_course_booking` AS `scb` ON sgu.id = scb.user_id '
             . 'WHERE `has_found_course` = \'1\' GROUP BY sgu.id '
-            . 'ORDER BY scb.id DESC LIMIT 0, 300 ',
+            . 'ORDER BY scb.id DESC LIMIT 0, 300',
             $stmt->build()
         );
     }
@@ -56,7 +56,7 @@ class SelectStatementTest extends TestCase
     public function testBuilderEndOptions()
     {
         /* Assertion 1 */
-        $query = 'SELECT  pid, name2 FROM tablename WHERE pid = 20 FOR UPDATE ';
+        $query = 'SELECT pid, name2 FROM tablename WHERE pid = 20 FOR UPDATE';
         $parser = new Parser($query);
         $stmt = $parser->statements[0];
 
@@ -66,7 +66,7 @@ class SelectStatementTest extends TestCase
         );
 
         /* Assertion 2 */
-        $query = 'SELECT  pid, name2 FROM tablename WHERE pid = 20 LOCK IN SHARE MODE ';
+        $query = 'SELECT pid, name2 FROM tablename WHERE pid = 20 LOCK IN SHARE MODE';
         $parser = new Parser($query);
         $stmt = $parser->statements[0];
 
@@ -79,10 +79,10 @@ class SelectStatementTest extends TestCase
     public function testBuilderIntoOptions()
     {
         /* Assertion 1 */
-        $query = 'SELECT  a, b, a+b INTO OUTFILE "/tmp/result.txt"'
+        $query = 'SELECT a, b, a+b INTO OUTFILE "/tmp/result.txt"'
             . ' COLUMNS TERMINATED BY \',\' OPTIONALLY ENCLOSED BY \'"\''
             . ' LINES TERMINATED BY \'\n\''
-            . ' FROM test_table ';
+            . ' FROM test_table';
         $parser = new Parser($query);
         $stmt = $parser->statements[0];
 
@@ -94,7 +94,7 @@ class SelectStatementTest extends TestCase
 
     public function testBuildGroupBy()
     {
-        $query = 'SELECT  COUNT(CustomerID), Country FROM Customers GROUP BY Country ';
+        $query = 'SELECT COUNT(CustomerID), Country FROM Customers GROUP BY Country';
         $parser = new Parser($query);
         $stmt = $parser->statements[0];
 
@@ -106,7 +106,7 @@ class SelectStatementTest extends TestCase
 
     public function testBuildIndexHint()
     {
-        $query = 'SELECT  * FROM address FORCE INDEX (idx_fk_city_id) IGNORE KEY FOR GROUP BY (a, b,c) WHERE city_id<0 ';
+        $query = 'SELECT * FROM address FORCE INDEX (idx_fk_city_id) IGNORE KEY FOR GROUP BY (a, b,c) WHERE city_id<0';
         $parser = new Parser($query);
         $stmt = $parser->statements[0];
 

--- a/tests/Builder/StatementTest.php
+++ b/tests/Builder/StatementTest.php
@@ -34,7 +34,7 @@ class StatementTest extends TestCase
             'SELECT DISTINCT `sakila`.`film`.`film_id` AS `fid`, COUNT(film_id) ' .
             'FROM `film`, `actor` ' .
             'WHERE film_id > 10 OR actor.age > 25 ' .
-            'LIMIT 10, 1 ',
+            'LIMIT 10, 1',
             (string) $stmt
         );
     }

--- a/tests/Builder/TransactionStatementTest.php
+++ b/tests/Builder/TransactionStatementTest.php
@@ -20,8 +20,8 @@ class TransactionStatementTest extends TestCase
 
         $this->assertEquals(
             'START TRANSACTION;' .
-            'SELECT  @A:=SUM(salary) FROM table1 WHERE type=1 ;' .
-            'UPDATE  table2 SET summary = @A WHERE type=1 ;' .
+            'SELECT @A:=SUM(salary) FROM table1 WHERE type=1;' .
+            'UPDATE table2 SET summary = @A WHERE type=1;' .
             'COMMIT',
             $stmt->build()
         );


### PR DESCRIPTION
Changed implementation of `build()` methods to generate more consistent SQL.

This commit fixes implementation of `build()` methods to produce more consistent SQL code without redundant spaces.