### PR TITLE
Add `SqlModes` class with SQL modes constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add missing return types annotations
 * Improve the WITH statements parser (#363)
+* Add SqlModes class with SQL modes constants
 
 ## [5.5.0] - 2021-12-08
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.18.0.0">
+<files psalm-version="4.18.1@dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb">
   <file src="src/Component.php">
     <MixedReturnStatement occurrences="1">
       <code>static::build($this)</code>
@@ -589,7 +589,7 @@
       <code>static::$MODE</code>
     </MixedAssignment>
     <MixedOperand occurrences="1">
-      <code>constant('static::SQL_MODE_' . $m)</code>
+      <code>constant(SqlModes::class . '::' . $m)</code>
     </MixedOperand>
   </file>
   <file src="src/Contexts/ContextMariaDb100000.php">

--- a/src/Context.php
+++ b/src/Context.php
@@ -143,123 +143,103 @@ abstract class Context
     ];
 
     /**
-     * The mode of the MySQL server that will be used in lexing, parsing and
-     * building the statements.
+     * The mode of the MySQL server that will be used in lexing, parsing and building the statements.
+     *
+     * @internal use the {@see Context::getMode()} method instead.
      *
      * @var int
      */
-    public static $MODE = 0;
+    public static $MODE = SqlModes::NONE;
 
-    /*
-     * Server SQL Modes
-     * https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html
-     */
+    /** @deprecated Use {@see SqlModes::COMPAT_MYSQL} instead. */
+    public const SQL_MODE_COMPAT_MYSQL = SqlModes::COMPAT_MYSQL;
 
