### PR TITLE
Add `@final` annotation to `Components` classes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,11 +81,6 @@ parameters:
 			path: src/Components/AlterOperation.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Components/AlterOperation.php
-
-		-
 			message: "#^array\\<PhpMyAdmin\\\\SqlParser\\\\Token\\>\\|string does not accept PhpMyAdmin\\\\SqlParser\\\\Token\\.$#"
 			count: 2
 			path: src/Components/AlterOperation.php
@@ -109,21 +104,6 @@ parameters:
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\Array2d\\:\\:parse\\(\\) should return array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\> but returns array\\<int, array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\>\\.$#"
 			count: 1
 			path: src/Components/Array2d.php
-
-		-
-			message: "#^Cannot access an offset on array\\<int, mixed\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\.$#"
-			count: 1
-			path: src/Components/ArrayObj.php
-
-		-
-			message: "#^Cannot access property \\$raw on array\\<int, mixed\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\.$#"
-			count: 2
-			path: src/Components/ArrayObj.php
-
-		-
-			message: "#^Cannot access property \\$values on array\\<int, mixed\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\.$#"
-			count: 2
-			path: src/Components/ArrayObj.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\:\\:__construct\\(\\) has parameter \\$raw with no value type specified in iterable type array\\.$#"
@@ -152,11 +132,6 @@ parameters:
 
 		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\:\\:\\$values type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Components/ArrayObj.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Components/ArrayObj.php
 
@@ -211,17 +186,17 @@ parameters:
 			path: src/Components/CaseExpression.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Components/CaseExpression.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\Condition\\:\\:build\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Components/Condition.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\Condition\\:\\:parse\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Components/Condition.php
+
+		-
+			message: "#^Parameter \\#1 \\$expr of class PhpMyAdmin\\\\SqlParser\\\\Components\\\\Condition constructor expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Components/Condition.php
 
@@ -243,11 +218,6 @@ parameters:
 		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
-			path: src/Components/Condition.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 3
 			path: src/Components/Condition.php
 
 		-
@@ -316,11 +286,6 @@ parameters:
 			path: src/Components/CreateDefinition.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 2
-			path: src/Components/CreateDefinition.php
-
-		-
 			message: "#^Cannot access property \\$raw on array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\.$#"
 			count: 1
 			path: src/Components/DataType.php
@@ -367,11 +332,6 @@ parameters:
 
 		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\DataType\\:\\:\\$parameters type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Components/DataType.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Components/DataType.php
 
@@ -466,11 +426,6 @@ parameters:
 			path: src/Components/Expression.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Components/Expression.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\ExpressionArray\\:\\:build\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Components/ExpressionArray.php
@@ -516,11 +471,6 @@ parameters:
 			path: src/Components/FunctionCall.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Components/FunctionCall.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\GroupKeyword\\:\\:build\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Components/GroupKeyword.php
@@ -537,11 +487,6 @@ parameters:
 
 		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\GroupKeyword\\:\\:\\$expr \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\) in empty\\(\\) is not falsy\\.$#"
-			count: 2
-			path: src/Components/GroupKeyword.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 2
 			path: src/Components/GroupKeyword.php
 
@@ -578,11 +523,6 @@ parameters:
 		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\IndexHint\\:\\:\\$type \\(string\\) does not accept string\\|null\\.$#"
 			count: 1
-			path: src/Components/IndexHint.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 3
 			path: src/Components/IndexHint.php
 
 		-
@@ -676,11 +616,6 @@ parameters:
 			path: src/Components/IntoKeyword.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Components/IntoKeyword.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\JoinKeyword\\:\\:build\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Components/JoinKeyword.php
@@ -723,11 +658,6 @@ parameters:
 		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\JoinKeyword\\:\\:\\$using \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
-			path: src/Components/JoinKeyword.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 4
 			path: src/Components/JoinKeyword.php
 
 		-
@@ -786,11 +716,6 @@ parameters:
 			path: src/Components/Key.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Components/Key.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\:\\:build\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Components/Limit.php
@@ -811,11 +736,6 @@ parameters:
 			path: src/Components/Limit.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Components/Limit.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\LockExpression\\:\\:build\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Components/LockExpression.php
