### PR TITLE
fix implode arg. order

### DIFF
--- a/src/Components/Expression.php
+++ b/src/Components/Expression.php
@@ -433,7 +433,7 @@ class Expression extends Component
     public static function build($component, array $options = array())
     {
         if (is_array($component)) {
-            return implode($component, ', ');
+            return implode(', ', $component);
         }
 
         if ($component->expr !== '' && ! is_null($component->expr)) {

--- a/src/Components/ExpressionArray.php
+++ b/src/Components/ExpressionArray.php
@@ -122,6 +122,6 @@ class ExpressionArray extends Component
             $ret[] = $frag::build($frag);
         }
 
-        return implode($ret, ', ');
+        return implode(', ', $ret);
     }
 }


### PR DESCRIPTION
Because legacy order is deprecated in 7.4


```
1) PhpMyAdmin\SqlParser\Tests\Builder\CreateStatementTest::testBuildSelect
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statement.php:184
/work/GIT/sql-parser/src/Statements/CreateStatement.php:395
/work/GIT/sql-parser/tests/Builder/CreateStatementTest.php:338

2) PhpMyAdmin\SqlParser\Tests\Builder\DeleteStatementTest::testBuilderSingleTable
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statements/DeleteStatement.php:173
/work/GIT/sql-parser/tests/Builder/DeleteStatementTest.php:19

3) PhpMyAdmin\SqlParser\Tests\Builder\DeleteStatementTest::testBuilderMultiTable
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statements/DeleteStatement.php:170
/work/GIT/sql-parser/tests/Builder/DeleteStatementTest.php:71

4) PhpMyAdmin\SqlParser\Tests\Builder\InsertStatementTest::testBuilder
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statement.php:184
/work/GIT/sql-parser/src/Statements/InsertStatement.php:121
/work/GIT/sql-parser/tests/Builder/InsertStatementTest.php:53

5) PhpMyAdmin\SqlParser\Tests\Builder\LoadStatementTest::testBuilder
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statements/LoadStatement.php:218
/work/GIT/sql-parser/tests/Builder/LoadStatementTest.php:74

6) PhpMyAdmin\SqlParser\Tests\Builder\ReplaceStatementTest::testBuilderSelect
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statement.php:184
/work/GIT/sql-parser/src/Statements/ReplaceStatement.php:98
/work/GIT/sql-parser/tests/Builder/ReplaceStatementTest.php:43

7) PhpMyAdmin\SqlParser\Tests\Builder\ReplaceStatementTest::testBuilderSelectDelayed
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statement.php:184
/work/GIT/sql-parser/src/Statements/ReplaceStatement.php:98
/work/GIT/sql-parser/tests/Builder/ReplaceStatementTest.php:55

8) PhpMyAdmin\SqlParser\Tests\Builder\SelectStatementTest::testBuilder
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statement.php:184
/work/GIT/sql-parser/tests/Builder/SelectStatementTest.php:22

9) PhpMyAdmin\SqlParser\Tests\Builder\SelectStatementTest::testBuilderUnion
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statement.php:184
/work/GIT/sql-parser/tests/Builder/SelectStatementTest.php:33

10) PhpMyAdmin\SqlParser\Tests\Builder\SelectStatementTest::testBuilderAlias
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statement.php:184
/work/GIT/sql-parser/tests/Builder/SelectStatementTest.php:52

11) PhpMyAdmin\SqlParser\Tests\Builder\SelectStatementTest::testBuilderEndOptions
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statement.php:184
/work/GIT/sql-parser/tests/Builder/SelectStatementTest.php:65

12) PhpMyAdmin\SqlParser\Tests\Builder\SelectStatementTest::testBuilderIntoOptions
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statement.php:184
/work/GIT/sql-parser/tests/Builder/SelectStatementTest.php:91

13) PhpMyAdmin\SqlParser\Tests\Builder\SelectStatementTest::testBuildGroupBy
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statement.php:184
/work/GIT/sql-parser/tests/Builder/SelectStatementTest.php:103

14) PhpMyAdmin\SqlParser\Tests\Builder\SelectStatementTest::testBuildIndexHint
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statement.php:184
/work/GIT/sql-parser/tests/Builder/SelectStatementTest.php:115

15) PhpMyAdmin\SqlParser\Tests\Builder\TransactionStatementTest::testBuilder
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Statement.php:184
/work/GIT/sql-parser/src/Statements/TransactionStatement.php:107
/work/GIT/sql-parser/tests/Builder/TransactionStatementTest.php:26

16) PhpMyAdmin\SqlParser\Tests\Components\ExpressionTest::testBuild
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/Expression.php:436
/work/GIT/sql-parser/tests/Components/ExpressionTest.php:73

17) PhpMyAdmin\SqlParser\Tests\Components\IntoKeywordTest::testBuild
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Components/IntoKeyword.php:279
/work/GIT/sql-parser/tests/Components/IntoKeywordTest.php:22

18) PhpMyAdmin\SqlParser\Tests\Components\IntoKeywordTest::testBuildValues
implode(): Passing glue string after array is deprecated. Swap the parameters

/work/GIT/sql-parser/src/Components/ExpressionArray.php:125
/work/GIT/sql-parser/src/Components/IntoKeyword.php:279
/work/GIT/sql-parser/tests/Components/IntoKeywordTest.php:28

```