-    // Compatibility mode for Microsoft's SQL server.
-    // This is the equivalent of ANSI_QUOTES.
-    public const SQL_MODE_COMPAT_MYSQL = 2;
+    /** @deprecated Use {@see SqlModes::ALLOW_INVALID_DATES} instead. */
+    public const SQL_MODE_ALLOW_INVALID_DATES = SqlModes::ALLOW_INVALID_DATES;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_allow_invalid_dates
-    public const SQL_MODE_ALLOW_INVALID_DATES = 1;
+    /** @deprecated Use {@see SqlModes::ANSI_QUOTES} instead. */
+    public const SQL_MODE_ANSI_QUOTES = SqlModes::ANSI_QUOTES;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_ansi_quotes
-    public const SQL_MODE_ANSI_QUOTES = 2;
+    /** @deprecated Use {@see SqlModes::ERROR_FOR_DIVISION_BY_ZERO} instead. */
+    public const SQL_MODE_ERROR_FOR_DIVISION_BY_ZERO = SqlModes::ERROR_FOR_DIVISION_BY_ZERO;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_error_for_division_by_zero
-    public const SQL_MODE_ERROR_FOR_DIVISION_BY_ZERO = 4;
+    /** @deprecated Use {@see SqlModes::HIGH_NOT_PRECEDENCE} instead. */
+    public const SQL_MODE_HIGH_NOT_PRECEDENCE = SqlModes::HIGH_NOT_PRECEDENCE;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_high_not_precedence
-    public const SQL_MODE_HIGH_NOT_PRECEDENCE = 8;
+    /** @deprecated Use {@see SqlModes::IGNORE_SPACE} instead. */
+    public const SQL_MODE_IGNORE_SPACE = SqlModes::IGNORE_SPACE;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_ignore_space
-    public const SQL_MODE_IGNORE_SPACE = 16;
+    /** @deprecated Use {@see SqlModes::NO_AUTO_CREATE_USER} instead. */
+    public const SQL_MODE_NO_AUTO_CREATE_USER = SqlModes::NO_AUTO_CREATE_USER;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_auto_create_user
-    public const SQL_MODE_NO_AUTO_CREATE_USER = 32;
+    /** @deprecated Use {@see SqlModes::NO_AUTO_VALUE_ON_ZERO} instead. */
+    public const SQL_MODE_NO_AUTO_VALUE_ON_ZERO = SqlModes::NO_AUTO_VALUE_ON_ZERO;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_auto_value_on_zero
-    public const SQL_MODE_NO_AUTO_VALUE_ON_ZERO = 64;
+    /** @deprecated Use {@see SqlModes::NO_BACKSLASH_ESCAPES} instead. */
+    public const SQL_MODE_NO_BACKSLASH_ESCAPES = SqlModes::NO_BACKSLASH_ESCAPES;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_backslash_escapes
-    public const SQL_MODE_NO_BACKSLASH_ESCAPES = 128;
+    /** @deprecated Use {@see SqlModes::NO_DIR_IN_CREATE} instead. */
+    public const SQL_MODE_NO_DIR_IN_CREATE = SqlModes::NO_DIR_IN_CREATE;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_dir_in_create
-    public const SQL_MODE_NO_DIR_IN_CREATE = 256;
+    /** @deprecated Use {@see SqlModes::NO_ENGINE_SUBSTITUTION} instead. */
+    public const SQL_MODE_NO_ENGINE_SUBSTITUTION = SqlModes::NO_ENGINE_SUBSTITUTION;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_dir_in_create
-    public const SQL_MODE_NO_ENGINE_SUBSTITUTION = 512;
+    /** @deprecated Use {@see SqlModes::NO_FIELD_OPTIONS} instead. */
+    public const SQL_MODE_NO_FIELD_OPTIONS = SqlModes::NO_FIELD_OPTIONS;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_field_options
-    public const SQL_MODE_NO_FIELD_OPTIONS = 1024;
+    /** @deprecated Use {@see SqlModes::NO_KEY_OPTIONS} instead. */
+    public const SQL_MODE_NO_KEY_OPTIONS = SqlModes::NO_KEY_OPTIONS;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_key_options
-    public const SQL_MODE_NO_KEY_OPTIONS = 2048;
+    /** @deprecated Use {@see SqlModes::NO_TABLE_OPTIONS} instead. */
+    public const SQL_MODE_NO_TABLE_OPTIONS = SqlModes::NO_TABLE_OPTIONS;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_table_options
-    public const SQL_MODE_NO_TABLE_OPTIONS = 4096;
+    /** @deprecated Use {@see SqlModes::NO_UNSIGNED_SUBTRACTION} instead. */
+    public const SQL_MODE_NO_UNSIGNED_SUBTRACTION = SqlModes::NO_UNSIGNED_SUBTRACTION;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_unsigned_subtraction
-    public const SQL_MODE_NO_UNSIGNED_SUBTRACTION = 8192;
+    /** @deprecated Use {@see SqlModes::NO_ZERO_DATE} instead. */
+    public const SQL_MODE_NO_ZERO_DATE = SqlModes::NO_ZERO_DATE;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_zero_date
-    public const SQL_MODE_NO_ZERO_DATE = 16384;
+    /** @deprecated Use {@see SqlModes::NO_ZERO_IN_DATE} instead. */
+    public const SQL_MODE_NO_ZERO_IN_DATE = SqlModes::NO_ZERO_IN_DATE;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_zero_in_date
-    public const SQL_MODE_NO_ZERO_IN_DATE = 32768;
+    /** @deprecated Use {@see SqlModes::ONLY_FULL_GROUP_BY} instead. */
+    public const SQL_MODE_ONLY_FULL_GROUP_BY = SqlModes::ONLY_FULL_GROUP_BY;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_only_full_group_by
-    public const SQL_MODE_ONLY_FULL_GROUP_BY = 65536;
+    /** @deprecated Use {@see SqlModes::PIPES_AS_CONCAT} instead. */
+    public const SQL_MODE_PIPES_AS_CONCAT = SqlModes::PIPES_AS_CONCAT;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_pipes_as_concat
-    public const SQL_MODE_PIPES_AS_CONCAT = 131072;
+    /** @deprecated Use {@see SqlModes::REAL_AS_FLOAT} instead. */
+    public const SQL_MODE_REAL_AS_FLOAT = SqlModes::REAL_AS_FLOAT;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_real_as_float
-    public const SQL_MODE_REAL_AS_FLOAT = 262144;
+    /** @deprecated Use {@see SqlModes::STRICT_ALL_TABLES} instead. */
+    public const SQL_MODE_STRICT_ALL_TABLES = SqlModes::STRICT_ALL_TABLES;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_strict_all_tables
-    public const SQL_MODE_STRICT_ALL_TABLES = 524288;
+    /** @deprecated Use {@see SqlModes::STRICT_TRANS_TABLES} instead. */
+    public const SQL_MODE_STRICT_TRANS_TABLES = SqlModes::STRICT_TRANS_TABLES;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_strict_trans_tables
-    public const SQL_MODE_STRICT_TRANS_TABLES = 1048576;
+    /** @deprecated Use {@see SqlModes::NO_ENCLOSING_QUOTES} instead. */
+    public const SQL_MODE_NO_ENCLOSING_QUOTES = SqlModes::NO_ENCLOSING_QUOTES;
 
