### PR TITLE
Supporting the `compression` options in `create` table statements

### DIFF
--- a/src/Statements/CreateStatement.php
+++ b/src/Statements/CreateStatement.php
@@ -211,6 +211,14 @@ class CreateStatement extends Statement
             21,
             'var',
         ],
+        'PAGE_COMPRESSED' => [
+            22,
+            'var',
+        ],
+        'PAGE_COMPRESSION_LEVEL' => [
+            23,
+            'var',
+        ],
     ];
 
     /**

--- a/tests/Builder/AlterStatementTest.php
+++ b/tests/Builder/AlterStatementTest.php
@@ -20,4 +20,12 @@ class AlterStatementTest extends TestCase
 
         $this->assertEquals($query, $stmt->build());
     }
+
+    public function testBuilderCompressed(): void
+    {
+        $query = 'ALTER TABLE `user` CHANGE `message` `message` TEXT COMPRESSED';
+        $parser = new Parser($query);
+        $stmt = $parser->statements[0];
+        $this->assertEquals($query, $stmt->build());
+    }
 }

--- a/tests/Builder/CreateStatementTest.php
+++ b/tests/Builder/CreateStatementTest.php
@@ -70,6 +70,16 @@ class CreateStatementTest extends TestCase
         );
     }
 
+    public function testBuilderCompressd(): void
+    {
+        $parser = new Parser('CREATE TABLE users ( user_id int ) PAGE_COMPRESSED=1 PAGE_COMPRESSION_LEVEL=9;');
+        $stmt = $parser->statements[0];
+        $this->assertEquals(
+            "CREATE TABLE users (\n  `user_id` int\n) PAGE_COMPRESSED=1 PAGE_COMPRESSION_LEVEL=9",
+            $stmt->build()
+        );
+    }
+
     public function testBuilderCollate(): void
     {
         $parser = new Parser(


### PR DESCRIPTION
Hi, this should add the support of using `PAGE_COMPRESSED` and `PAGE_COMPRESSION_LEVEL` options https://github.com/phpmyadmin/phpmyadmin/issues/14956.