### PR TITLE
Fixes array_key_exists warning when parsing a "DEFAULT FALSE" token

### DIFF
--- a/src/Components/AlterOperation.php
+++ b/src/Components/AlterOperation.php
@@ -263,6 +263,12 @@ class AlterOperation extends Component
                 }
                 $state = 2;
             } elseif ($state === 2) {
+                $array_key = '';
+                if (is_string($token->value) || is_numeric($token->value)) {
+                    $array_key = $token->value;
+                } else {
+                    $array_key = $token->token;
+                }
                 if ($token->type === Token::TYPE_OPERATOR) {
                     if ($token->value === '(') {
                         ++$brackets;
@@ -282,9 +288,9 @@ class AlterOperation extends Component
                         );
                         break;
                     }
-                } elseif ((array_key_exists($token->value, self::$DB_OPTIONS)
-                    || array_key_exists($token->value, self::$TABLE_OPTIONS))
-                    && ! self::checkIfColumnDefinitionKeyword($token->value)
+                } elseif ((array_key_exists($array_key, self::$DB_OPTIONS)
+                    || array_key_exists($array_key, self::$TABLE_OPTIONS))
+                    && ! self::checkIfColumnDefinitionKeyword($array_key)
                 ) {
                     // This alter operation has finished, which means a comma was missing before start of new alter operation
                     $parser->error(

--- a/tests/Components/CreateDefinitionTest.php
+++ b/tests/Components/CreateDefinitionTest.php
@@ -92,6 +92,38 @@ class CreateDefinitionTest extends TestCase
         );
     }
 
+    public function testBuild3()
+    {
+        $parser = new Parser(
+            'DROP TABLE IF EXISTS `searches`;'
+            . 'CREATE TABLE `searches` ('
+            . '  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,'
+            . '  `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,'
+            . '  `public_name` varchar(120) COLLATE utf8_unicode_ci NOT NULL,'
+            . '  `group_id` smallint(5) unsigned NOT NULL DEFAULT \'0\','
+            . '  `shortdesc` tinytext COLLATE utf8_unicode_ci,'
+            . '  `show_separators` tinyint(1) NOT NULL DEFAULT \'0\','
+            . '  `show_separators_two` tinyint(1) NOT NULL DEFAULT FALSE,'
+            . '  `deleted` tinyint(1) NOT NULL DEFAULT \'0\','
+            . '  PRIMARY KEY (`id`)'
+            . ') ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci ;'
+            . ''
+            . 'ALTER TABLE `searches` ADD `admins_only` BOOLEAN NOT NULL DEFAULT FALSE AFTER `show_separators`;'
+        );
+        $this->assertEquals(
+            '`public_name` varchar(120) COLLATE utf8_unicode_ci NOT NULL',
+            CreateDefinition::build($parser->statements[1]->fields[2])
+        );
+        $this->assertEquals(
+            '`show_separators` tinyint(1) NOT NULL DEFAULT \'0\'',
+            CreateDefinition::build($parser->statements[1]->fields[5])
+        );
+        $this->assertEquals(
+            '`show_separators_two` tinyint(1) NOT NULL DEFAULT FALSE',
+            CreateDefinition::build($parser->statements[1]->fields[6])
+        );
+    }
+
     public function testBuildWithInvisibleKeyword()
     {
         $parser = new Parser(


### PR DESCRIPTION
Fixes: https://github.com/phpmyadmin/sql-parser/issues/299

The issue was caused because the value of token `FALSE` became boolean instead of string.

Signed-off-by: Saksham Gupta <shucon01@gmail.com>