-    // Custom modes.
+    /** @deprecated Use {@see SqlModes::ANSI} instead. */
+    public const SQL_MODE_ANSI = SqlModes::ANSI;
 
-    // The table and column names and any other field that must be escaped will
-    // not be.
-    // Reserved keywords are being escaped regardless this mode is used or not.
-    public const SQL_MODE_NO_ENCLOSING_QUOTES = 1073741824;
+    /** @deprecated Use {@see SqlModes::DB2} instead. */
+    public const SQL_MODE_DB2 = SqlModes::DB2;
 
-    /*
-     * Combination SQL Modes
-     * https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sql-mode-combo
-     */
+    /** @deprecated Use {@see SqlModes::MAXDB} instead. */
+    public const SQL_MODE_MAXDB = SqlModes::MAXDB;
 
-    // REAL_AS_FLOAT, PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE
-    public const SQL_MODE_ANSI = 393234;
+    /** @deprecated Use {@see SqlModes::MSSQL} instead. */
+    public const SQL_MODE_MSSQL = SqlModes::MSSQL;
 
-    // PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE, NO_KEY_OPTIONS,
-    // NO_TABLE_OPTIONS, NO_FIELD_OPTIONS,
-    public const SQL_MODE_DB2 = 138258;
+    /** @deprecated Use {@see SqlModes::ORACLE} instead. */
+    public const SQL_MODE_ORACLE = SqlModes::ORACLE;
 
-    // PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE, NO_KEY_OPTIONS,
-    // NO_TABLE_OPTIONS, NO_FIELD_OPTIONS, NO_AUTO_CREATE_USER
-    public const SQL_MODE_MAXDB = 138290;
+    /** @deprecated Use {@see SqlModes::POSTGRESQL} instead. */
+    public const SQL_MODE_POSTGRESQL = SqlModes::POSTGRESQL;
 
-    // PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE, NO_KEY_OPTIONS,
-    // NO_TABLE_OPTIONS, NO_FIELD_OPTIONS
-    public const SQL_MODE_MSSQL = 138258;
-
-    // PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE, NO_KEY_OPTIONS,
-    // NO_TABLE_OPTIONS, NO_FIELD_OPTIONS, NO_AUTO_CREATE_USER
-    public const SQL_MODE_ORACLE = 138290;
-
-    // PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE, NO_KEY_OPTIONS,
-    // NO_TABLE_OPTIONS, NO_FIELD_OPTIONS
-    public const SQL_MODE_POSTGRESQL = 138258;
-
-    // STRICT_TRANS_TABLES, STRICT_ALL_TABLES, NO_ZERO_IN_DATE, NO_ZERO_DATE,
-    // ERROR_FOR_DIVISION_BY_ZERO, NO_AUTO_CREATE_USER
-    public const SQL_MODE_TRADITIONAL = 1622052;
+    /** @deprecated Use {@see SqlModes::TRADITIONAL} instead. */
+    public const SQL_MODE_TRADITIONAL = SqlModes::TRADITIONAL;
 
     // -------------------------------------------------------------------------
     // Keyword.
