### PR TITLE
Stop instanciating an object to check its class name.

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -407,12 +407,11 @@ abstract class Statement
             $this->after($parser, $list, $token);
 
             // #223 Here may make a patch, if last is delimiter, back one
-            if ($class !== null) {
-                if ((new $class()) instanceof FunctionCall) {
-                    if ($list->offsetGet($list->idx)->type === Token::TYPE_DELIMITER) {
-                        --$list->idx;
-                    }
-                }
+            // TODO: when not supporting PHP 5.3 anymore, replace this by FunctionCall::class.
+            if ($class === 'PhpMyAdmin\\SqlParser\\Components\\FunctionCall'
+                && $list->offsetGet($list->idx)->type === Token::TYPE_DELIMITER
+            ) {
+                --$list->idx;
             }
         }
 


### PR DESCRIPTION
Fixes #246 
When set on master, where PHP 5.3 is not maintained anymore, this could be a little bit improved.

I did not use `is_a` because of the function call (not good for performance) and I did not use `instanceof` neither because `$class` is a string, not an object. We are actually comparing 2 strings, so let's just compare 2 strings...

I'm aware it has not the exact same behavior in case of `$class` is a string evaluated to a class name of a child of `FunctionCall` class, but it appears that `FunctionCall` has no children, so the misbehavior here is not applicable.
