### PR TITLE
Fixing tests on php 8.3 - making `getMergedOptions` protected

### DIFF
--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -92,7 +92,7 @@ class Formatter
      *
      * @return array<string, bool|string|array<int, array<string, int|string>>>
      */
-    private function getMergedOptions(array $options)
+    protected function getMergedOptions(array $options)
     {
         $options = array_merge(
             $this->getDefaultOptions(),


### PR DESCRIPTION
Hi, this should fix the reflector issues on PHP 8.3
Signed-off-by: iifawzi <iifawzie@gmail.com>