@@ -572,15 +552,23 @@ abstract class Context
      */
     public static function setMode($mode = '')
     {
-        static::$MODE = 0;
+        static::$MODE = SqlModes::NONE;
         if (empty($mode)) {
             return;
         }
 
         $mode = explode(',', $mode);
         foreach ($mode as $m) {
-            static::$MODE |= constant('static::SQL_MODE_' . $m);
+            static::$MODE |= constant(SqlModes::class . '::' . $m);
         }
+    }
+
+    /**
+     * Gets the SQL mode.
+     */
+    public static function getMode(): int
+    {
+        return static::$MODE;
     }
 
     /**
@@ -601,11 +589,11 @@ abstract class Context
             return $str;
         }
 
-        if ((static::$MODE & self::SQL_MODE_NO_ENCLOSING_QUOTES) && (! static::isKeyword($str, true))) {
+        if ((static::$MODE & SqlModes::NO_ENCLOSING_QUOTES) && (! static::isKeyword($str, true))) {
             return $str;
         }
 
-        if (static::$MODE & self::SQL_MODE_ANSI_QUOTES) {
+        if (static::$MODE & SqlModes::ANSI_QUOTES) {
             $quote = '"';
         }
 
@@ -619,13 +607,13 @@ abstract class Context
      */
     public static function getIdentifierQuote()
     {
-        return self::hasMode(self::SQL_MODE_ANSI_QUOTES) ? '"' : '`';
+        return self::hasMode(SqlModes::ANSI_QUOTES) ? '"' : '`';
     }
 
     /**
      * Function verifies that given SQL Mode constant is currently set
      *
-     * @param int $flag for example Context::SQL_MODE_ANSI_QUOTES
+     * @param int $flag for example {@see SqlModes::ANSI_QUOTES}
      *
      * @return bool false on empty param, true/false on given constant/int value
      */

