### PR TITLE
Repair simulated delete query syntax error

### DIFF
--- a/src/Utils/Query.php
+++ b/src/Utils/Query.php
@@ -648,7 +648,7 @@ class Query
                 }
             }
 
-            if (($firstClauseIdx <= $currIdx) && ($currIdx <= $lastClauseIdx)) {
+            if (($firstClauseIdx <= $currIdx) && ($currIdx < $lastClauseIdx)) {
                 $ret .= $token->token;
             }
         }


### PR DESCRIPTION
When a DELETE query was simulated, the result would be a MySQL syntax error, because the WHERE clause had ORDER BY ... added to it and the ORDER BY clause had LIMIT ... added to it.  

The actual query (OK button) finished normally

See the discussion in [Simulated Delete Query with ORDER BY and LIMIT Causes Error](https://github.com/phpmyadmin/phpmyadmin/issues/14995)