### PR TITLE
Supporting table structure with `COMPRESSED` columns

### DIFF
--- a/src/Components/CreateDefinition.php
+++ b/src/Components/CreateDefinition.php
@@ -88,6 +88,7 @@ class CreateDefinition extends Component
         'INVISIBLE' => 13,
         'ENFORCED' => 14,
         'NOT' => 15,
+        'COMPRESSED' => 16,
         // Common entries.
         //
         // NOTE: Some of the common options are not in the same order which

--- a/tests/Components/CreateDefinitionTest.php
+++ b/tests/Components/CreateDefinitionTest.php
@@ -143,12 +143,11 @@ class CreateDefinitionTest extends TestCase
         );
     }
 
-    public function testBuildWithCompressed(): void
+    public function testBuildWithCompressed()
     {
-
         $query = 'CREATE TABLE `user` ( `message2` TEXT COMPRESSED )';
         $parser = new Parser($query);
         $stmt = $parser->statements[0];
-        $this->assertEquals("CREATE TABLE `user` (\n  `message2` text COMPRESSED\n) ",$stmt->build());
+        $this->assertEquals("CREATE TABLE `user` (\n  `message2` text COMPRESSED\n) ", $stmt->build());
     }
 }

--- a/tests/Components/CreateDefinitionTest.php
+++ b/tests/Components/CreateDefinitionTest.php
@@ -142,4 +142,13 @@ class CreateDefinitionTest extends TestCase
             CreateDefinition::build($parser->statements[0]->fields[0])
         );
     }
+
+    public function testBuildWithCompressed(): void
+    {
+
+        $query = 'CREATE TABLE `user` ( `message2` TEXT COMPRESSED )';
+        $parser = new Parser($query);
+        $stmt = $parser->statements[0];
+        $this->assertEquals("CREATE TABLE `user` (\n  `message2` text COMPRESSED\n) ",$stmt->build());
+    }
 }


### PR DESCRIPTION
Hi, this PR should fix https://github.com/phpmyadmin/sql-parser/issues/351
I've written a test, and also integrated it with PMA, and worked as expected. 

<img width="448" alt="image" src="https://user-images.githubusercontent.com/46695441/180334795-f72e56a4-0128-45a4-a9c2-078f44e395bf.png">