@@ -827,11 +747,6 @@ parameters:
 
 		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\LockExpression\\:\\:\\$table \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\) does not accept PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|null\\.$#"
-			count: 1
-			path: src/Components/LockExpression.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Components/LockExpression.php
 
@@ -876,11 +791,6 @@ parameters:
 			path: src/Components/OptionsArray.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Components/OptionsArray.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\OrderKeyword\\:\\:build\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Components/OrderKeyword.php
@@ -897,11 +807,6 @@ parameters:
 
 		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\OrderKeyword\\:\\:\\$expr \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\) in empty\\(\\) is not falsy\\.$#"
-			count: 2
-			path: src/Components/OrderKeyword.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 2
 			path: src/Components/OrderKeyword.php
 
@@ -946,11 +851,6 @@ parameters:
 			path: src/Components/ParameterDefinition.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 2
-			path: src/Components/ParameterDefinition.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\PartitionDefinition\\:\\:build\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Components/PartitionDefinition.php
@@ -987,11 +887,6 @@ parameters:
 
 		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\PartitionDefinition\\:\\:\\$type \\(string\\) does not accept mixed\\.$#"
-			count: 1
-			path: src/Components/PartitionDefinition.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Components/PartitionDefinition.php
 
@@ -1041,11 +936,6 @@ parameters:
 			path: src/Components/Reference.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Components/Reference.php
-
-		-
 			message: "#^Call to function is_array\\(\\) with PhpMyAdmin\\\\SqlParser\\\\Components\\\\RenameOperation will always evaluate to false\\.$#"
 			count: 1
 			path: src/Components/RenameOperation.php
@@ -1081,11 +971,6 @@ parameters:
 			path: src/Components/RenameOperation.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 2
-			path: src/Components/RenameOperation.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\SetOperation\\:\\:build\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Components/SetOperation.php
@@ -1093,11 +978,6 @@ parameters:
 		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Components\\\\SetOperation\\:\\:parse\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Components/SetOperation.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 2
 			path: src/Components/SetOperation.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.12.0@e42bc4a23f67acba28a23bb09c348e2ff38a1d87">
+<files psalm-version="4.13.1@5cf660f63b548ccd4a56f62d916ee4d6028e01a3">
   <file src="src/Component.php">
     <MixedReturnStatement occurrences="1">
       <code>static::build($this)</code>
@@ -39,9 +39,6 @@
       <code>isset($component-&gt;field)</code>
       <code>isset($component-&gt;field) &amp;&amp; ($component-&gt;field !== '')</code>
     </RedundantConditionGivenDocblockType>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
     <UnusedVariable occurrences="1">
       <code>$arrayKey</code>
     </UnusedVariable>
@@ -97,9 +94,6 @@
     <UndefinedMethod occurrences="1">
       <code>$ret</code>
     </UndefinedMethod>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/CaseExpression.php">
     <InvalidOperand occurrences="1">
@@ -153,9 +147,6 @@
       <code>isset($component-&gt;else_result)</code>
       <code>isset($component-&gt;value)</code>
     </RedundantConditionGivenDocblockType>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/Condition.php">
     <MixedArgument occurrences="1">
@@ -182,11 +173,6 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>is_array($component)</code>
     </RedundantConditionGivenDocblockType>
-    <UnsafeInstantiation occurrences="3">
-      <code>new static($token-&gt;value)</code>
-      <code>new static()</code>
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/CreateDefinition.php">
     <MixedArgument occurrences="1">
@@ -219,10 +205,6 @@
       <code>! empty($expr-&gt;type)</code>
       <code>isset($component-&gt;name)</code>
     </RedundantConditionGivenDocblockType>
-    <UnsafeInstantiation occurrences="2">
-      <code>new static()</code>
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/DataType.php">
     <MixedArgumentTypeCoercion occurrences="1">
@@ -239,9 +221,6 @@
       <code>$name</code>
       <code>$options</code>
     </PossiblyNullPropertyAssignmentValue>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/Expression.php">
     <DocblockTypeContradiction occurrences="2">
