### PR TITLE
Exclude tests using .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /tools export-ignore
+/tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .editorconfig export-ignore


### PR DESCRIPTION
The `tests` directory has no meaning in the `vendor` directory.