### PR TITLE
Support reading from stdin

### DIFF
--- a/src/Utils/CLI.php
+++ b/src/Utils/CLI.php
@@ -77,6 +77,11 @@ class CLI
 
             return 0;
         }
+        if (!isset($params['q'])) {
+            if ($stdIn = $this->readStdin()) {
+                $params['q'] = $stdIn;
+            }
+        }
         if (isset($params['q'])) {
             echo Formatter::format(
                 $params['q'],
@@ -126,6 +131,11 @@ class CLI
         }
         if (isset($params['c'])) {
             Context::load($params['c']);
+        }
+        if (!isset($params['q'])) {
+            if ($stdIn = $this->readStdin()) {
+                $params['q'] = $stdIn;
+            }
         }
         if (isset($params['q'])) {
             $lexer = new Lexer($params['q'], false);
@@ -177,6 +187,11 @@ class CLI
 
             return 0;
         }
+        if (!isset($params['q'])) {
+            if ($stdIn = $this->readStdin()) {
+                $params['q'] = $stdIn;
+            }
+        }
         if (isset($params['q'])) {
             $lexer = new Lexer($params['q'], false);
             foreach ($lexer->list->tokens as $idx => $token) {
@@ -198,5 +213,13 @@ class CLI
         $this->usageTokenize();
 
         return 1;
+    }
+
+    private function readStdin() {
+        stream_set_blocking(STDIN, false);
+        $stdin = stream_get_contents(STDIN);
+        // restore-default block-mode setting
+        stream_set_blocking(STDIN, true);
+        return $stdin;
     }
 }

--- a/tests/Utils/CLITest.php
+++ b/tests/Utils/CLITest.php
@@ -205,4 +205,30 @@ class CLITest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider stdinParams
+     *
+     * @param string $cmd
+     * @param int $result
+     */
+    public function testStdinPipe($cmd, $result)
+    {
+        exec ($cmd, $out, $ret);
+        $this->assertSame($result, $ret);
+    }
+
+    public function stdinParams()
+    {
+        $binPath = PHP_BINARY .' '. dirname(__DIR__,2 ). '/bin/';
+
+        return [
+            ['echo "SELECT 1" | '. $binPath .'highlight-query', 0],
+            ['echo "invalid query" | '. $binPath .'highlight-query', 0],
+            ['echo "SELECT 1" | '. $binPath .'lint-query', 0],
+            ['echo "invalid query" | '. $binPath .'lint-query', 10],
+            ['echo "SELECT 1" | '. $binPath .'tokenize-query', 0],
+            ['echo "invalid query" | '. $binPath .'tokenize-query', 0],
+        ];
+    }
 }


### PR DESCRIPTION
this change implements reading from stdin, so the command can be used in a unix-pipe style:

```sh
tools/sql-parser$ echo "SELECT 1" | php bin/highlight-query
SELECT
    1

tools/sql-parser$ echo "SELECT 1" | php bin/lint-query
tools/sql-parser$ echo $?
0

tools/sql-parser$ echo "abc" | php bin/lint-query
#1: Unexpected beginning of statement. (near "abc" at position 0)
tools/sql-parser$ echo $?
10

tools/sql-parser$ echo "SELECT 1" | php bin/tokenize-query
[TOKEN 0]
Type = 1
Flags = 3
Value = 'SELECT'
Token = 'SELECT'

[TOKEN 1]
Type = 3
Flags = 0
Value = ' '
Token = ' '

[TOKEN 2]
Type = 6
Flags = 0
Value = 1
Token = '1'

[TOKEN 3]
Type = 3
Flags = 0
Value = ' '
Token = '
'

[TOKEN 4]
Type = 9
Flags = 0
Value = NULL
Token = NULL

```

refs #237