### PR TITLE
Fix #348 - Add missing KEY options for MySQL and MariaDB

### DIFF
--- a/src/Components/Key.php
+++ b/src/Components/Key.php
@@ -31,7 +31,7 @@ class Key extends Component
     public static $KEY_OPTIONS = array(
         'KEY_BLOCK_SIZE' => array(
             1,
-            'var',
+            'var=',
         ),
         'USING' => array(
             2,
@@ -44,7 +44,26 @@ class Key extends Component
         'COMMENT' => array(
             4,
             'var',
-        )
+        ),
+        'INVISIBLE' => 1,
+        'VISIBLE' => 1,
+        'ENGINE_ATTRIBUTE' => array(
+            3,
+            'var=',
+        ),
+        'SECONDARY_ENGINE_ATTRIBUTE' => array(
+            4,
+            'var=',
+        ),
+
+        // MariaDB options
+
+        'CLUSTERING' => array(
+            4,
+            'var=',
+        ),
+        'IGNORED' => 1,
+        'NOT IGNORED' => 1,
     );
 
     /**

--- a/tests/Components/KeyTest.php
+++ b/tests/Components/KeyTest.php
@@ -85,6 +85,65 @@ class KeyTest extends TestCase
         ), $component->columns);
     }
 
+    public function testParseKeyWithLengthWithAllOptions()
+    {
+        $component = Key::parse(
+            new Parser(),
+            $this->getTokensList(
+                // This is not a vary plausible example but it runs
+                // Only ENGINE_ATTRIBUTE gives a not supported error but is still a valid syntax
+                'KEY `alias_type_idx` (`alias_type`(10))'
+                . ' COMMENT \'my comment\' VISIBLE KEY_BLOCK_SIZE=1'
+                . ' INVISIBLE ENGINE_ATTRIBUTE \'foo\' SECONDARY_ENGINE_ATTRIBUTE=\'bar\' USING BTREE,'
+            )
+        );
+        $this->assertEquals('KEY', $component->type);
+        $this->assertEquals('alias_type_idx', $component->name);
+        $this->assertEquals(new OptionsArray(
+            array(
+                1 => 'VISIBLE',
+                2 => array(
+                    'name' => 'USING',
+                    'equals' => false,
+                    'expr' => 'BTREE',
+                    'value' => 'BTREE',
+                ),
+                3 => array(
+                    'name' => 'ENGINE_ATTRIBUTE',
+                    'equals' => true,
+                    'expr' => '\'foo\'',
+                    'value' => 'foo',
+                ),
+                4 => array(
+                    'name' => 'COMMENT',
+                    'equals' => false,
+                    'expr' => '\'my comment\'',
+                    'value' => 'my comment',
+                ),
+                12 => array(
+                    'name' => 'KEY_BLOCK_SIZE',
+                    'equals' => true,
+                    'expr' => '1',
+                    'value' => '1',
+                ),
+                13 => 'INVISIBLE',
+                14 => array(
+                    'name' => 'SECONDARY_ENGINE_ATTRIBUTE',
+                    'equals' => true,
+                    'expr' => '\'bar\'',
+                    'value' => 'bar',
+                ),
+            )
+        ), $component->options);
+        $this->assertNull($component->expr);
+        $this->assertSame(array(
+            array(
+                'name' => 'alias_type',
+                'length' => 10,
+            )
+        ), $component->columns);
+    }
+
     public function testParseKeyExpressionWithoutOptions()
     {
         $component = Key::parse(


### PR DESCRIPTION
Fixes: #348