### PR TITLE
Add PHP 8.0 polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "require": {
         "php": "^7.1 || ^8.0",
-        "symfony/polyfill-mbstring": "^1.3"
+        "symfony/polyfill-mbstring": "^1.3",
+        "symfony/polyfill-php80": "^1.16"
     },
     "require-dev": {
         "phpmyadmin/coding-standard": "^3.0",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -29,9 +29,6 @@
       <code>isset($component-&gt;field)</code>
       <code>isset($component-&gt;field) &amp;&amp; ($component-&gt;field !== '')</code>
     </RedundantConditionGivenDocblockType>
-    <UnusedVariable occurrences="1">
-      <code>$arrayKey</code>
-    </UnusedVariable>
   </file>
   <file src="src/Components/Array2d.php">
     <InvalidReturnStatement occurrences="1">

--- a/src/Component.php
+++ b/src/Component.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser;
 
 use Exception;
+use Stringable;
 
 /**
  * A component (of a statement) is a part of a statement that is common to
  * multiple query types.
  */
-abstract class Component
+abstract class Component implements Stringable
 {
     /**
      * Parses the tokens contained in the given list in the context of the given

--- a/src/Context.php
+++ b/src/Context.php
@@ -19,8 +19,8 @@ use function intval;
 use function is_array;
 use function is_numeric;
 use function str_replace;
+use function str_starts_with;
 use function strlen;
-use function strncmp;
 use function strtoupper;
 use function substr;
 
@@ -553,11 +553,11 @@ abstract class Context
         }
 
         /* Fallback to loading at least matching engine */
-        if (strncmp($context, 'MariaDb', 7) === 0) {
+        if (str_starts_with($context, 'MariaDb')) {
             return static::loadClosest('MariaDb100300');
         }
 
-        if (strncmp($context, 'MySql', 5) === 0) {
+        if (str_starts_with($context, 'MySql')) {
             return static::loadClosest('MySql50700');
         }
 

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -18,6 +18,7 @@ use function defined;
 use function in_array;
 use function mb_strlen;
 use function sprintf;
+use function str_ends_with;
 use function strlen;
 use function substr;
 
@@ -1014,7 +1015,7 @@ class Lexer extends Core
             $token .= $this->str[$this->last];
 
             // Test if end of token equals the current delimiter. If so, remove it from the token.
-            if (substr($token, -$this->delimiterLen) === $this->delimiter) {
+            if (str_ends_with($token, $this->delimiter)) {
                 $token = substr($token, 0, -$this->delimiterLen);
                 $this->last -= $this->delimiterLen - 1;
                 break;

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -12,6 +12,7 @@ namespace PhpMyAdmin\SqlParser;
 
 use PhpMyAdmin\SqlParser\Components\FunctionCall;
 use PhpMyAdmin\SqlParser\Components\OptionsArray;
+use Stringable;
 
 use function array_flip;
 use function array_keys;
@@ -23,7 +24,7 @@ use function trim;
 /**
  * Abstract statement definition.
  */
-abstract class Statement
+abstract class Statement implements Stringable
 {
     /**
      * Options for this statement.

--- a/src/Tools/TestGenerator.php
+++ b/src/Tools/TestGenerator.php
@@ -23,6 +23,8 @@ use function mkdir;
 use function print_r;
 use function scandir;
 use function sprintf;
+use function str_contains;
+use function str_ends_with;
 use function strpos;
 use function substr;
 
@@ -219,7 +221,7 @@ class TestGenerator
 
                 // Generating tests recursively.
                 static::buildAll($inputFile, $outputFile, $debugFile);
-            } elseif (substr($inputFile, -3) === '.in') {
+            } elseif (str_ends_with($inputFile, '.in')) {
                 // Generating file names by replacing `.in` with `.out` and
                 // `.debug`.
                 $outputFile = substr($outputFile, 0, -3) . '.out';
@@ -231,11 +233,11 @@ class TestGenerator
                 if (! file_exists($outputFile)) {
                     sprintf("Building test for %s...\n", $inputFile);
                     static::build(
-                        strpos($inputFile, 'lex') !== false ? 'lexer' : 'parser',
+                        str_contains($inputFile, 'lex') ? 'lexer' : 'parser',
                         $inputFile,
                         $outputFile,
                         $debugFile,
-                        strpos($inputFile, 'ansi') !== false
+                        str_contains($inputFile, 'ansi')
                     );
                 } else {
                     sprintf("Test for %s already built!\n", $inputFile);

--- a/src/UtfString.php
+++ b/src/UtfString.php
@@ -16,6 +16,7 @@ namespace PhpMyAdmin\SqlParser;
 
 use ArrayAccess;
 use Exception;
+use Stringable;
 
 use function mb_check_encoding;
 use function mb_strlen;
@@ -28,7 +29,7 @@ use function ord;
  *
  * @implements ArrayAccess<int, string>
  */
-class UtfString implements ArrayAccess
+class UtfString implements ArrayAccess, Stringable
 {
     /**
      * The raw, multi-byte string.

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -19,9 +19,9 @@ use function end;
 use function htmlspecialchars;
 use function in_array;
 use function mb_strlen;
+use function str_contains;
 use function str_repeat;
 use function str_replace;
-use function strpos;
 use function strtoupper;
 
 use const ENT_NOQUOTES;
@@ -399,7 +399,7 @@ class Formatter
             if ($curr->type === Token::TYPE_WHITESPACE) {
                 // Keep linebreaks before and after comments
                 if (
-                    strpos($curr->token, "\n") !== false && (
+                    str_contains($curr->token, "\n") && (
                         ($prev !== null && $prev->type === Token::TYPE_COMMENT) ||
                         ($next !== null && $next->type === Token::TYPE_COMMENT)
                     )

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 use Zumba\JsonSerializer\JsonSerializer;
 
 use function file_get_contents;
+use function str_contains;
 use function strpos;
 use function substr;
 
@@ -107,7 +108,7 @@ abstract class TestCase extends BaseTestCase
          */
         $data = $this->getData($name);
 
-        if (strpos($name, '/ansi/') !== false) {
+        if (str_contains($name, '/ansi/')) {
             // set mode if appropriate
             Context::setMode('ANSI_QUOTES');
         }


### PR DESCRIPTION
Adds support for `Stringable` interface and `str_starts_with`, `str_ends_with` and `str_contains` functions.