### PR TITLE
Fixing BufferedQuery when has odd number of backslashes in the end

### DIFF
--- a/src/Utils/BufferedQuery.php
+++ b/src/Utils/BufferedQuery.php
@@ -192,7 +192,7 @@ class BufferedQuery
              * be ignored.
              */
             if ((($this->status & static::STATUS_COMMENT) === 0) && ($this->query[$i] === '\\')) {
-                $this->current .= $this->query[$i] . $this->query[++$i];
+                $this->current .= $this->query[$i] . ($i + 1 < $len ? $this->query[++$i] : '');
                 continue;
             }
 

--- a/tests/Utils/BufferedQueryTest.php
+++ b/tests/Utils/BufferedQueryTest.php
@@ -114,6 +114,18 @@ class BufferedQueryTest extends TestCase
             ),
 
             array(
+                "SELECT \\",
+                8,
+                array(
+                    'parse_delimiter' => false,
+                    'add_delimiter' => false,
+                ),
+                array(
+                    "SELECT \\",
+                ),
+            ),
+
+            array(
                 "CREATE TABLE `test` (\n" .
                 "  `txt` varchar(10)\n" .
                 ");\n" .


### PR DESCRIPTION
Hi, this's a fix for the issues noticed @ https://github.com/phpmyadmin/phpmyadmin/issues/15931. 

The issue seems to happen when ANY statement has an odd number of backslashes in the end, and this was happening because: 
https://github.com/phpmyadmin/sql-parser/blob/3013045a9a700f0998c29ada6770f5103372e9ca/src/Utils/BufferedQuery.php#L187-L197

Here the code is assuming that any backslash will be followed by another backslash, that's why as per my understand the code is pre-incrementing `$i` to skip both the backslash and the followed character. if there's odd number of backslashes in the end of the statement, the pre-incremented variable would lead to empty string and will mess the variable up.

For example:  
```SQL
\<?php echo \'\1\'\; ?>\
```
The length (`$len`) of this statement is 24, the last backslash position  (`$i`) is 23, and (`++$i`) is 24 which's empty string, and the for loop will also increment it again `$i++` which will make this check always false, because `$i !== $len` 25 !== 24. 
https://github.com/phpmyadmin/sql-parser/blob/3013045a9a700f0998c29ada6770f5103372e9ca/src/Utils/BufferedQuery.php#L408-L410

which will make the extract method return empty string, therefore this will go infinitely: 

https://github.com/phpmyadmin/phpmyadmin/blob/81e1749cabe40bc429f8d55ff21501bba4c70ed0/libraries/classes/Plugins/Import/ImportSql.php#L163-L167


What I've made is that I've checked whether the `($i + 1) < $len` or not, if `false`, it means that the backslash is in the end of the statement so we don't need to pre-increment and add the followed char to the query - it doesn't even exist - , if `true`, the variable will be pre-incremented and the followed char will be added to the query. 

the `($i + 1) < $len` check could be written in many ways, we can make the check this way `! empty($this->query[$i + 1])`, which's the way that I've firstly written, but I think it's more meaningful the way in the commit. 

That's all I found, I've tested with some queries to ensure that everything is working as expected, but I might be missing something though. You can test with any sql query that has odd number of backslashes in the end. 