--- a/src/SqlModes.php
+++ b/src/SqlModes.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\SqlParser;
+
+/**
+ * Server SQL Modes
+ *
+ * @link https://dev.mysql.com/doc/refman/en/sql-mode.html
+ * @link https://mariadb.com/kb/en/sql-mode/
+ */
+final class SqlModes
+{
+    public const NONE = 0;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_allow_invalid_dates
+     * @link https://mariadb.com/kb/en/sql-mode/#allow_invalid_dates
+     */
+    public const ALLOW_INVALID_DATES = 1;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_ansi_quotes
+     * @link https://mariadb.com/kb/en/sql-mode/#ansi_quotes
+     */
+    public const ANSI_QUOTES = 2;
+
+    /** Compatibility mode for Microsoft's SQL server. This is the equivalent of {@see ANSI_QUOTES}. */
+    public const COMPAT_MYSQL = 2;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_error_for_division_by_zero
+     * @link https://mariadb.com/kb/en/sql-mode/#error_for_division_by_zero
+     */
+    public const ERROR_FOR_DIVISION_BY_ZERO = 4;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_high_not_precedence
+     * @link https://mariadb.com/kb/en/sql-mode/#high_not_precedence
+     */
+    public const HIGH_NOT_PRECEDENCE = 8;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_ignore_space
+     * @link https://mariadb.com/kb/en/sql-mode/#ignore_space
+     */
+    public const IGNORE_SPACE = 16;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_auto_create_user
+     * @link https://mariadb.com/kb/en/sql-mode/#no_auto_create_user
+     */
+    public const NO_AUTO_CREATE_USER = 32;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_auto_value_on_zero
+     * @link https://mariadb.com/kb/en/sql-mode/#no_auto_value_on_zero
+     */
+    public const NO_AUTO_VALUE_ON_ZERO = 64;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_backslash_escapes
+     * @link https://mariadb.com/kb/en/sql-mode/#no_backslash_escapes
+     */
+    public const NO_BACKSLASH_ESCAPES = 128;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_dir_in_create
+     * @link https://mariadb.com/kb/en/sql-mode/#no_dir_in_create
+     */
+    public const NO_DIR_IN_CREATE = 256;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_engine_substitution
+     * @link https://mariadb.com/kb/en/sql-mode/#no_engine_substitution
+     */
+    public const NO_ENGINE_SUBSTITUTION = 512;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_field_options
+     * @link https://mariadb.com/kb/en/sql-mode/#no_field_options
+     */
+    public const NO_FIELD_OPTIONS = 1024;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_key_options
+     * @link https://mariadb.com/kb/en/sql-mode/#no_key_options
+     */
+    public const NO_KEY_OPTIONS = 2048;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_table_options
+     * @link https://mariadb.com/kb/en/sql-mode/#no_table_options
+     */
+    public const NO_TABLE_OPTIONS = 4096;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_unsigned_subtraction
+     * @link https://mariadb.com/kb/en/sql-mode/#no_unsigned_subtraction
+     */
+    public const NO_UNSIGNED_SUBTRACTION = 8192;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_zero_date
+     * @link https://mariadb.com/kb/en/sql-mode/#no_zero_date
+     */
+    public const NO_ZERO_DATE = 16384;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_zero_in_date
+     * @link https://mariadb.com/kb/en/sql-mode/#no_zero_in_date
+     */
+    public const NO_ZERO_IN_DATE = 32768;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_only_full_group_by
+     * @link https://mariadb.com/kb/en/sql-mode/#only_full_group_by
+     */
+    public const ONLY_FULL_GROUP_BY = 65536;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_pipes_as_concat
+     * @link https://mariadb.com/kb/en/sql-mode/#pipes_as_concat
+     */
+    public const PIPES_AS_CONCAT = 131072;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_real_as_float
+     * @link https://mariadb.com/kb/en/sql-mode/#real_as_float
+     */
+    public const REAL_AS_FLOAT = 262144;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_strict_all_tables
+     * @link https://mariadb.com/kb/en/sql-mode/#strict_all_tables
+     */
+    public const STRICT_ALL_TABLES = 524288;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_strict_trans_tables
+     * @link https://mariadb.com/kb/en/sql-mode/#strict_trans_tables
+     */
+    public const STRICT_TRANS_TABLES = 1048576;
+
+    /**
+     * Custom mode.
+     * The table and column names and any other field that must be escaped will not be.
+     * Reserved keywords are being escaped regardless this mode is used or not.
+     */
+    public const NO_ENCLOSING_QUOTES = 1073741824;
+
+    /**
+     * Equivalent to {@see REAL_AS_FLOAT}, {@see PIPES_AS_CONCAT}, {@see ANSI_QUOTES}, {@see IGNORE_SPACE}.
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_ansi
+     * @link https://mariadb.com/kb/en/sql-mode/#ansi
+     */
+    public const ANSI = 393234;
+
+    /**
+     * Equivalent to {@see PIPES_AS_CONCAT}, {@see ANSI_QUOTES}, {@see IGNORE_SPACE}, {@see NO_KEY_OPTIONS},
+     * {@see NO_TABLE_OPTIONS}, {@see NO_FIELD_OPTIONS}.
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_db2
+     * @link https://mariadb.com/kb/en/sql-mode/#db2
+     */
+    public const DB2 = 138258;
+
+    /**
+     * Equivalent to {@see PIPES_AS_CONCAT}, {@see ANSI_QUOTES}, {@see IGNORE_SPACE}, {@see NO_KEY_OPTIONS},
+     * {@see NO_TABLE_OPTIONS}, {@see NO_FIELD_OPTIONS}, {@see NO_AUTO_CREATE_USER}.
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_maxdb
+     * @link https://mariadb.com/kb/en/sql-mode/#maxdb
+     */
+    public const MAXDB = 138290;
+
+    /**
+     * Equivalent to {@see PIPES_AS_CONCAT}, {@see ANSI_QUOTES}, {@see IGNORE_SPACE}, {@see NO_KEY_OPTIONS},
+     * {@see NO_TABLE_OPTIONS}, {@see NO_FIELD_OPTIONS}.
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_mssql
+     * @link https://mariadb.com/kb/en/sql-mode/#mssql
+     */
+    public const MSSQL = 138258;
+
+    /**
+     * Equivalent to {@see PIPES_AS_CONCAT}, {@see ANSI_QUOTES}, {@see IGNORE_SPACE}, {@see NO_KEY_OPTIONS},
+     * {@see NO_TABLE_OPTIONS}, {@see NO_FIELD_OPTIONS}, {@see NO_AUTO_CREATE_USER}.
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_oracle
+     * @link https://mariadb.com/kb/en/sql-mode/#oracle
+     */
+    public const ORACLE = 138290;
+
+    /**
+     * Equivalent to {@see PIPES_AS_CONCAT}, {@see ANSI_QUOTES}, {@see IGNORE_SPACE}, {@see NO_KEY_OPTIONS},
+     * {@see NO_TABLE_OPTIONS}, {@see NO_FIELD_OPTIONS}.
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_postgresql
+     * @link https://mariadb.com/kb/en/sql-mode/#postgresql
+     */
+    public const POSTGRESQL = 138258;
+
+    /**
+     * Equivalent to {@see STRICT_TRANS_TABLES}, {@see STRICT_ALL_TABLES}, {@see NO_ZERO_IN_DATE},
+     * {@see NO_ZERO_DATE}, {@see ERROR_FOR_DIVISION_BY_ZERO}, {@see NO_AUTO_CREATE_USER}.
+     *
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_traditional
+     * @link https://mariadb.com/kb/en/sql-mode/#traditional
+     */
+    public const TRADITIONAL = 1622052;
+}