@@ -305,9 +284,6 @@
       <code>isset($component-&gt;database)</code>
       <code>isset($component-&gt;table)</code>
     </RedundantConditionGivenDocblockType>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/ExpressionArray.php">
     <InvalidReturnStatement occurrences="1">
@@ -342,9 +318,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$parameters</code>
     </PropertyNotSetInConstructor>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/GroupKeyword.php">
     <MoreSpecificImplementedParamType occurrences="1">
@@ -354,10 +327,6 @@
       <code>$expr</code>
       <code>Expression::parse($parser, $list)</code>
     </PossiblyNullPropertyAssignmentValue>
-    <UnsafeInstantiation occurrences="2">
-      <code>new static()</code>
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/IndexHint.php">
     <MixedArgumentTypeCoercion occurrences="1">
@@ -378,11 +347,6 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$component-&gt;for !== null</code>
     </RedundantConditionGivenDocblockType>
-    <UnsafeInstantiation occurrences="3">
-      <code>new static()</code>
-      <code>new static()</code>
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/IntoKeyword.php">
     <MixedArgument occurrences="2">
@@ -417,9 +381,6 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>isset($component-&gt;values)</code>
     </RedundantConditionGivenDocblockType>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/JoinKeyword.php">
     <DocblockTypeContradiction occurrences="1">
@@ -451,12 +412,6 @@
       <code>$using</code>
       <code>Expression::parse($parser, $list, ['field' =&gt; 'table'])</code>
     </PossiblyNullPropertyAssignmentValue>
-    <UnsafeInstantiation occurrences="4">
-      <code>new static()</code>
-      <code>new static()</code>
-      <code>new static()</code>
-      <code>new static()</code>
-    </UnsafeInstantiation>
     <UnusedVariable occurrences="3">
       <code>$state</code>
       <code>$state</code>
@@ -493,9 +448,6 @@
     <PropertyTypeCoercion occurrences="1">
       <code>$ret-&gt;columns</code>
     </PropertyTypeCoercion>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/Limit.php">
     <MixedArgument occurrences="1">
@@ -508,9 +460,6 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$component</code>
     </MoreSpecificImplementedParamType>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/LockExpression.php">
     <MissingConstructor occurrences="2">
@@ -527,9 +476,6 @@
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>Expression::parse($parser, $list, ['parseField' =&gt; 'table'])</code>
     </PossiblyNullPropertyAssignmentValue>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/OptionsArray.php">
     <MissingReturnType occurrences="1">
@@ -612,9 +558,6 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$options instanceof self</code>
     </RedundantConditionGivenDocblockType>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/OrderKeyword.php">
     <MoreSpecificImplementedParamType occurrences="1">
@@ -624,10 +567,6 @@
       <code>$expr</code>
       <code>Expression::parse($parser, $list)</code>
     </PossiblyNullPropertyAssignmentValue>
-    <UnsafeInstantiation occurrences="2">
-      <code>new static()</code>
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/ParameterDefinition.php">
     <MixedArgument occurrences="1">
@@ -661,10 +600,6 @@
       <code>is_array($component)</code>
       <code>isset($expr-&gt;name)</code>
     </RedundantConditionGivenDocblockType>
-    <UnsafeInstantiation occurrences="2">
-      <code>new static()</code>
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/PartitionDefinition.php">
     <MissingConstructor occurrences="6">
@@ -695,9 +630,6 @@
     </MoreSpecificImplementedParamType>
     <PossiblyNullPropertyAssignmentValue occurrences="1"/>
     <PropertyTypeCoercion occurrences="1"/>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
     <UnusedVariable occurrences="1">
       <code>$idx</code>
     </UnusedVariable>
@@ -716,9 +648,6 @@
       <code>$options</code>
       <code>$table</code>
     </PossiblyNullPropertyAssignmentValue>
-    <UnsafeInstantiation occurrences="1">
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/RenameOperation.php">
     <DocblockTypeContradiction occurrences="1">
@@ -735,10 +664,6 @@
       <code>$new</code>
       <code>$old</code>
     </PossiblyNullPropertyAssignmentValue>
