### PR TITLE
Fix #13951 wrong parsing partitions

### DIFF
--- a/src/Components/PartitionDefinition.php
+++ b/src/Components/PartitionDefinition.php
@@ -170,10 +170,16 @@ class PartitionDefinition extends Component
                 $ret->name = $token->value;
 
                 // Looking ahead for a 'VALUES' keyword.
-                $idx = $list->idx;
-                $list->getNext();
-                $nextToken = $list->getNext();
-                $list->idx = $idx;
+                // Loop until the end of the partition name (delimited by a whitespace)
+                while ($nextToken = $list->tokens[++$list->idx]) {
+                    if ($nextToken->type === Token::TYPE_WHITESPACE) {
+                        break;
+                    }
+                    $ret->name .= $nextToken->value;
+                }
+                $idx = $list->idx--;
+                // Get the first token after the white space.
+                $nextToken = $list->tokens[++$idx];
 
                 $state = ($nextToken->type === Token::TYPE_KEYWORD)
                     && ($nextToken->value === 'VALUES')

--- a/src/Components/PartitionDefinition.php
+++ b/src/Components/PartitionDefinition.php
@@ -172,7 +172,7 @@ class PartitionDefinition extends Component
                 // Looking ahead for a 'VALUES' keyword.
                 // Loop until the end of the partition name (delimited by a whitespace)
                 while ($nextToken = $list->tokens[++$list->idx]) {
-                    if ($nextToken->type === Token::TYPE_WHITESPACE) {
+                    if ($nextToken->type !== Token::TYPE_NONE) {
                         break;
                     }
                     $ret->name .= $nextToken->value;

--- a/tests/Components/PartitionDefinitionTest.php
+++ b/tests/Components/PartitionDefinitionTest.php
@@ -19,4 +19,16 @@ class PartitionDefinitionTest extends TestCase
         $this->assertEquals('LESS THAN', $component->type);
         $this->assertEquals('(1990)', $component->expr->expr);
     }
+
+    public function testParseNameWithUnderscore()
+    {
+        $component = PartitionDefinition::parse(
+            new Parser(),
+            $this->getTokensList('PARTITION 2017_12 VALUES LESS THAN (\'2018-01-01 00:00:00\') ENGINE = MyISAM')
+        );
+        $this->assertFalse($component->isSubpartition);
+        $this->assertEquals('2017_12', $component->name);
+        $this->assertEquals('LESS THAN', $component->type);
+        $this->assertEquals('(\'2018-01-01 00:00:00\')', $component->expr->expr);
+    }
 }


### PR DESCRIPTION
When partition names starts with a number, the parser wasn't reading the full name and stopped before the first "_".