--- a/tests/Lexer/ContextTest.php
+++ b/tests/Lexer/ContextTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Lexer;
 
 use PhpMyAdmin\SqlParser\Context;
+use PhpMyAdmin\SqlParser\SqlModes;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use Throwable;
 
@@ -124,14 +125,17 @@ class ContextTest extends TestCase
     public function testMode(): void
     {
         Context::setMode('REAL_AS_FLOAT,ANSI_QUOTES,IGNORE_SPACE');
-        $this->assertEquals(
-            Context::SQL_MODE_REAL_AS_FLOAT | Context::SQL_MODE_ANSI_QUOTES | Context::SQL_MODE_IGNORE_SPACE,
-            Context::$MODE
-        );
+        $this->assertSame(SqlModes::REAL_AS_FLOAT | SqlModes::ANSI_QUOTES | SqlModes::IGNORE_SPACE, Context::getMode());
+        $this->assertTrue(Context::hasMode(SqlModes::REAL_AS_FLOAT | SqlModes::IGNORE_SPACE));
+        $this->assertTrue(Context::hasMode(SqlModes::ANSI_QUOTES));
+        $this->assertFalse(Context::hasMode(SqlModes::REAL_AS_FLOAT | SqlModes::ALLOW_INVALID_DATES));
+        $this->assertFalse(Context::hasMode(SqlModes::ALLOW_INVALID_DATES));
+
         Context::setMode('TRADITIONAL');
-        $this->assertEquals(Context::SQL_MODE_TRADITIONAL, Context::$MODE);
+        $this->assertSame(SqlModes::TRADITIONAL, Context::getMode());
+
         Context::setMode();
-        $this->assertEquals(0, Context::$MODE);
+        $this->assertSame(SqlModes::NONE, Context::$MODE);
     }
 
     public function testEscape(): void


### PR DESCRIPTION
- Creates the `PhpMyAdmin\SqlParser\SqlModes` class with the `Context::SQL_MODE_*` constants.
- Deprecates the `Context::SQL_MODE_*` constants.

I'm not sure if this is a good thing since an SQL mode can be different depending on the context.