-    <UnsafeInstantiation occurrences="2">
-      <code>new static()</code>
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/SetOperation.php">
     <MoreSpecificImplementedParamType occurrences="1">
@@ -747,10 +672,6 @@
     <RedundantCondition occurrences="1">
       <code>$token-&gt;value === ','</code>
     </RedundantCondition>
-    <UnsafeInstantiation occurrences="2">
-      <code>new static()</code>
-      <code>new static()</code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/Components/UnionKeyword.php">
     <MoreSpecificImplementedParamType occurrences="1">

--- a/src/Components/AlterOperation.php
+++ b/src/Components/AlterOperation.php
@@ -19,6 +19,8 @@ use function is_string;
 
 /**
  * Parses an alter operation.
+ *
+ * @final
  */
 class AlterOperation extends Component
 {

--- a/src/Components/Array2d.php
+++ b/src/Components/Array2d.php
@@ -18,6 +18,8 @@ use function sprintf;
 
 /**
  * `VALUES` keyword parser.
+ *
+ * @final
  */
 class Array2d extends Component
 {

--- a/src/Components/ArrayObj.php
+++ b/src/Components/ArrayObj.php
@@ -19,6 +19,8 @@ use function trim;
 
 /**
  * Parses an array.
+ *
+ * @final
  */
 class ArrayObj extends Component
 {

--- a/src/Components/CaseExpression.php
+++ b/src/Components/CaseExpression.php
@@ -17,6 +17,8 @@ use function count;
 
 /**
  * Parses a reference to a CASE expression.
+ *
+ * @final
  */
 class CaseExpression extends Component
 {

--- a/src/Components/Condition.php
+++ b/src/Components/Condition.php
@@ -19,6 +19,8 @@ use function trim;
 
 /**
  * `WHERE` keyword parser.
+ *
+ * @final
  */
 class Condition extends Component
 {

--- a/src/Components/CreateDefinition.php
+++ b/src/Components/CreateDefinition.php
@@ -23,6 +23,8 @@ use function trim;
  * Parses the create definition of a column or a key.
  *
  * Used for parsing `CREATE TABLE` statement.
+ *
+ * @final
  */
 class CreateDefinition extends Component
 {

--- a/src/Components/DataType.php
+++ b/src/Components/DataType.php
@@ -19,6 +19,8 @@ use function trim;
 
 /**
  * Parses a data type.
+ *
+ * @final
  */
 class DataType extends Component
 {

--- a/src/Components/Expression.php
+++ b/src/Components/Expression.php
@@ -23,6 +23,8 @@ use function trim;
 /**
  * Parses a reference to an expression (column, table or database name, function
  * call, mathematical expression, etc.).
+ *
+ * @final
  */
 class Expression extends Component
 {

--- a/src/Components/ExpressionArray.php
+++ b/src/Components/ExpressionArray.php
@@ -22,6 +22,8 @@ use function substr;
 
 /**
  * Parses a list of expressions delimited by a comma.
+ *
+ * @final
  */
 class ExpressionArray extends Component
 {

--- a/src/Components/FunctionCall.php
+++ b/src/Components/FunctionCall.php
@@ -16,6 +16,8 @@ use function is_array;
 
 /**
  * Parses a function call.
+ *
+ * @final
  */
 class FunctionCall extends Component
 {

--- a/src/Components/GroupKeyword.php
+++ b/src/Components/GroupKeyword.php
@@ -18,6 +18,8 @@ use function trim;
 
 /**
  * `GROUP BY` keyword parser.
+ *
+ * @final
  */
 class GroupKeyword extends Component
 {

--- a/src/Components/IndexHint.php
+++ b/src/Components/IndexHint.php
@@ -17,6 +17,8 @@ use function is_array;
 
 /**
  * Parses an Index hint.
+ *
+ * @final
  */
 class IndexHint extends Component
 {

--- a/src/Components/IntoKeyword.php
+++ b/src/Components/IntoKeyword.php
@@ -17,6 +17,8 @@ use function trim;
 
 /**
  * `INTO` keyword parser.
+ *
+ * @final
  */
 class IntoKeyword extends Component
 {

--- a/src/Components/JoinKeyword.php
+++ b/src/Components/JoinKeyword.php
@@ -17,6 +17,8 @@ use function implode;
 
 /**
  * `JOIN` keyword parser.
+ *
+ * @final
  */
 class JoinKeyword extends Component
 {

--- a/src/Components/Key.php
+++ b/src/Components/Key.php
@@ -20,6 +20,8 @@ use function trim;
  * Parses the definition of a key.
  *
  * Used for parsing `CREATE TABLE` statement.
+ *
+ * @final
  */
 class Key extends Component
 {

--- a/src/Components/Limit.php
+++ b/src/Components/Limit.php
@@ -14,6 +14,8 @@ use PhpMyAdmin\SqlParser\TokensList;
 
 /**
  * `LIMIT` keyword parser.
+ *
+ * @final
  */
 class Limit extends Component
 {

--- a/src/Components/LockExpression.php
+++ b/src/Components/LockExpression.php
@@ -17,6 +17,8 @@ use function is_array;
 
 /**
  * Parses a reference to a LOCK expression.
+ *
+ * @final
  */
 class LockExpression extends Component
 {

--- a/src/Components/OptionsArray.php
+++ b/src/Components/OptionsArray.php
@@ -24,6 +24,8 @@ use function strtoupper;
 
 /**
  * Parses a list of options.
+ *
+ * @final
  */
 class OptionsArray extends Component
 {

--- a/src/Components/OrderKeyword.php
+++ b/src/Components/OrderKeyword.php
@@ -17,6 +17,8 @@ use function is_array;
 
 /**
  * `ORDER BY` keyword parser.
+ *
+ * @final
  */
 class OrderKeyword extends Component
 {

--- a/src/Components/ParameterDefinition.php
+++ b/src/Components/ParameterDefinition.php
@@ -19,6 +19,8 @@ use function trim;
 
 /**
  * The definition of a parameter of a function or procedure.
+ *
+ * @final
  */
 class ParameterDefinition extends Component
 {

--- a/src/Components/PartitionDefinition.php
+++ b/src/Components/PartitionDefinition.php
@@ -22,6 +22,8 @@ use function trim;
  * Parses the create definition of a partition.
  *
  * Used for parsing `CREATE TABLE` statement.
+ *
+ * @final
  */
 class PartitionDefinition extends Component
 {

--- a/src/Components/Reference.php
+++ b/src/Components/Reference.php
@@ -18,6 +18,8 @@ use function trim;
 
 /**
  * `REFERENCES` keyword parser.
+ *
+ * @final
  */
 class Reference extends Component
 {

--- a/src/Components/RenameOperation.php
+++ b/src/Components/RenameOperation.php
@@ -17,6 +17,8 @@ use function is_array;
 
 /**
  * `RENAME TABLE` keyword parser.
+ *
+ * @final
  */
 class RenameOperation extends Component
 {

--- a/src/Components/SetOperation.php
+++ b/src/Components/SetOperation.php
@@ -18,6 +18,8 @@ use function trim;
 
 /**
  * `SET` keyword parser.
+ *
+ * @final
  */
 class SetOperation extends Component
 {

--- a/src/Components/UnionKeyword.php
+++ b/src/Components/UnionKeyword.php
@@ -13,6 +13,8 @@ use function implode;
 
 /**
  * `UNION` keyword builder.
+ *
+ * @final
  */
 class UnionKeyword extends Component
 {

--- a/src/Components/WithKeyword.php
+++ b/src/Components/WithKeyword.php
@@ -13,6 +13,8 @@ use RuntimeException;
 
 /**
  * `WITH` keyword builder.
+ *
+ * @final
  */
 final class WithKeyword extends Component
 {


### PR DESCRIPTION
Since there is no reason to extend the `PhpMyAdmin\SqlParser\Components` classes, this pull request adds the `@final` annotation to these classes. This removes the unsafe instantiation errors reported by PHPStan and Psalm.

The `@final` annotation should be replaced with the [`final` keyword](https://www.php.net/manual/en/language.oop5.final.php) in the next major version.

Fixes #271.