### PR TITLE
Add support for passing integers to `Context::setMode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Add missing return types annotations
 * Improve the WITH statements parser (#363)
+* Add support for passing `Context::SQL_MODE*` constants to `Context::setMode` method
+* Deprecate passing strings to the `Context::setMode` method
 
 ## [5.5.0] - 2021-12-08
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ composer require phpmyadmin/sql-parser
 
 ## Documentation
 
-The API documentation is available at 
+The API documentation is available at
 <https://develdocs.phpmyadmin.net/sql-parser/>.
 
 ## Usage
@@ -96,7 +96,7 @@ $query2 = $statement->build();
 var_dump($query2); // outputs string(19) 'SELECT  * FROM `b` '
 
 // Change SQL mode
-PhpMyAdmin\SqlParser\Context::setMode('ANSI_QUOTES');
+PhpMyAdmin\SqlParser\Context::setMode(PhpMyAdmin\SqlParser\Context::SQL_MODE_ANSI_QUOTES);
 
 // build the query again using different quotes
 $query2 = $statement->build();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,11 +56,6 @@ parameters:
 			path: src/Components/ArrayObj.php
 
 		-
-			message: "#^Array \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\>\\) does not accept PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|null\\.$#"
-			count: 3
-			path: src/Components/CaseExpression.php
-
-		-
 			message: "#^Binary operation \"\\.\" between ' AS ' and array\\<string\\>\\|string results in an error\\.$#"
 			count: 1
 			path: src/Components/CaseExpression.php
@@ -68,6 +63,16 @@ parameters:
 		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\CaseExpression\\:\\:\\$alias \\(string\\|null\\) does not accept mixed\\.$#"
 			count: 1
+			path: src/Components/CaseExpression.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\CaseExpression\\:\\:\\$compare_values \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\>\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|null\\>\\.$#"
+			count: 1
+			path: src/Components/CaseExpression.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\CaseExpression\\:\\:\\$results \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\>\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|null\\>\\.$#"
+			count: 2
 			path: src/Components/CaseExpression.php
 
 		-
@@ -251,17 +256,17 @@ parameters:
 			path: src/Components/JoinKeyword.php
 
 		-
-			message: "#^Array \\(array\\<array\\{name\\?\\: string, length\\?\\: int, order\\?\\: string\\}\\>\\) does not accept non\\-empty\\-array\\<string, mixed\\>\\.$#"
-			count: 1
-			path: src/Components/Key.php
-
-		-
 			message: "#^Binary operation \"\\.\" between array\\<string\\>\\|string and ' ' results in an error\\.$#"
 			count: 1
 			path: src/Components/Key.php
 
 		-
 			message: "#^Binary operation \"\\.\\=\" between '' and array\\<string\\>\\|string results in an error\\.$#"
+			count: 1
+			path: src/Components/Key.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\Key\\:\\:\\$columns \\(array\\<array\\{name\\?\\: string, length\\?\\: int, order\\?\\: string\\}\\>\\) does not accept non\\-empty\\-array\\<array\\<string, mixed\\>\\>\\.$#"
 			count: 1
 			path: src/Components/Key.php
 
@@ -343,6 +348,11 @@ parameters:
 		-
 			message: "#^Parameter \\#3 \\$options of static method PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\:\\:parse\\(\\) expects array\\<string, mixed\\>, mixed given\\.$#"
 			count: 1
+			path: src/Components/OptionsArray.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\:\\:\\$options \\(array\\<int, mixed\\>\\) does not accept array\\<int\\|string, mixed\\>\\.$#"
+			count: 8
 			path: src/Components/OptionsArray.php
 
 		-
@@ -501,18 +511,13 @@ parameters:
 			path: src/Lexer.php
 
 		-
-			message: "#^Array \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\>\\) does not accept array\\<int, PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\|string\\|true\\>\\.$#"
-			count: 1
-			path: src/Parser.php
-
-		-
 			message: "#^Cannot access property \\$count on PhpMyAdmin\\\\SqlParser\\\\TokensList\\|null\\.$#"
 			count: 1
 			path: src/Parser.php
 
 		-
 			message: "#^Cannot access property \\$idx on PhpMyAdmin\\\\SqlParser\\\\TokensList\\|null\\.$#"
-			count: 7
+			count: 8
 			path: src/Parser.php
 
 		-
@@ -533,6 +538,11 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$list of method PhpMyAdmin\\\\SqlParser\\\\Statement\\:\\:validateClauseOrder\\(\\) expects PhpMyAdmin\\\\SqlParser\\\\TokensList, PhpMyAdmin\\\\SqlParser\\\\TokensList\\|null given\\.$#"
 			count: 3
+			path: src/Parser.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$union \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\>\\) does not accept array\\<array\\<int, bool\\|PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\|string\\>\\|PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\>\\.$#"
+			count: 1
 			path: src/Parser.php
 
 		-
@@ -1131,7 +1141,7 @@ parameters:
 			path: tests/Parser/WithStatementTest.php
 
 		-
-			message: "#^Cannot access offset int on non\\-empty\\-array\\<int, string\\>\\|false\\.$#"
+			message: "#^Cannot access offset int\\<0, max\\> on non\\-empty\\-array\\<int, string\\>\\|false\\.$#"
 			count: 1
 			path: tests/Utils/BufferedQueryTest.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.18.0.0">
+<files psalm-version="4.18.1@dda05fa913f4dc6eb3386f2f7ce5a45d37a71bcb">
   <file src="src/Component.php">
     <MixedReturnStatement occurrences="1">
       <code>static::build($this)</code>
@@ -584,13 +584,9 @@
     <InvalidReturnType occurrences="1">
       <code>string|string[]</code>
     </InvalidReturnType>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>self::$KEYWORDS</code>
-      <code>static::$MODE</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>constant('static::SQL_MODE_' . $m)</code>
-    </MixedOperand>
   </file>
   <file src="src/Contexts/ContextMariaDb100000.php">
     <PropertyTypeCoercion occurrences="1"/>

--- a/src/Context.php
+++ b/src/Context.php
@@ -7,11 +7,12 @@ namespace PhpMyAdmin\SqlParser;
 use PhpMyAdmin\SqlParser\Exceptions\LoaderException;
 
 use function class_exists;
-use function constant;
 use function explode;
 use function intval;
 use function is_array;
+use function is_int;
 use function is_numeric;
+use function is_string;
 use function str_replace;
 use function str_starts_with;
 use function strlen;
@@ -143,122 +144,219 @@ abstract class Context
     ];
 
     /**
-     * The mode of the MySQL server that will be used in lexing, parsing and
-     * building the statements.
+     * The mode of the MySQL server that will be used in lexing, parsing and building the statements.
+     *
+     * @internal use the {@see Context::getMode()} method instead.
+     *
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html
+     * @link https://mariadb.com/kb/en/sql-mode/
      *
      * @var int
      */
-    public static $MODE = 0;
+    public static $MODE = self::SQL_MODE_NONE;
 
-    /*
-     * Server SQL Modes
-     * https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html
+    public const SQL_MODE_NONE = 0;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_allow_invalid_dates
+     * @link https://mariadb.com/kb/en/sql-mode/#allow_invalid_dates
      */
-
-    // Compatibility mode for Microsoft's SQL server.
-    // This is the equivalent of ANSI_QUOTES.
-    public const SQL_MODE_COMPAT_MYSQL = 2;
-
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_allow_invalid_dates
     public const SQL_MODE_ALLOW_INVALID_DATES = 1;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_ansi_quotes
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_ansi_quotes
+     * @link https://mariadb.com/kb/en/sql-mode/#ansi_quotes
+     */
     public const SQL_MODE_ANSI_QUOTES = 2;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_error_for_division_by_zero
+    /** Compatibility mode for Microsoft's SQL server. This is the equivalent of {@see SQL_MODE_ANSI_QUOTES}. */
+    public const SQL_MODE_COMPAT_MYSQL = 2;
+
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_error_for_division_by_zero
+     * @link https://mariadb.com/kb/en/sql-mode/#error_for_division_by_zero
+     */
     public const SQL_MODE_ERROR_FOR_DIVISION_BY_ZERO = 4;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_high_not_precedence
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_high_not_precedence
+     * @link https://mariadb.com/kb/en/sql-mode/#high_not_precedence
+     */
     public const SQL_MODE_HIGH_NOT_PRECEDENCE = 8;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_ignore_space
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_ignore_space
+     * @link https://mariadb.com/kb/en/sql-mode/#ignore_space
+     */
     public const SQL_MODE_IGNORE_SPACE = 16;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_auto_create_user
+    /**
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_auto_create_user
+     * @link https://mariadb.com/kb/en/sql-mode/#no_auto_create_user
+     */
     public const SQL_MODE_NO_AUTO_CREATE_USER = 32;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_auto_value_on_zero
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_auto_value_on_zero
+     * @link https://mariadb.com/kb/en/sql-mode/#no_auto_value_on_zero
+     */
     public const SQL_MODE_NO_AUTO_VALUE_ON_ZERO = 64;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_backslash_escapes
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_backslash_escapes
+     * @link https://mariadb.com/kb/en/sql-mode/#no_backslash_escapes
+     */
     public const SQL_MODE_NO_BACKSLASH_ESCAPES = 128;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_dir_in_create
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_dir_in_create
+     * @link https://mariadb.com/kb/en/sql-mode/#no_dir_in_create
+     */
     public const SQL_MODE_NO_DIR_IN_CREATE = 256;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_dir_in_create
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_engine_substitution
+     * @link https://mariadb.com/kb/en/sql-mode/#no_engine_substitution
+     */
     public const SQL_MODE_NO_ENGINE_SUBSTITUTION = 512;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_field_options
+    /**
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_field_options
+     * @link https://mariadb.com/kb/en/sql-mode/#no_field_options
+     */
     public const SQL_MODE_NO_FIELD_OPTIONS = 1024;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_key_options
+    /**
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_key_options
+     * @link https://mariadb.com/kb/en/sql-mode/#no_key_options
+     */
     public const SQL_MODE_NO_KEY_OPTIONS = 2048;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_table_options
+    /**
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_table_options
+     * @link https://mariadb.com/kb/en/sql-mode/#no_table_options
+     */
     public const SQL_MODE_NO_TABLE_OPTIONS = 4096;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_unsigned_subtraction
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_unsigned_subtraction
+     * @link https://mariadb.com/kb/en/sql-mode/#no_unsigned_subtraction
+     */
     public const SQL_MODE_NO_UNSIGNED_SUBTRACTION = 8192;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_zero_date
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_zero_date
+     * @link https://mariadb.com/kb/en/sql-mode/#no_zero_date
+     */
     public const SQL_MODE_NO_ZERO_DATE = 16384;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_no_zero_in_date
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_no_zero_in_date
+     * @link https://mariadb.com/kb/en/sql-mode/#no_zero_in_date
+     */
     public const SQL_MODE_NO_ZERO_IN_DATE = 32768;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_only_full_group_by
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_only_full_group_by
+     * @link https://mariadb.com/kb/en/sql-mode/#only_full_group_by
+     */
     public const SQL_MODE_ONLY_FULL_GROUP_BY = 65536;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_pipes_as_concat
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_pipes_as_concat
+     * @link https://mariadb.com/kb/en/sql-mode/#pipes_as_concat
+     */
     public const SQL_MODE_PIPES_AS_CONCAT = 131072;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_real_as_float
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_real_as_float
+     * @link https://mariadb.com/kb/en/sql-mode/#real_as_float
+     */
     public const SQL_MODE_REAL_AS_FLOAT = 262144;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_strict_all_tables
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_strict_all_tables
+     * @link https://mariadb.com/kb/en/sql-mode/#strict_all_tables
+     */
     public const SQL_MODE_STRICT_ALL_TABLES = 524288;
 
-    // https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sqlmode_strict_trans_tables
+    /**
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_strict_trans_tables
+     * @link https://mariadb.com/kb/en/sql-mode/#strict_trans_tables
+     */
     public const SQL_MODE_STRICT_TRANS_TABLES = 1048576;
 
-    // Custom modes.
-
-    // The table and column names and any other field that must be escaped will
-    // not be.
-    // Reserved keywords are being escaped regardless this mode is used or not.
+    /**
+     * Custom mode.
+     * The table and column names and any other field that must be escaped will not be.
+     * Reserved keywords are being escaped regardless this mode is used or not.
+     */
     public const SQL_MODE_NO_ENCLOSING_QUOTES = 1073741824;
 
-    /*
-     * Combination SQL Modes
-     * https://dev.mysql.com/doc/refman/5.0/en/sql-mode.html#sql-mode-combo
+    /**
+     * Equivalent to {@see SQL_MODE_REAL_AS_FLOAT}, {@see SQL_MODE_PIPES_AS_CONCAT}, {@see SQL_MODE_ANSI_QUOTES},
+     * {@see SQL_MODE_IGNORE_SPACE}.
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_ansi
+     * @link https://mariadb.com/kb/en/sql-mode/#ansi
      */
-
-    // REAL_AS_FLOAT, PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE
     public const SQL_MODE_ANSI = 393234;
 
-    // PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE, NO_KEY_OPTIONS,
-    // NO_TABLE_OPTIONS, NO_FIELD_OPTIONS,
+    /**
+     * Equivalent to {@see SQL_MODE_PIPES_AS_CONCAT}, {@see SQL_MODE_ANSI_QUOTES}, {@see SQL_MODE_IGNORE_SPACE},
+     * {@see SQL_MODE_NO_KEY_OPTIONS}, {@see SQL_MODE_NO_TABLE_OPTIONS}, {@see SQL_MODE_NO_FIELD_OPTIONS}.
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_db2
+     * @link https://mariadb.com/kb/en/sql-mode/#db2
+     */
     public const SQL_MODE_DB2 = 138258;
 
-    // PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE, NO_KEY_OPTIONS,
-    // NO_TABLE_OPTIONS, NO_FIELD_OPTIONS, NO_AUTO_CREATE_USER
+    /**
+     * Equivalent to {@see SQL_MODE_PIPES_AS_CONCAT}, {@see SQL_MODE_ANSI_QUOTES}, {@see SQL_MODE_IGNORE_SPACE},
+     * {@see SQL_MODE_NO_KEY_OPTIONS}, {@see SQL_MODE_NO_TABLE_OPTIONS}, {@see SQL_MODE_NO_FIELD_OPTIONS},
+     * {@see SQL_MODE_NO_AUTO_CREATE_USER}.
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_maxdb
+     * @link https://mariadb.com/kb/en/sql-mode/#maxdb
+     */
     public const SQL_MODE_MAXDB = 138290;
 
-    // PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE, NO_KEY_OPTIONS,
-    // NO_TABLE_OPTIONS, NO_FIELD_OPTIONS
+    /**
+     * Equivalent to {@see SQL_MODE_PIPES_AS_CONCAT}, {@see SQL_MODE_ANSI_QUOTES}, {@see SQL_MODE_IGNORE_SPACE},
+     * {@see SQL_MODE_NO_KEY_OPTIONS}, {@see SQL_MODE_NO_TABLE_OPTIONS}, {@see SQL_MODE_NO_FIELD_OPTIONS}.
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_mssql
+     * @link https://mariadb.com/kb/en/sql-mode/#mssql
+     */
     public const SQL_MODE_MSSQL = 138258;
 
-    // PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE, NO_KEY_OPTIONS,
-    // NO_TABLE_OPTIONS, NO_FIELD_OPTIONS, NO_AUTO_CREATE_USER
+    /**
+     * Equivalent to {@see SQL_MODE_PIPES_AS_CONCAT}, {@see SQL_MODE_ANSI_QUOTES}, {@see SQL_MODE_IGNORE_SPACE},
+     * {@see SQL_MODE_NO_KEY_OPTIONS}, {@see SQL_MODE_NO_TABLE_OPTIONS}, {@see SQL_MODE_NO_FIELD_OPTIONS},
+     * {@see SQL_MODE_NO_AUTO_CREATE_USER}.
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_oracle
+     * @link https://mariadb.com/kb/en/sql-mode/#oracle
+     */
     public const SQL_MODE_ORACLE = 138290;
 
-    // PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE, NO_KEY_OPTIONS,
-    // NO_TABLE_OPTIONS, NO_FIELD_OPTIONS
+    /**
+     * Equivalent to {@see SQL_MODE_PIPES_AS_CONCAT}, {@see SQL_MODE_ANSI_QUOTES}, {@see SQL_MODE_IGNORE_SPACE},
+     * {@see SQL_MODE_NO_KEY_OPTIONS}, {@see SQL_MODE_NO_TABLE_OPTIONS}, {@see SQL_MODE_NO_FIELD_OPTIONS}.
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_postgresql
+     * @link https://mariadb.com/kb/en/sql-mode/#postgresql
+     */
     public const SQL_MODE_POSTGRESQL = 138258;
 
-    // STRICT_TRANS_TABLES, STRICT_ALL_TABLES, NO_ZERO_IN_DATE, NO_ZERO_DATE,
-    // ERROR_FOR_DIVISION_BY_ZERO, NO_AUTO_CREATE_USER
+    /**
+     * Equivalent to {@see SQL_MODE_STRICT_TRANS_TABLES}, {@see SQL_MODE_STRICT_ALL_TABLES},
+     * {@see SQL_MODE_NO_ZERO_IN_DATE}, {@see SQL_MODE_NO_ZERO_DATE}, {@see SQL_MODE_ERROR_FOR_DIVISION_BY_ZERO},
+     * {@see SQL_MODE_NO_AUTO_CREATE_USER}.
+     *
+     * @link https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_traditional
+     * @link https://mariadb.com/kb/en/sql-mode/#traditional
+     */
     public const SQL_MODE_TRADITIONAL = 1622052;
 
     // -------------------------------------------------------------------------
@@ -564,23 +662,143 @@ abstract class Context
     }
 
     /**
+     * Gets the SQL mode.
+     */
+    public static function getMode(): int
+    {
+        return static::$MODE;
+    }
+
+    /**
      * Sets the SQL mode.
      *
-     * @param string $mode The list of modes. If empty, the mode is reset.
+     * @param int $mode
+     * @psalm-param 0|positive-int $mode
      *
      * @return void
      */
-    public static function setMode($mode = '')
+    public static function setMode($mode = self::SQL_MODE_NONE)
     {
-        static::$MODE = 0;
-        if (empty($mode)) {
+        /** @var int|string $mode Used to set the old type to $mode for static analysis tools. */
+        $mode = $mode;
+        if (is_int($mode) && $mode >= 1) {
+            static::$MODE = $mode;
+
             return;
         }
 
-        $mode = explode(',', $mode);
-        foreach ($mode as $m) {
-            static::$MODE |= constant('static::SQL_MODE_' . $m);
+        static::$MODE = self::SQL_MODE_NONE;
+        if (! is_string($mode) || $mode === '') {
+            return;
         }
+
+        $modes = explode(',', $mode);
+        foreach ($modes as $sqlMode) {
+            static::$MODE |= self::getModeFromString($sqlMode);
+        }
+    }
+
+    /**
+     * @psalm-suppress MixedReturnStatement, MixedInferredReturnType Is caused by the LSB of the constants
+     */
+    private static function getModeFromString(string $mode): int
+    {
+        // phpcs:disable SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants.DisallowedLateStaticBindingForConstant
+        switch ($mode) {
+            case 'ALLOW_INVALID_DATES':
+                return static::SQL_MODE_ALLOW_INVALID_DATES;
+
+            case 'ANSI_QUOTES':
+                return static::SQL_MODE_ANSI_QUOTES;
+
+            case 'COMPAT_MYSQL':
+                return static::SQL_MODE_COMPAT_MYSQL;
+
+            case 'ERROR_FOR_DIVISION_BY_ZERO':
+                return static::SQL_MODE_ERROR_FOR_DIVISION_BY_ZERO;
+
+            case 'HIGH_NOT_PRECEDENCE':
+                return static::SQL_MODE_HIGH_NOT_PRECEDENCE;
+
+            case 'IGNORE_SPACE':
+                return static::SQL_MODE_IGNORE_SPACE;
+
+            case 'NO_AUTO_CREATE_USER':
+                return static::SQL_MODE_NO_AUTO_CREATE_USER;
+
+            case 'NO_AUTO_VALUE_ON_ZERO':
+                return static::SQL_MODE_NO_AUTO_VALUE_ON_ZERO;
+
+            case 'NO_BACKSLASH_ESCAPES':
+                return static::SQL_MODE_NO_BACKSLASH_ESCAPES;
+
+            case 'NO_DIR_IN_CREATE':
+                return static::SQL_MODE_NO_DIR_IN_CREATE;
+
+            case 'NO_ENGINE_SUBSTITUTION':
+                return static::SQL_MODE_NO_ENGINE_SUBSTITUTION;
+
+            case 'NO_FIELD_OPTIONS':
+                return static::SQL_MODE_NO_FIELD_OPTIONS;
+
+            case 'NO_KEY_OPTIONS':
+                return static::SQL_MODE_NO_KEY_OPTIONS;
+
+            case 'NO_TABLE_OPTIONS':
+                return static::SQL_MODE_NO_TABLE_OPTIONS;
+
+            case 'NO_UNSIGNED_SUBTRACTION':
+                return static::SQL_MODE_NO_UNSIGNED_SUBTRACTION;
+
+            case 'NO_ZERO_DATE':
+                return static::SQL_MODE_NO_ZERO_DATE;
+
+            case 'NO_ZERO_IN_DATE':
+                return static::SQL_MODE_NO_ZERO_IN_DATE;
+
+            case 'ONLY_FULL_GROUP_BY':
+                return static::SQL_MODE_ONLY_FULL_GROUP_BY;
+
+            case 'PIPES_AS_CONCAT':
+                return static::SQL_MODE_PIPES_AS_CONCAT;
+
+            case 'REAL_AS_FLOAT':
+                return static::SQL_MODE_REAL_AS_FLOAT;
+
+            case 'STRICT_ALL_TABLES':
+                return static::SQL_MODE_STRICT_ALL_TABLES;
+
+            case 'STRICT_TRANS_TABLES':
+                return static::SQL_MODE_STRICT_TRANS_TABLES;
+
+            case 'NO_ENCLOSING_QUOTES':
+                return static::SQL_MODE_NO_ENCLOSING_QUOTES;
+
+            case 'ANSI':
+                return static::SQL_MODE_ANSI;
+
+            case 'DB2':
+                return static::SQL_MODE_DB2;
+
+            case 'MAXDB':
+                return static::SQL_MODE_MAXDB;
+
+            case 'MSSQL':
+                return static::SQL_MODE_MSSQL;
+
+            case 'ORACLE':
+                return static::SQL_MODE_ORACLE;
+
+            case 'POSTGRESQL':
+                return static::SQL_MODE_POSTGRESQL;
+
+            case 'TRADITIONAL':
+                return static::SQL_MODE_TRADITIONAL;
+
+            default:
+                return self::SQL_MODE_NONE;
+        }
+        // phpcs:enable
     }
 
     /**
@@ -625,7 +843,7 @@ abstract class Context
     /**
      * Function verifies that given SQL Mode constant is currently set
      *
-     * @param int $flag for example Context::SQL_MODE_ANSI_QUOTES
+     * @param int $flag for example {@see Context::SQL_MODE_ANSI_QUOTES}
      *
      * @return bool false on empty param, true/false on given constant/int value
      */

--- a/src/Tools/TestGenerator.php
+++ b/src/Tools/TestGenerator.php
@@ -156,7 +156,7 @@ class TestGenerator
 
         if ($ansi === true) {
             // set ANSI_QUOTES for ansi tests
-            Context::setMode('ANSI_QUOTES');
+            Context::setMode(Context::SQL_MODE_ANSI_QUOTES);
         }
 
         $mariaDbPos = strpos($input, '_mariadb_');

--- a/src/Utils/CLI.php
+++ b/src/Utils/CLI.php
@@ -117,7 +117,7 @@ class CLI
         }
 
         if (isset($params['a'])) {
-            Context::setMode('ANSI_QUOTES');
+            Context::setMode(Context::SQL_MODE_ANSI_QUOTES);
         }
 
         if (isset($params['q'])) {
@@ -191,7 +191,7 @@ class CLI
         }
 
         if (isset($params['a'])) {
-            Context::setMode('ANSI_QUOTES');
+            Context::setMode(Context::SQL_MODE_ANSI_QUOTES);
         }
 
         if (isset($params['q'])) {
@@ -265,7 +265,7 @@ class CLI
         }
 
         if (isset($params['a'])) {
-            Context::setMode('ANSI_QUOTES');
+            Context::setMode(Context::SQL_MODE_ANSI_QUOTES);
         }
 
         if (isset($params['q'])) {

--- a/tests/Lexer/ContextTest.php
+++ b/tests/Lexer/ContextTest.php
@@ -121,36 +121,132 @@ class ContextTest extends TestCase
         Context::load('Foo');
     }
 
-    public function testMode(): void
+    /**
+     * @param int|string $mode
+     *
+     * @dataProvider providerForTestMode
+     */
+    public function testMode($mode, int $expected): void
     {
-        Context::setMode('REAL_AS_FLOAT,ANSI_QUOTES,IGNORE_SPACE');
-        $this->assertEquals(
-            Context::SQL_MODE_REAL_AS_FLOAT | Context::SQL_MODE_ANSI_QUOTES | Context::SQL_MODE_IGNORE_SPACE,
-            Context::$MODE
+        /**
+         * @psalm-suppress ArgumentTypeCoercion
+         * @phpstan-ignore-next-line
+         */
+        Context::setMode($mode);
+        $this->assertSame($expected, Context::getMode());
+    }
+
+    /**
+     * @return array<int, array<int, int|string>>
+     * @psalm-return list<array{int|string, int}>
+     */
+    public function providerForTestMode(): array
+    {
+        return [
+            [-1, Context::SQL_MODE_NONE],
+            [0, Context::SQL_MODE_NONE],
+            [1, 1],
+            ['', Context::SQL_MODE_NONE],
+            ['invalid', Context::SQL_MODE_NONE],
+            ['ALLOW_INVALID_DATES', Context::SQL_MODE_ALLOW_INVALID_DATES],
+            ['ANSI_QUOTES', Context::SQL_MODE_ANSI_QUOTES],
+            ['COMPAT_MYSQL', Context::SQL_MODE_COMPAT_MYSQL],
+            ['ERROR_FOR_DIVISION_BY_ZERO', Context::SQL_MODE_ERROR_FOR_DIVISION_BY_ZERO],
+            ['HIGH_NOT_PRECEDENCE', Context::SQL_MODE_HIGH_NOT_PRECEDENCE],
+            ['IGNORE_SPACE', Context::SQL_MODE_IGNORE_SPACE],
+            ['NO_AUTO_CREATE_USER', Context::SQL_MODE_NO_AUTO_CREATE_USER],
+            ['NO_AUTO_VALUE_ON_ZERO', Context::SQL_MODE_NO_AUTO_VALUE_ON_ZERO],
+            ['NO_BACKSLASH_ESCAPES', Context::SQL_MODE_NO_BACKSLASH_ESCAPES],
+            ['NO_DIR_IN_CREATE', Context::SQL_MODE_NO_DIR_IN_CREATE],
+            ['NO_ENGINE_SUBSTITUTION', Context::SQL_MODE_NO_ENGINE_SUBSTITUTION],
+            ['NO_FIELD_OPTIONS', Context::SQL_MODE_NO_FIELD_OPTIONS],
+            ['NO_KEY_OPTIONS', Context::SQL_MODE_NO_KEY_OPTIONS],
+            ['NO_TABLE_OPTIONS', Context::SQL_MODE_NO_TABLE_OPTIONS],
+            ['NO_UNSIGNED_SUBTRACTION', Context::SQL_MODE_NO_UNSIGNED_SUBTRACTION],
+            ['NO_ZERO_DATE', Context::SQL_MODE_NO_ZERO_DATE],
+            ['NO_ZERO_IN_DATE', Context::SQL_MODE_NO_ZERO_IN_DATE],
+            ['ONLY_FULL_GROUP_BY', Context::SQL_MODE_ONLY_FULL_GROUP_BY],
+            ['PIPES_AS_CONCAT', Context::SQL_MODE_PIPES_AS_CONCAT],
+            ['REAL_AS_FLOAT', Context::SQL_MODE_REAL_AS_FLOAT],
+            ['STRICT_ALL_TABLES', Context::SQL_MODE_STRICT_ALL_TABLES],
+            ['STRICT_TRANS_TABLES', Context::SQL_MODE_STRICT_TRANS_TABLES],
+            ['NO_ENCLOSING_QUOTES', Context::SQL_MODE_NO_ENCLOSING_QUOTES],
+            ['ANSI', Context::SQL_MODE_ANSI],
+            ['DB2', Context::SQL_MODE_DB2],
+            ['MAXDB', Context::SQL_MODE_MAXDB],
+            ['MSSQL', Context::SQL_MODE_MSSQL],
+            ['ORACLE', Context::SQL_MODE_ORACLE],
+            ['POSTGRESQL', Context::SQL_MODE_POSTGRESQL],
+            ['TRADITIONAL', Context::SQL_MODE_TRADITIONAL],
+        ];
+    }
+
+    public function testModeWithCombinedModes(): void
+    {
+        Context::setMode(
+            Context::SQL_MODE_REAL_AS_FLOAT | Context::SQL_MODE_ANSI_QUOTES | Context::SQL_MODE_IGNORE_SPACE
         );
-        Context::setMode('TRADITIONAL');
-        $this->assertEquals(Context::SQL_MODE_TRADITIONAL, Context::$MODE);
+        $this->assertSame(
+            Context::SQL_MODE_REAL_AS_FLOAT | Context::SQL_MODE_ANSI_QUOTES | Context::SQL_MODE_IGNORE_SPACE,
+            Context::getMode()
+        );
+        $this->assertTrue(Context::hasMode(Context::SQL_MODE_REAL_AS_FLOAT | Context::SQL_MODE_IGNORE_SPACE));
+        $this->assertTrue(Context::hasMode(Context::SQL_MODE_ANSI_QUOTES));
+        $this->assertFalse(Context::hasMode(Context::SQL_MODE_REAL_AS_FLOAT | Context::SQL_MODE_ALLOW_INVALID_DATES));
+        $this->assertFalse(Context::hasMode(Context::SQL_MODE_ALLOW_INVALID_DATES));
+
+        Context::setMode(Context::SQL_MODE_TRADITIONAL);
+        $this->assertSame(Context::SQL_MODE_TRADITIONAL, Context::getMode());
+
         Context::setMode();
-        $this->assertEquals(0, Context::$MODE);
+        $this->assertSame(Context::SQL_MODE_NONE, Context::getMode());
+    }
+
+    /**
+     * BC tests
+     */
+    public function testModeWithString(): void
+    {
+        /**
+         * @psalm-suppress InvalidScalarArgument
+         * @phpstan-ignore-next-line
+         */
+        Context::setMode('REAL_AS_FLOAT,ANSI_QUOTES,IGNORE_SPACE');
+        $this->assertSame(
+            Context::SQL_MODE_REAL_AS_FLOAT | Context::SQL_MODE_ANSI_QUOTES | Context::SQL_MODE_IGNORE_SPACE,
+            Context::getMode()
+        );
+        $this->assertTrue(Context::hasMode(Context::SQL_MODE_REAL_AS_FLOAT | Context::SQL_MODE_IGNORE_SPACE));
+        $this->assertTrue(Context::hasMode(Context::SQL_MODE_ANSI_QUOTES));
+        $this->assertFalse(Context::hasMode(Context::SQL_MODE_REAL_AS_FLOAT | Context::SQL_MODE_ALLOW_INVALID_DATES));
+        $this->assertFalse(Context::hasMode(Context::SQL_MODE_ALLOW_INVALID_DATES));
+
+        /**
+         * @psalm-suppress InvalidScalarArgument
+         * @phpstan-ignore-next-line
+         */
+        Context::setMode('TRADITIONAL');
+        $this->assertSame(Context::SQL_MODE_TRADITIONAL, Context::getMode());
+
+        /**
+         * @psalm-suppress InvalidScalarArgument
+         * @phpstan-ignore-next-line
+         */
+        Context::setMode('');
+        $this->assertSame(Context::SQL_MODE_NONE, Context::getMode());
     }
 
     public function testEscape(): void
     {
-        Context::setMode('NO_ENCLOSING_QUOTES');
+        Context::setMode(Context::SQL_MODE_NO_ENCLOSING_QUOTES);
         $this->assertEquals('test', Context::escape('test'));
 
-        Context::setMode('ANSI_QUOTES');
+        Context::setMode(Context::SQL_MODE_ANSI_QUOTES);
         $this->assertEquals('"test"', Context::escape('test'));
 
         Context::setMode();
         $this->assertEquals('`test`', Context::escape('test'));
 
-        $this->assertEquals(
-            [
-                '`a`',
-                '`b`',
-            ],
-            Context::escape(['a', 'b'])
-        );
+        $this->assertEquals(['`a`', '`b`'], Context::escape(['a', 'b']));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,6 +33,7 @@ abstract class TestCase extends BaseTestCase
         // Users can have French language as default on their OS
         // That would make the assertions fail
         $lang = 'en';
+        Context::load();
     }
 
     /**
@@ -135,7 +136,7 @@ abstract class TestCase extends BaseTestCase
 
         if (str_contains($name, '/ansi/')) {
             // set mode if appropriate
-            Context::setMode('ANSI_QUOTES');
+            Context::setMode(Context::SQL_MODE_ANSI_QUOTES);
         }
 
         $mariaDbPos = strpos($name, '_mariadb_');


### PR DESCRIPTION
I'm not confident about extracting the SQL mode constants from the `Context` class (#369), so I just improved the constants documentation blocks and I also added support for passing a combination of `Context::SQL_MODE*` constants to the `Context::setMode` method.

Closes #369