### PR TITLE
Fix #418 - ALTER EVENT statement with DEFINER=user modifier fails to be parsed

### DIFF
--- a/src/Statements/AlterStatement.php
+++ b/src/Statements/AlterStatement.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
 
 use function implode;
+use function trim;
 
 /**
  * `ALTER` statement.
@@ -44,10 +45,10 @@ class AlterStatement extends Statement
         'OFFLINE' => 1,
         'IGNORE' => 2,
         // `DEFINER` is also used for `ALTER EVENT`
-        //'DEFINER' => [
-        //    2,
-        //    'expr=',
-        //],
+        'DEFINER' => [
+            2,
+            'expr=',
+        ],
         'DATABASE' => 3,
         'EVENT' => 3,
         'FUNCTION' => 3,
@@ -143,8 +144,10 @@ class AlterStatement extends Statement
             $tmp[] = $altered::build($altered);
         }
 
-        return 'ALTER ' . OptionsArray::build($this->options)
+        return trim(
+            'ALTER ' . OptionsArray::build($this->options)
             . ' ' . Expression::build($this->table)
-            . ' ' . implode(', ', $tmp);
+            . ' ' . implode(', ', $tmp)
+        );
     }
 }

--- a/src/Statements/AlterStatement.php
+++ b/src/Statements/AlterStatement.php
@@ -43,7 +43,11 @@ class AlterStatement extends Statement
         'ONLINE' => 1,
         'OFFLINE' => 1,
         'IGNORE' => 2,
-
+        // `DEFINER` is also used for `ALTER EVENT`
+        //'DEFINER' => [
+        //    2,
+        //    'expr=',
+        //],
         'DATABASE' => 3,
         'EVENT' => 3,
         'FUNCTION' => 3,

--- a/tests/Builder/AlterStatementTest.php
+++ b/tests/Builder/AlterStatementTest.php
@@ -34,7 +34,7 @@ class AlterStatementTest extends TestCase
         $parser = new Parser('ALTER TABLE t1 PARTITION BY HASH(id) PARTITIONS 8');
         $stmt = $parser->statements[0];
 
-        $this->assertEquals('ALTER TABLE t1 PARTITION BY  HASH(id) PARTITIONS 8 ', $stmt->build());
+        $this->assertEquals('ALTER TABLE t1 PARTITION BY  HASH(id) PARTITIONS 8', $stmt->build());
 
         $parser = new Parser('ALTER TABLE t1 ADD PARTITION (PARTITION p3 VALUES LESS THAN (2002))');
         $stmt = $parser->statements[0];
@@ -50,7 +50,7 @@ class AlterStatementTest extends TestCase
         $stmt = $parser->statements[0];
 
         $this->assertEquals(
-            'ALTER TABLE p PARTITION BY  LINEAR KEY ALGORITHM=2 (id) PARTITIONS 32 ',
+            'ALTER TABLE p PARTITION BY  LINEAR KEY ALGORITHM=2 (id) PARTITIONS 32',
             $stmt->build()
         );
 
@@ -58,8 +58,16 @@ class AlterStatementTest extends TestCase
         $stmt = $parser->statements[0];
 
         $this->assertEquals(
-            'ALTER TABLE t1 DROP PARTITION  p0, p1 ',
+            'ALTER TABLE t1 DROP PARTITION  p0, p1',
             $stmt->build()
         );
+    }
+
+    public function testBuilderEventWithDefiner(): void
+    {
+        $query = 'ALTER DEFINER=user EVENT myEvent ENABLE';
+        $parser = new Parser($query);
+        $stmt = $parser->statements[0];
+        $this->assertEquals($query, $stmt->build());
     }
 }

--- a/tests/Builder/AlterStatementTest.php
+++ b/tests/Builder/AlterStatementTest.php
@@ -21,6 +21,37 @@ class AlterStatementTest extends TestCase
         $this->assertEquals($query, $stmt->build());
     }
 
+    public function testBuilderWithComments(): void
+    {
+        $query = 'ALTER /* comment */ TABLE `actor` ' .
+            'ADD PRIMARY KEY (`actor_id`), -- comment at the end of the line' . "\n" .
+            'ADD KEY `idx_actor_last_name` (`last_name`) -- and that is the last comment.';
+
+        $expectedQuery = 'ALTER TABLE `actor` ' .
+            'ADD PRIMARY KEY (`actor_id`), ' .
+            'ADD KEY `idx_actor_last_name` (`last_name`)';
+
+        $parser = new Parser($query);
+        $stmt = $parser->statements[0];
+
+        $this->assertEquals($expectedQuery, $stmt->build());
+    }
+
+    public function testBuilderWithCommentsOnOptions(): void
+    {
+        $query = 'ALTER EVENT `myEvent` /* comment */ ' .
+            'ON SCHEDULE -- Comment at the end of the line' . "\n" .
+            'AT "2023-01-01 01:23:45"';
+
+        $expectedQuery = 'ALTER EVENT `myEvent` ' .
+            'ON SCHEDULE AT "2023-01-01 01:23:45"';
+
+        $parser = new Parser($query);
+        $stmt = $parser->statements[0];
+
+        $this->assertEquals($expectedQuery, $stmt->build());
+    }
+
     public function testBuilderCompressed(): void
     {
         $query = 'ALTER TABLE `user` CHANGE `message` `message` TEXT COMPRESSED';

--- a/tests/Parser/AlterStatementTest.php
+++ b/tests/Parser/AlterStatementTest.php
@@ -77,6 +77,7 @@ class AlterStatementTest extends TestCase
             ['parser/parseAlterEventOnScheduleEvery5'],
             ['parser/parseAlterEventOnScheduleEvery6'],
             ['parser/parseAlterEventWithDefiner'],
+            ['parser/parseAlterEventWithOtherDefiners'],
         ];
     }
 }

--- a/tests/Parser/AlterStatementTest.php
+++ b/tests/Parser/AlterStatementTest.php
@@ -76,6 +76,7 @@ class AlterStatementTest extends TestCase
             ['parser/parseAlterEventOnScheduleEvery4'],
             ['parser/parseAlterEventOnScheduleEvery5'],
             ['parser/parseAlterEventOnScheduleEvery6'],
+            ['parser/parseAlterEventWithDefiner'],
         ];
     }
 }

--- a/tests/data/parser/parseAlterEventWithDefiner.in
+++ b/tests/data/parser/parseAlterEventWithDefiner.in
@@ -1,0 +1,1 @@
+ALTER DEFINER = user EVENT my_event ENABLE;

--- a/tests/data/parser/parseAlterEventWithDefiner.out
+++ b/tests/data/parser/parseAlterEventWithDefiner.out
@@ -1,0 +1,776 @@
+{
+    "query": "ALTER DEFINER = user EVENT my_event ENABLE;\n",
+    "lexer": {
+        "@type": "PhpMyAdmin\\SqlParser\\Lexer",
+        "PARSER_METHODS": [
+            "parseDelimiter",
+            "parseWhitespace",
+            "parseNumber",
+            "parseComment",
+            "parseOperator",
+            "parseBool",
+            "parseString",
+            "parseSymbol",
+            "parseKeyword",
+            "parseLabel",
+            "parseUnknown"
+        ],
+        "KEYWORD_NAME_INDICATORS": [
+            "FROM",
+            "SET",
+            "WHERE"
+        ],
+        "OPERATOR_NAME_INDICATORS": [
+            ",",
+            "."
+        ],
+        "str": "ALTER DEFINER = user EVENT my_event ENABLE;\n",
+        "len": 44,
+        "last": 44,
+        "list": {
+            "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "tokens": [
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "ALTER",
+                    "value": "ALTER",
+                    "keyword": "ALTER",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 0
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 5
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "DEFINER",
+                    "value": "DEFINER",
+                    "keyword": "DEFINER",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 6
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 13
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "=",
+                    "value": "=",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 2,
+                    "position": 14
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 15
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "user",
+                    "value": "user",
+                    "keyword": "USER",
+                    "type": 1,
+                    "flags": 33,
+                    "position": 16
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 20
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "EVENT",
+                    "value": "EVENT",
+                    "keyword": "EVENT",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 21
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 26
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "my_event",
+                    "value": "my_event",
+                    "keyword": null,
+                    "type": 0,
+                    "flags": 0,
+                    "position": 27
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 35
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "ENABLE",
+                    "value": "ENABLE",
+                    "keyword": "ENABLE",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 36
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ";",
+                    "value": ";",
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": 42
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 43
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": null,
+                    "value": null,
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": null
+                }
+            ],
+            "count": 16,
+            "idx": 16
+        },
+        "DEFAULT_DELIMITER": ";",
+        "delimiter": ";",
+        "delimiterLen": 1,
+        "strict": false,
+        "errors": []
+    },
+    "parser": {
+        "@type": "PhpMyAdmin\\SqlParser\\Parser",
+        "STATEMENT_PARSERS": {
+            "DESCRIBE": "PhpMyAdmin\\SqlParser\\Statements\\ExplainStatement",
+            "DESC": "PhpMyAdmin\\SqlParser\\Statements\\ExplainStatement",
+            "EXPLAIN": "PhpMyAdmin\\SqlParser\\Statements\\ExplainStatement",
+            "FLUSH": "",
+            "GRANT": "",
+            "HELP": "",
+            "SET PASSWORD": "",
+            "STATUS": "",
+            "USE": "",
+            "ANALYZE": "PhpMyAdmin\\SqlParser\\Statements\\AnalyzeStatement",
+            "BACKUP": "PhpMyAdmin\\SqlParser\\Statements\\BackupStatement",
+            "CHECK": "PhpMyAdmin\\SqlParser\\Statements\\CheckStatement",
+            "CHECKSUM": "PhpMyAdmin\\SqlParser\\Statements\\ChecksumStatement",
+            "OPTIMIZE": "PhpMyAdmin\\SqlParser\\Statements\\OptimizeStatement",
+            "REPAIR": "PhpMyAdmin\\SqlParser\\Statements\\RepairStatement",
+            "RESTORE": "PhpMyAdmin\\SqlParser\\Statements\\RestoreStatement",
+            "SET": "PhpMyAdmin\\SqlParser\\Statements\\SetStatement",
+            "SHOW": "PhpMyAdmin\\SqlParser\\Statements\\ShowStatement",
+            "ALTER": "PhpMyAdmin\\SqlParser\\Statements\\AlterStatement",
+            "CREATE": "PhpMyAdmin\\SqlParser\\Statements\\CreateStatement",
+            "DROP": "PhpMyAdmin\\SqlParser\\Statements\\DropStatement",
+            "RENAME": "PhpMyAdmin\\SqlParser\\Statements\\RenameStatement",
+            "TRUNCATE": "PhpMyAdmin\\SqlParser\\Statements\\TruncateStatement",
+            "CALL": "PhpMyAdmin\\SqlParser\\Statements\\CallStatement",
+            "DELETE": "PhpMyAdmin\\SqlParser\\Statements\\DeleteStatement",
+            "DO": "",
+            "HANDLER": "",
+            "INSERT": "PhpMyAdmin\\SqlParser\\Statements\\InsertStatement",
+            "LOAD DATA": "PhpMyAdmin\\SqlParser\\Statements\\LoadStatement",
+            "REPLACE": "PhpMyAdmin\\SqlParser\\Statements\\ReplaceStatement",
+            "SELECT": "PhpMyAdmin\\SqlParser\\Statements\\SelectStatement",
+            "UPDATE": "PhpMyAdmin\\SqlParser\\Statements\\UpdateStatement",
+            "WITH": "PhpMyAdmin\\SqlParser\\Statements\\WithStatement",
+            "DEALLOCATE": "",
+            "EXECUTE": "",
+            "PREPARE": "",
+            "BEGIN": "PhpMyAdmin\\SqlParser\\Statements\\TransactionStatement",
+            "COMMIT": "PhpMyAdmin\\SqlParser\\Statements\\TransactionStatement",
+            "ROLLBACK": "PhpMyAdmin\\SqlParser\\Statements\\TransactionStatement",
+            "START TRANSACTION": "PhpMyAdmin\\SqlParser\\Statements\\TransactionStatement",
+            "PURGE": "PhpMyAdmin\\SqlParser\\Statements\\PurgeStatement",
+            "LOCK": "PhpMyAdmin\\SqlParser\\Statements\\LockStatement",
+            "UNLOCK": "PhpMyAdmin\\SqlParser\\Statements\\LockStatement"
+        },
+        "KEYWORD_PARSERS": {
+            "PARTITION BY": [],
+            "SUBPARTITION BY": [],
+            "_OPTIONS": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                "field": "options"
+            },
+            "_END_OPTIONS": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                "field": "end_options"
+            },
+            "INTERSECT": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\UnionKeyword",
+                "field": "union"
+            },
+            "EXCEPT": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\UnionKeyword",
+                "field": "union"
+            },
+            "UNION": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\UnionKeyword",
+                "field": "union"
+            },
+            "UNION ALL": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\UnionKeyword",
+                "field": "union"
+            },
+            "UNION DISTINCT": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\UnionKeyword",
+                "field": "union"
+            },
+            "ALTER": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                "field": "table",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "ANALYZE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "BACKUP": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "CALL": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\FunctionCall",
+                "field": "call"
+            },
+            "CHECK": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "CHECKSUM": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "CROSS JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "DROP": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "fields",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "FORCE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\IndexHint",
+                "field": "index_hints"
+            },
+            "FROM": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "from",
+                "options": {
+                    "field": "table"
+                }
+            },
+            "GROUP BY": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\GroupKeyword",
+                "field": "group"
+            },
+            "HAVING": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Condition",
+                "field": "having"
+            },
+            "IGNORE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\IndexHint",
+                "field": "index_hints"
+            },
+            "INTO": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\IntoKeyword",
+                "field": "into"
+            },
+            "JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "LEFT JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "LEFT OUTER JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "ON": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                "field": "table",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "RIGHT JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "RIGHT OUTER JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "INNER JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "FULL JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "FULL OUTER JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "NATURAL JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "NATURAL LEFT JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "NATURAL RIGHT JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "NATURAL LEFT OUTER JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "NATURAL RIGHT OUTER JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "STRAIGHT_JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "LIMIT": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Limit",
+                "field": "limit"
+            },
+            "OPTIMIZE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "ORDER BY": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\OrderKeyword",
+                "field": "order"
+            },
+            "PARTITION": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ArrayObj",
+                "field": "partition"
+            },
+            "PROCEDURE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\FunctionCall",
+                "field": "procedure"
+            },
+            "RENAME": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\RenameOperation",
+                "field": "renames"
+            },
+            "REPAIR": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "RESTORE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "SET": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\SetOperation",
+                "field": "set"
+            },
+            "SELECT": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "expr"
+            },
+            "TRUNCATE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                "field": "table",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "UPDATE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "USE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\IndexHint",
+                "field": "index_hints"
+            },
+            "VALUE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Array2d",
+                "field": "values"
+            },
+            "VALUES": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Array2d",
+                "field": "values"
+            },
+            "WHERE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Condition",
+                "field": "where"
+            }
+        },
+        "list": {
+            "@type": "@1"
+        },
+        "statements": [
+            {
+                "@type": "PhpMyAdmin\\SqlParser\\Statements\\AlterStatement",
+                "table": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                    "ALLOWED_KEYWORDS": {
+                        "AND": 1,
+                        "AS": 1,
+                        "BETWEEN": 1,
+                        "CASE": 1,
+                        "DUAL": 1,
+                        "DIV": 1,
+                        "IS": 1,
+                        "MOD": 1,
+                        "NOT": 1,
+                        "NOT NULL": 1,
+                        "NULL": 1,
+                        "OR": 1,
+                        "OVER": 1,
+                        "REGEXP": 1,
+                        "RLIKE": 1,
+                        "XOR": 1
+                    },
+                    "database": null,
+                    "table": "DEFINER",
+                    "column": null,
+                    "expr": "DEFINER",
+                    "alias": null,
+                    "function": null,
+                    "subquery": null
+                },
+                "altered": [
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\AlterOperation",
+                        "DB_OPTIONS": {
+                            "CHARACTER SET": [
+                                1,
+                                "var"
+                            ],
+                            "CHARSET": [
+                                1,
+                                "var"
+                            ],
+                            "DEFAULT CHARACTER SET": [
+                                1,
+                                "var"
+                            ],
+                            "DEFAULT CHARSET": [
+                                1,
+                                "var"
+                            ],
+                            "UPGRADE": [
+                                1,
+                                "var"
+                            ],
+                            "COLLATE": [
+                                2,
+                                "var"
+                            ],
+                            "DEFAULT COLLATE": [
+                                2,
+                                "var"
+                            ]
+                        },
+                        "TABLE_OPTIONS": {
+                            "ENGINE": [
+                                1,
+                                "var="
+                            ],
+                            "AUTO_INCREMENT": [
+                                1,
+                                "var="
+                            ],
+                            "AVG_ROW_LENGTH": [
+                                1,
+                                "var"
+                            ],
+                            "MAX_ROWS": [
+                                1,
+                                "var"
+                            ],
+                            "ROW_FORMAT": [
+                                1,
+                                "var"
+                            ],
+                            "COMMENT": [
+                                1,
+                                "var"
+                            ],
+                            "ADD": 1,
+                            "ALTER": 1,
+                            "ANALYZE": 1,
+                            "CHANGE": 1,
+                            "CHARSET": 1,
+                            "CHECK": 1,
+                            "COALESCE": 1,
+                            "CONVERT": 1,
+                            "DEFAULT CHARSET": 1,
+                            "DISABLE": 1,
+                            "DISCARD": 1,
+                            "DROP": 1,
+                            "ENABLE": 1,
+                            "IMPORT": 1,
+                            "MODIFY": 1,
+                            "OPTIMIZE": 1,
+                            "ORDER": 1,
+                            "REBUILD": 1,
+                            "REMOVE": 1,
+                            "RENAME": 1,
+                            "REORGANIZE": 1,
+                            "REPAIR": 1,
+                            "UPGRADE": 1,
+                            "COLUMN": 2,
+                            "CONSTRAINT": 2,
+                            "DEFAULT": 2,
+                            "BY": 2,
+                            "FOREIGN": 2,
+                            "FULLTEXT": 2,
+                            "KEY": 2,
+                            "KEYS": 2,
+                            "PARTITION": 2,
+                            "PARTITION BY": 2,
+                            "PARTITIONING": 2,
+                            "PRIMARY KEY": 2,
+                            "SPATIAL": 2,
+                            "TABLESPACE": 2,
+                            "INDEX": [
+                                2,
+                                "var"
+                            ],
+                            "CHARACTER SET": 3,
+                            "TO": [
+                                3,
+                                "var"
+                            ]
+                        },
+                        "USER_OPTIONS": {
+                            "ATTRIBUTE": [
+                                1,
+                                "var"
+                            ],
+                            "COMMENT": [
+                                1,
+                                "var"
+                            ],
+                            "REQUIRE": [
+                                1,
+                                "var"
+                            ],
+                            "BY": [
+                                2,
+                                "expr"
+                            ],
+                            "PASSWORD": [
+                                2,
+                                "var"
+                            ],
+                            "WITH": [
+                                2,
+                                "var"
+                            ],
+                            "ACCOUNT": 1,
+                            "DEFAULT": 1,
+                            "LOCK": 2,
+                            "UNLOCK": 2,
+                            "IDENTIFIED": 3
+                        },
+                        "VIEW_OPTIONS": {
+                            "AS": 1
+                        },
+                        "EVENT_OPTIONS": {
+                            "ON SCHEDULE": 1,
+                            "EVERY": [
+                                2,
+                                "expr"
+                            ],
+                            "AT": [
+                                2,
+                                "expr"
+                            ],
+                            "STARTS": [
+                                3,
+                                "expr"
+                            ],
+                            "ENDS": [
+                                4,
+                                "expr"
+                            ],
+                            "ON COMPLETION PRESERVE": 5,
+                            "ON COMPLETION NOT PRESERVE": 5,
+                            "RENAME": 6,
+                            "TO": [
+                                7,
+                                "expr",
+                                {
+                                    "parseField": "table"
+                                }
+                            ],
+                            "ENABLE": 8,
+                            "DISABLE": 8,
+                            "DISABLE ON SLAVE": 8,
+                            "COMMENT": [
+                                9,
+                                "var"
+                            ],
+                            "DO": 10
+                        },
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        },
+                        "field": null,
+                        "partitions": null,
+                        "unknown": [
+                            {
+                                "@type": "@6"
+                            },
+                            {
+                                "@type": "@7"
+                            },
+                            {
+                                "@type": "@8"
+                            },
+                            {
+                                "@type": "@9"
+                            },
+                            {
+                                "@type": "@10"
+                            },
+                            {
+                                "@type": "@11"
+                            },
+                            {
+                                "@type": "@12"
+                            },
+                            {
+                                "@type": "@13"
+                            }
+                        ]
+                    }
+                ],
+                "OPTIONS": {
+                    "ONLINE": 1,
+                    "OFFLINE": 1,
+                    "IGNORE": 2,
+                    "DATABASE": 3,
+                    "EVENT": 3,
+                    "FUNCTION": 3,
+                    "PROCEDURE": 3,
+                    "SERVER": 3,
+                    "TABLE": 3,
+                    "TABLESPACE": 3,
+                    "USER": 3,
+                    "VIEW": 3
+                },
+                "CLAUSES": [],
+                "END_OPTIONS": [],
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 0,
+                "last": 13
+            }
+        ],
+        "brackets": 0,
+        "strict": false,
+        "errors": []
+    },
+    "errors": {
+        "lexer": [],
+        "parser": [
+            [
+                "Missing comma before start of a new alter operation.",
+                {
+                    "@type": "@14"
+                },
+                0
+            ],
+            [
+                "Unrecognized alter operation.",
+                {
+                    "@type": "@14"
+                },
+                0
+            ]
+        ]
+    }
+}

--- a/tests/data/parser/parseAlterEventWithDefiner.out
+++ b/tests/data/parser/parseAlterEventWithDefiner.out
@@ -509,9 +509,9 @@
                         "XOR": 1
                     },
                     "database": null,
-                    "table": "DEFINER",
+                    "table": "my_event",
                     "column": null,
-                    "expr": "DEFINER",
+                    "expr": "my_event",
                     "alias": null,
                     "function": null,
                     "subquery": null
@@ -694,42 +694,23 @@
                         },
                         "options": {
                             "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                            "options": []
+                            "options": {
+                                "8": "ENABLE"
+                            }
                         },
                         "field": null,
                         "partitions": null,
-                        "unknown": [
-                            {
-                                "@type": "@6"
-                            },
-                            {
-                                "@type": "@7"
-                            },
-                            {
-                                "@type": "@8"
-                            },
-                            {
-                                "@type": "@9"
-                            },
-                            {
-                                "@type": "@10"
-                            },
-                            {
-                                "@type": "@11"
-                            },
-                            {
-                                "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
-                            }
-                        ]
+                        "unknown": []
                     }
                 ],
                 "OPTIONS": {
                     "ONLINE": 1,
                     "OFFLINE": 1,
                     "IGNORE": 2,
+                    "DEFINER": [
+                        2,
+                        "expr="
+                    ],
                     "DATABASE": 3,
                     "EVENT": 3,
                     "FUNCTION": 3,
@@ -744,7 +725,42 @@
                 "END_OPTIONS": [],
                 "options": {
                     "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
+                    "options": {
+                        "2": {
+                            "name": "DEFINER",
+                            "equals": true,
+                            "expr": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                                "ALLOWED_KEYWORDS": {
+                                    "AND": 1,
+                                    "AS": 1,
+                                    "BETWEEN": 1,
+                                    "CASE": 1,
+                                    "DUAL": 1,
+                                    "DIV": 1,
+                                    "IS": 1,
+                                    "MOD": 1,
+                                    "NOT": 1,
+                                    "NOT NULL": 1,
+                                    "NULL": 1,
+                                    "OR": 1,
+                                    "OVER": 1,
+                                    "REGEXP": 1,
+                                    "RLIKE": 1,
+                                    "XOR": 1
+                                },
+                                "database": null,
+                                "table": null,
+                                "column": null,
+                                "expr": "user",
+                                "alias": null,
+                                "function": null,
+                                "subquery": null
+                            },
+                            "value": "user"
+                        },
+                        "3": "EVENT"
+                    }
                 },
                 "first": 0,
                 "last": 13
@@ -756,21 +772,6 @@
     },
     "errors": {
         "lexer": [],
-        "parser": [
-            [
-                "Missing comma before start of a new alter operation.",
-                {
-                    "@type": "@14"
-                },
-                0
-            ],
-            [
-                "Unrecognized alter operation.",
-                {
-                    "@type": "@14"
-                },
-                0
-            ]
-        ]
+        "parser": []
     }
 }

--- a/tests/data/parser/parseAlterEventWithOtherDefiners.in
+++ b/tests/data/parser/parseAlterEventWithOtherDefiners.in
@@ -1,0 +1,5 @@
+ALTER DEFINER = 'user' EVENT my_event ENABLE;
+ALTER DEFINER = `user` EVENT my_event ENABLE;
+ALTER DEFINER = user@host EVENT my_event ENABLE;
+ALTER DEFINER = 'user'@'host' EVENT my_event ENABLE;
+ALTER DEFINER = `user`@`host` EVENT my_event ENABLE;

--- a/tests/data/parser/parseAlterEventWithOtherDefiners.out
+++ b/tests/data/parser/parseAlterEventWithOtherDefiners.out
@@ -1058,9 +1058,9 @@
                         "XOR": 1
                     },
                     "database": null,
-                    "table": "DEFINER",
+                    "table": "my_event",
                     "column": null,
-                    "expr": "DEFINER",
+                    "expr": "my_event",
                     "alias": null,
                     "function": null,
                     "subquery": null
@@ -1243,42 +1243,23 @@
                         },
                         "options": {
                             "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                            "options": []
+                            "options": {
+                                "8": "ENABLE"
+                            }
                         },
                         "field": null,
                         "partitions": null,
-                        "unknown": [
-                            {
-                                "@type": "@6"
-                            },
-                            {
-                                "@type": "@7"
-                            },
-                            {
-                                "@type": "@8"
-                            },
-                            {
-                                "@type": "@9"
-                            },
-                            {
-                                "@type": "@10"
-                            },
-                            {
-                                "@type": "@11"
-                            },
-                            {
-                                "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
-                            }
-                        ]
+                        "unknown": []
                     }
                 ],
                 "OPTIONS": {
                     "ONLINE": 1,
                     "OFFLINE": 1,
                     "IGNORE": 2,
+                    "DEFINER": [
+                        2,
+                        "expr="
+                    ],
                     "DATABASE": 3,
                     "EVENT": 3,
                     "FUNCTION": 3,
@@ -1293,7 +1274,42 @@
                 "END_OPTIONS": [],
                 "options": {
                     "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
+                    "options": {
+                        "2": {
+                            "name": "DEFINER",
+                            "equals": true,
+                            "expr": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                                "ALLOWED_KEYWORDS": {
+                                    "AND": 1,
+                                    "AS": 1,
+                                    "BETWEEN": 1,
+                                    "CASE": 1,
+                                    "DUAL": 1,
+                                    "DIV": 1,
+                                    "IS": 1,
+                                    "MOD": 1,
+                                    "NOT": 1,
+                                    "NOT NULL": 1,
+                                    "NULL": 1,
+                                    "OR": 1,
+                                    "OVER": 1,
+                                    "REGEXP": 1,
+                                    "RLIKE": 1,
+                                    "XOR": 1
+                                },
+                                "database": null,
+                                "table": null,
+                                "column": "user",
+                                "expr": "'user'",
+                                "alias": null,
+                                "function": null,
+                                "subquery": null
+                            },
+                            "value": "'user'"
+                        },
+                        "3": "EVENT"
+                    }
                 },
                 "first": 0,
                 "last": 13
@@ -1321,9 +1337,9 @@
                         "XOR": 1
                     },
                     "database": null,
-                    "table": "DEFINER",
+                    "table": "my_event",
                     "column": null,
-                    "expr": "DEFINER",
+                    "expr": "my_event",
                     "alias": null,
                     "function": null,
                     "subquery": null
@@ -1506,42 +1522,23 @@
                         },
                         "options": {
                             "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                            "options": []
+                            "options": {
+                                "8": "ENABLE"
+                            }
                         },
                         "field": null,
                         "partitions": null,
-                        "unknown": [
-                            {
-                                "@type": "@21"
-                            },
-                            {
-                                "@type": "@22"
-                            },
-                            {
-                                "@type": "@23"
-                            },
-                            {
-                                "@type": "@24"
-                            },
-                            {
-                                "@type": "@25"
-                            },
-                            {
-                                "@type": "@26"
-                            },
-                            {
-                                "@type": "@27"
-                            },
-                            {
-                                "@type": "@28"
-                            }
-                        ]
+                        "unknown": []
                     }
                 ],
                 "OPTIONS": {
                     "ONLINE": 1,
                     "OFFLINE": 1,
                     "IGNORE": 2,
+                    "DEFINER": [
+                        2,
+                        "expr="
+                    ],
                     "DATABASE": 3,
                     "EVENT": 3,
                     "FUNCTION": 3,
@@ -1556,7 +1553,42 @@
                 "END_OPTIONS": [],
                 "options": {
                     "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
+                    "options": {
+                        "2": {
+                            "name": "DEFINER",
+                            "equals": true,
+                            "expr": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                                "ALLOWED_KEYWORDS": {
+                                    "AND": 1,
+                                    "AS": 1,
+                                    "BETWEEN": 1,
+                                    "CASE": 1,
+                                    "DUAL": 1,
+                                    "DIV": 1,
+                                    "IS": 1,
+                                    "MOD": 1,
+                                    "NOT": 1,
+                                    "NOT NULL": 1,
+                                    "NULL": 1,
+                                    "OR": 1,
+                                    "OVER": 1,
+                                    "REGEXP": 1,
+                                    "RLIKE": 1,
+                                    "XOR": 1
+                                },
+                                "database": null,
+                                "table": null,
+                                "column": "user",
+                                "expr": "`user`",
+                                "alias": null,
+                                "function": null,
+                                "subquery": null
+                            },
+                            "value": "`user`"
+                        },
+                        "3": "EVENT"
+                    }
                 },
                 "first": 14,
                 "last": 28
@@ -1584,9 +1616,9 @@
                         "XOR": 1
                     },
                     "database": null,
-                    "table": "DEFINER",
+                    "table": "my_event",
                     "column": null,
-                    "expr": "DEFINER",
+                    "expr": "my_event",
                     "alias": null,
                     "function": null,
                     "subquery": null
@@ -1769,45 +1801,23 @@
                         },
                         "options": {
                             "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                            "options": []
+                            "options": {
+                                "8": "ENABLE"
+                            }
                         },
                         "field": null,
                         "partitions": null,
-                        "unknown": [
-                            {
-                                "@type": "@36"
-                            },
-                            {
-                                "@type": "@37"
-                            },
-                            {
-                                "@type": "@38"
-                            },
-                            {
-                                "@type": "@39"
-                            },
-                            {
-                                "@type": "@40"
-                            },
-                            {
-                                "@type": "@41"
-                            },
-                            {
-                                "@type": "@42"
-                            },
-                            {
-                                "@type": "@43"
-                            },
-                            {
-                                "@type": "@44"
-                            }
-                        ]
+                        "unknown": []
                     }
                 ],
                 "OPTIONS": {
                     "ONLINE": 1,
                     "OFFLINE": 1,
                     "IGNORE": 2,
+                    "DEFINER": [
+                        2,
+                        "expr="
+                    ],
                     "DATABASE": 3,
                     "EVENT": 3,
                     "FUNCTION": 3,
@@ -1822,7 +1832,42 @@
                 "END_OPTIONS": [],
                 "options": {
                     "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
+                    "options": {
+                        "2": {
+                            "name": "DEFINER",
+                            "equals": true,
+                            "expr": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                                "ALLOWED_KEYWORDS": {
+                                    "AND": 1,
+                                    "AS": 1,
+                                    "BETWEEN": 1,
+                                    "CASE": 1,
+                                    "DUAL": 1,
+                                    "DIV": 1,
+                                    "IS": 1,
+                                    "MOD": 1,
+                                    "NOT": 1,
+                                    "NOT NULL": 1,
+                                    "NULL": 1,
+                                    "OR": 1,
+                                    "OVER": 1,
+                                    "REGEXP": 1,
+                                    "RLIKE": 1,
+                                    "XOR": 1
+                                },
+                                "database": null,
+                                "table": null,
+                                "column": null,
+                                "expr": "user@host",
+                                "alias": null,
+                                "function": null,
+                                "subquery": null
+                            },
+                            "value": "user@host"
+                        },
+                        "3": "EVENT"
+                    }
                 },
                 "first": 29,
                 "last": 44
@@ -1850,9 +1895,9 @@
                         "XOR": 1
                     },
                     "database": null,
-                    "table": "DEFINER",
+                    "table": "my_event",
                     "column": null,
-                    "expr": "DEFINER",
+                    "expr": "my_event",
                     "alias": null,
                     "function": null,
                     "subquery": null
@@ -2035,42 +2080,23 @@
                         },
                         "options": {
                             "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                            "options": []
+                            "options": {
+                                "8": "ENABLE"
+                            }
                         },
                         "field": null,
                         "partitions": null,
-                        "unknown": [
-                            {
-                                "@type": "@52"
-                            },
-                            {
-                                "@type": "@53"
-                            },
-                            {
-                                "@type": "@54"
-                            },
-                            {
-                                "@type": "@55"
-                            },
-                            {
-                                "@type": "@56"
-                            },
-                            {
-                                "@type": "@57"
-                            },
-                            {
-                                "@type": "@58"
-                            },
-                            {
-                                "@type": "@59"
-                            }
-                        ]
+                        "unknown": []
                     }
                 ],
                 "OPTIONS": {
                     "ONLINE": 1,
                     "OFFLINE": 1,
                     "IGNORE": 2,
+                    "DEFINER": [
+                        2,
+                        "expr="
+                    ],
                     "DATABASE": 3,
                     "EVENT": 3,
                     "FUNCTION": 3,
@@ -2085,7 +2111,42 @@
                 "END_OPTIONS": [],
                 "options": {
                     "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
+                    "options": {
+                        "2": {
+                            "name": "DEFINER",
+                            "equals": true,
+                            "expr": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                                "ALLOWED_KEYWORDS": {
+                                    "AND": 1,
+                                    "AS": 1,
+                                    "BETWEEN": 1,
+                                    "CASE": 1,
+                                    "DUAL": 1,
+                                    "DIV": 1,
+                                    "IS": 1,
+                                    "MOD": 1,
+                                    "NOT": 1,
+                                    "NOT NULL": 1,
+                                    "NULL": 1,
+                                    "OR": 1,
+                                    "OVER": 1,
+                                    "REGEXP": 1,
+                                    "RLIKE": 1,
+                                    "XOR": 1
+                                },
+                                "database": null,
+                                "table": null,
+                                "column": "user@host",
+                                "expr": "'user'@'host'",
+                                "alias": null,
+                                "function": null,
+                                "subquery": null
+                            },
+                            "value": "'user'@'host'"
+                        },
+                        "3": "EVENT"
+                    }
                 },
                 "first": 45,
                 "last": 59
@@ -2113,9 +2174,9 @@
                         "XOR": 1
                     },
                     "database": null,
-                    "table": "DEFINER",
+                    "table": "my_event",
                     "column": null,
-                    "expr": "DEFINER",
+                    "expr": "my_event",
                     "alias": null,
                     "function": null,
                     "subquery": null
@@ -2298,42 +2359,23 @@
                         },
                         "options": {
                             "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                            "options": []
+                            "options": {
+                                "8": "ENABLE"
+                            }
                         },
                         "field": null,
                         "partitions": null,
-                        "unknown": [
-                            {
-                                "@type": "@67"
-                            },
-                            {
-                                "@type": "@68"
-                            },
-                            {
-                                "@type": "@69"
-                            },
-                            {
-                                "@type": "@70"
-                            },
-                            {
-                                "@type": "@71"
-                            },
-                            {
-                                "@type": "@72"
-                            },
-                            {
-                                "@type": "@73"
-                            },
-                            {
-                                "@type": "@74"
-                            }
-                        ]
+                        "unknown": []
                     }
                 ],
                 "OPTIONS": {
                     "ONLINE": 1,
                     "OFFLINE": 1,
                     "IGNORE": 2,
+                    "DEFINER": [
+                        2,
+                        "expr="
+                    ],
                     "DATABASE": 3,
                     "EVENT": 3,
                     "FUNCTION": 3,
@@ -2348,7 +2390,42 @@
                 "END_OPTIONS": [],
                 "options": {
                     "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
+                    "options": {
+                        "2": {
+                            "name": "DEFINER",
+                            "equals": true,
+                            "expr": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                                "ALLOWED_KEYWORDS": {
+                                    "AND": 1,
+                                    "AS": 1,
+                                    "BETWEEN": 1,
+                                    "CASE": 1,
+                                    "DUAL": 1,
+                                    "DIV": 1,
+                                    "IS": 1,
+                                    "MOD": 1,
+                                    "NOT": 1,
+                                    "NOT NULL": 1,
+                                    "NULL": 1,
+                                    "OR": 1,
+                                    "OVER": 1,
+                                    "REGEXP": 1,
+                                    "RLIKE": 1,
+                                    "XOR": 1
+                                },
+                                "database": null,
+                                "table": null,
+                                "column": "user@host",
+                                "expr": "`user`@`host`",
+                                "alias": null,
+                                "function": null,
+                                "subquery": null
+                            },
+                            "value": "`user`@`host`"
+                        },
+                        "3": "EVENT"
+                    }
                 },
                 "first": 60,
                 "last": 74
@@ -2360,77 +2437,6 @@
     },
     "errors": {
         "lexer": [],
-        "parser": [
-            [
-                "Missing comma before start of a new alter operation.",
-                {
-                    "@type": "@14"
-                },
-                0
-            ],
-            [
-                "Unrecognized alter operation.",
-                {
-                    "@type": "@14"
-                },
-                0
-            ],
-            [
-                "Missing comma before start of a new alter operation.",
-                {
-                    "@type": "@29"
-                },
-                0
-            ],
-            [
-                "Unrecognized alter operation.",
-                {
-                    "@type": "@29"
-                },
-                0
-            ],
-            [
-                "Missing comma before start of a new alter operation.",
-                {
-                    "@type": "@45"
-                },
-                0
-            ],
-            [
-                "Unrecognized alter operation.",
-                {
-                    "@type": "@45"
-                },
-                0
-            ],
-            [
-                "Missing comma before start of a new alter operation.",
-                {
-                    "@type": "@60"
-                },
-                0
-            ],
-            [
-                "Unrecognized alter operation.",
-                {
-                    "@type": "@60"
-                },
-                0
-            ],
-            [
-                "Missing comma before start of a new alter operation.",
-                {
-                    "@type": "@75"
-                },
-                0
-            ],
-            [
-                "Unrecognized alter operation.",
-                {
-                    "@type": "@75"
-                },
-                0
-            ]
-        ]
+        "parser": []
     }
 }

--- a/tests/data/parser/parseAlterEventWithOtherDefiners.out
+++ b/tests/data/parser/parseAlterEventWithOtherDefiners.out
@@ -1,0 +1,2436 @@
+{
+    "query": "ALTER DEFINER = 'user' EVENT my_event ENABLE;\nALTER DEFINER = `user` EVENT my_event ENABLE;\nALTER DEFINER = user@host EVENT my_event ENABLE;\nALTER DEFINER = 'user'@'host' EVENT my_event ENABLE;\nALTER DEFINER = `user`@`host` EVENT my_event ENABLE;\n",
+    "lexer": {
+        "@type": "PhpMyAdmin\\SqlParser\\Lexer",
+        "PARSER_METHODS": [
+            "parseDelimiter",
+            "parseWhitespace",
+            "parseNumber",
+            "parseComment",
+            "parseOperator",
+            "parseBool",
+            "parseString",
+            "parseSymbol",
+            "parseKeyword",
+            "parseLabel",
+            "parseUnknown"
+        ],
+        "KEYWORD_NAME_INDICATORS": [
+            "FROM",
+            "SET",
+            "WHERE"
+        ],
+        "OPERATOR_NAME_INDICATORS": [
+            ",",
+            "."
+        ],
+        "str": "ALTER DEFINER = 'user' EVENT my_event ENABLE;\nALTER DEFINER = `user` EVENT my_event ENABLE;\nALTER DEFINER = user@host EVENT my_event ENABLE;\nALTER DEFINER = 'user'@'host' EVENT my_event ENABLE;\nALTER DEFINER = `user`@`host` EVENT my_event ENABLE;\n",
+        "len": 247,
+        "last": 247,
+        "list": {
+            "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "tokens": [
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "ALTER",
+                    "value": "ALTER",
+                    "keyword": "ALTER",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 0
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 5
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "DEFINER",
+                    "value": "DEFINER",
+                    "keyword": "DEFINER",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 6
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 13
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "=",
+                    "value": "=",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 2,
+                    "position": 14
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 15
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "'user'",
+                    "value": "user",
+                    "keyword": null,
+                    "type": 7,
+                    "flags": 1,
+                    "position": 16
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 22
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "EVENT",
+                    "value": "EVENT",
+                    "keyword": "EVENT",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 23
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 28
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "my_event",
+                    "value": "my_event",
+                    "keyword": null,
+                    "type": 0,
+                    "flags": 0,
+                    "position": 29
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 37
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "ENABLE",
+                    "value": "ENABLE",
+                    "keyword": "ENABLE",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 38
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ";",
+                    "value": ";",
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": 44
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 45
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "ALTER",
+                    "value": "ALTER",
+                    "keyword": "ALTER",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 46
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 51
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "DEFINER",
+                    "value": "DEFINER",
+                    "keyword": "DEFINER",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 52
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 59
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "=",
+                    "value": "=",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 2,
+                    "position": 60
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 61
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "`user`",
+                    "value": "user",
+                    "keyword": null,
+                    "type": 8,
+                    "flags": 2,
+                    "position": 62
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 68
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "EVENT",
+                    "value": "EVENT",
+                    "keyword": "EVENT",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 69
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 74
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "my_event",
+                    "value": "my_event",
+                    "keyword": null,
+                    "type": 0,
+                    "flags": 0,
+                    "position": 75
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 83
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "ENABLE",
+                    "value": "ENABLE",
+                    "keyword": "ENABLE",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 84
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ";",
+                    "value": ";",
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": 90
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 91
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "ALTER",
+                    "value": "ALTER",
+                    "keyword": "ALTER",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 92
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 97
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "DEFINER",
+                    "value": "DEFINER",
+                    "keyword": "DEFINER",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 98
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 105
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "=",
+                    "value": "=",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 2,
+                    "position": 106
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 107
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "user",
+                    "value": "user",
+                    "keyword": "USER",
+                    "type": 1,
+                    "flags": 33,
+                    "position": 108
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "@host",
+                    "value": "host",
+                    "keyword": null,
+                    "type": 8,
+                    "flags": 1,
+                    "position": 112
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 117
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "EVENT",
+                    "value": "EVENT",
+                    "keyword": "EVENT",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 118
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 123
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "my_event",
+                    "value": "my_event",
+                    "keyword": null,
+                    "type": 0,
+                    "flags": 0,
+                    "position": 124
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 132
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "ENABLE",
+                    "value": "ENABLE",
+                    "keyword": "ENABLE",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 133
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ";",
+                    "value": ";",
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": 139
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 140
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "ALTER",
+                    "value": "ALTER",
+                    "keyword": "ALTER",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 141
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 146
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "DEFINER",
+                    "value": "DEFINER",
+                    "keyword": "DEFINER",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 147
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 154
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "=",
+                    "value": "=",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 2,
+                    "position": 155
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 156
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "'user'@'host'",
+                    "value": "user@host",
+                    "keyword": null,
+                    "type": 8,
+                    "flags": 4,
+                    "position": 157
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 170
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "EVENT",
+                    "value": "EVENT",
+                    "keyword": "EVENT",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 171
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 176
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "my_event",
+                    "value": "my_event",
+                    "keyword": null,
+                    "type": 0,
+                    "flags": 0,
+                    "position": 177
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 185
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "ENABLE",
+                    "value": "ENABLE",
+                    "keyword": "ENABLE",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 186
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ";",
+                    "value": ";",
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": 192
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 193
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "ALTER",
+                    "value": "ALTER",
+                    "keyword": "ALTER",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 194
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 199
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "DEFINER",
+                    "value": "DEFINER",
+                    "keyword": "DEFINER",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 200
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 207
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "=",
+                    "value": "=",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 2,
+                    "position": 208
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 209
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "`user`@`host`",
+                    "value": "user@host",
+                    "keyword": null,
+                    "type": 8,
+                    "flags": 4,
+                    "position": 210
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 223
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "EVENT",
+                    "value": "EVENT",
+                    "keyword": "EVENT",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 224
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 229
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "my_event",
+                    "value": "my_event",
+                    "keyword": null,
+                    "type": 0,
+                    "flags": 0,
+                    "position": 230
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 238
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "ENABLE",
+                    "value": "ENABLE",
+                    "keyword": "ENABLE",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 239
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ";",
+                    "value": ";",
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": 245
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 246
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": null,
+                    "value": null,
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": null
+                }
+            ],
+            "count": 77,
+            "idx": 77
+        },
+        "DEFAULT_DELIMITER": ";",
+        "delimiter": ";",
+        "delimiterLen": 1,
+        "strict": false,
+        "errors": []
+    },
+    "parser": {
+        "@type": "PhpMyAdmin\\SqlParser\\Parser",
+        "STATEMENT_PARSERS": {
+            "DESCRIBE": "PhpMyAdmin\\SqlParser\\Statements\\ExplainStatement",
+            "DESC": "PhpMyAdmin\\SqlParser\\Statements\\ExplainStatement",
+            "EXPLAIN": "PhpMyAdmin\\SqlParser\\Statements\\ExplainStatement",
+            "FLUSH": "",
+            "GRANT": "",
+            "HELP": "",
+            "SET PASSWORD": "",
+            "STATUS": "",
+            "USE": "",
+            "ANALYZE": "PhpMyAdmin\\SqlParser\\Statements\\AnalyzeStatement",
+            "BACKUP": "PhpMyAdmin\\SqlParser\\Statements\\BackupStatement",
+            "CHECK": "PhpMyAdmin\\SqlParser\\Statements\\CheckStatement",
+            "CHECKSUM": "PhpMyAdmin\\SqlParser\\Statements\\ChecksumStatement",
+            "OPTIMIZE": "PhpMyAdmin\\SqlParser\\Statements\\OptimizeStatement",
+            "REPAIR": "PhpMyAdmin\\SqlParser\\Statements\\RepairStatement",
+            "RESTORE": "PhpMyAdmin\\SqlParser\\Statements\\RestoreStatement",
+            "SET": "PhpMyAdmin\\SqlParser\\Statements\\SetStatement",
+            "SHOW": "PhpMyAdmin\\SqlParser\\Statements\\ShowStatement",
+            "ALTER": "PhpMyAdmin\\SqlParser\\Statements\\AlterStatement",
+            "CREATE": "PhpMyAdmin\\SqlParser\\Statements\\CreateStatement",
+            "DROP": "PhpMyAdmin\\SqlParser\\Statements\\DropStatement",
+            "RENAME": "PhpMyAdmin\\SqlParser\\Statements\\RenameStatement",
+            "TRUNCATE": "PhpMyAdmin\\SqlParser\\Statements\\TruncateStatement",
+            "CALL": "PhpMyAdmin\\SqlParser\\Statements\\CallStatement",
+            "DELETE": "PhpMyAdmin\\SqlParser\\Statements\\DeleteStatement",
+            "DO": "",
+            "HANDLER": "",
+            "INSERT": "PhpMyAdmin\\SqlParser\\Statements\\InsertStatement",
+            "LOAD DATA": "PhpMyAdmin\\SqlParser\\Statements\\LoadStatement",
+            "REPLACE": "PhpMyAdmin\\SqlParser\\Statements\\ReplaceStatement",
+            "SELECT": "PhpMyAdmin\\SqlParser\\Statements\\SelectStatement",
+            "UPDATE": "PhpMyAdmin\\SqlParser\\Statements\\UpdateStatement",
+            "WITH": "PhpMyAdmin\\SqlParser\\Statements\\WithStatement",
+            "DEALLOCATE": "",
+            "EXECUTE": "",
+            "PREPARE": "",
+            "BEGIN": "PhpMyAdmin\\SqlParser\\Statements\\TransactionStatement",
+            "COMMIT": "PhpMyAdmin\\SqlParser\\Statements\\TransactionStatement",
+            "ROLLBACK": "PhpMyAdmin\\SqlParser\\Statements\\TransactionStatement",
+            "START TRANSACTION": "PhpMyAdmin\\SqlParser\\Statements\\TransactionStatement",
+            "PURGE": "PhpMyAdmin\\SqlParser\\Statements\\PurgeStatement",
+            "LOCK": "PhpMyAdmin\\SqlParser\\Statements\\LockStatement",
+            "UNLOCK": "PhpMyAdmin\\SqlParser\\Statements\\LockStatement"
+        },
+        "KEYWORD_PARSERS": {
+            "PARTITION BY": [],
+            "SUBPARTITION BY": [],
+            "_OPTIONS": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                "field": "options"
+            },
+            "_END_OPTIONS": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                "field": "end_options"
+            },
+            "INTERSECT": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\UnionKeyword",
+                "field": "union"
+            },
+            "EXCEPT": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\UnionKeyword",
+                "field": "union"
+            },
+            "UNION": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\UnionKeyword",
+                "field": "union"
+            },
+            "UNION ALL": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\UnionKeyword",
+                "field": "union"
+            },
+            "UNION DISTINCT": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\UnionKeyword",
+                "field": "union"
+            },
+            "ALTER": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                "field": "table",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "ANALYZE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "BACKUP": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "CALL": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\FunctionCall",
+                "field": "call"
+            },
+            "CHECK": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "CHECKSUM": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "CROSS JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "DROP": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "fields",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "FORCE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\IndexHint",
+                "field": "index_hints"
+            },
+            "FROM": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "from",
+                "options": {
+                    "field": "table"
+                }
+            },
+            "GROUP BY": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\GroupKeyword",
+                "field": "group"
+            },
+            "HAVING": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Condition",
+                "field": "having"
+            },
+            "IGNORE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\IndexHint",
+                "field": "index_hints"
+            },
+            "INTO": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\IntoKeyword",
+                "field": "into"
+            },
+            "JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "LEFT JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "LEFT OUTER JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "ON": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                "field": "table",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "RIGHT JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "RIGHT OUTER JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "INNER JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "FULL JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "FULL OUTER JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "NATURAL JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "NATURAL LEFT JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "NATURAL RIGHT JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "NATURAL LEFT OUTER JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "NATURAL RIGHT OUTER JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "STRAIGHT_JOIN": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
+                "field": "join"
+            },
+            "LIMIT": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Limit",
+                "field": "limit"
+            },
+            "OPTIMIZE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "ORDER BY": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\OrderKeyword",
+                "field": "order"
+            },
+            "PARTITION": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ArrayObj",
+                "field": "partition"
+            },
+            "PROCEDURE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\FunctionCall",
+                "field": "procedure"
+            },
+            "RENAME": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\RenameOperation",
+                "field": "renames"
+            },
+            "REPAIR": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "RESTORE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "SET": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\SetOperation",
+                "field": "set"
+            },
+            "SELECT": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "expr"
+            },
+            "TRUNCATE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                "field": "table",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "UPDATE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\ExpressionArray",
+                "field": "tables",
+                "options": {
+                    "parseField": "table"
+                }
+            },
+            "USE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\IndexHint",
+                "field": "index_hints"
+            },
+            "VALUE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Array2d",
+                "field": "values"
+            },
+            "VALUES": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Array2d",
+                "field": "values"
+            },
+            "WHERE": {
+                "class": "PhpMyAdmin\\SqlParser\\Components\\Condition",
+                "field": "where"
+            }
+        },
+        "list": {
+            "@type": "@1"
+        },
+        "statements": [
+            {
+                "@type": "PhpMyAdmin\\SqlParser\\Statements\\AlterStatement",
+                "table": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                    "ALLOWED_KEYWORDS": {
+                        "AND": 1,
+                        "AS": 1,
+                        "BETWEEN": 1,
+                        "CASE": 1,
+                        "DUAL": 1,
+                        "DIV": 1,
+                        "IS": 1,
+                        "MOD": 1,
+                        "NOT": 1,
+                        "NOT NULL": 1,
+                        "NULL": 1,
+                        "OR": 1,
+                        "OVER": 1,
+                        "REGEXP": 1,
+                        "RLIKE": 1,
+                        "XOR": 1
+                    },
+                    "database": null,
+                    "table": "DEFINER",
+                    "column": null,
+                    "expr": "DEFINER",
+                    "alias": null,
+                    "function": null,
+                    "subquery": null
+                },
+                "altered": [
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\AlterOperation",
+                        "DB_OPTIONS": {
+                            "CHARACTER SET": [
+                                1,
+                                "var"
+                            ],
+                            "CHARSET": [
+                                1,
+                                "var"
+                            ],
+                            "DEFAULT CHARACTER SET": [
+                                1,
+                                "var"
+                            ],
+                            "DEFAULT CHARSET": [
+                                1,
+                                "var"
+                            ],
+                            "UPGRADE": [
+                                1,
+                                "var"
+                            ],
+                            "COLLATE": [
+                                2,
+                                "var"
+                            ],
+                            "DEFAULT COLLATE": [
+                                2,
+                                "var"
+                            ]
+                        },
+                        "TABLE_OPTIONS": {
+                            "ENGINE": [
+                                1,
+                                "var="
+                            ],
+                            "AUTO_INCREMENT": [
+                                1,
+                                "var="
+                            ],
+                            "AVG_ROW_LENGTH": [
+                                1,
+                                "var"
+                            ],
+                            "MAX_ROWS": [
+                                1,
+                                "var"
+                            ],
+                            "ROW_FORMAT": [
+                                1,
+                                "var"
+                            ],
+                            "COMMENT": [
+                                1,
+                                "var"
+                            ],
+                            "ADD": 1,
+                            "ALTER": 1,
+                            "ANALYZE": 1,
+                            "CHANGE": 1,
+                            "CHARSET": 1,
+                            "CHECK": 1,
+                            "COALESCE": 1,
+                            "CONVERT": 1,
+                            "DEFAULT CHARSET": 1,
+                            "DISABLE": 1,
+                            "DISCARD": 1,
+                            "DROP": 1,
+                            "ENABLE": 1,
+                            "IMPORT": 1,
+                            "MODIFY": 1,
+                            "OPTIMIZE": 1,
+                            "ORDER": 1,
+                            "REBUILD": 1,
+                            "REMOVE": 1,
+                            "RENAME": 1,
+                            "REORGANIZE": 1,
+                            "REPAIR": 1,
+                            "UPGRADE": 1,
+                            "COLUMN": 2,
+                            "CONSTRAINT": 2,
+                            "DEFAULT": 2,
+                            "BY": 2,
+                            "FOREIGN": 2,
+                            "FULLTEXT": 2,
+                            "KEY": 2,
+                            "KEYS": 2,
+                            "PARTITION": 2,
+                            "PARTITION BY": 2,
+                            "PARTITIONING": 2,
+                            "PRIMARY KEY": 2,
+                            "SPATIAL": 2,
+                            "TABLESPACE": 2,
+                            "INDEX": [
+                                2,
+                                "var"
+                            ],
+                            "CHARACTER SET": 3,
+                            "TO": [
+                                3,
+                                "var"
+                            ]
+                        },
+                        "USER_OPTIONS": {
+                            "ATTRIBUTE": [
+                                1,
+                                "var"
+                            ],
+                            "COMMENT": [
+                                1,
+                                "var"
+                            ],
+                            "REQUIRE": [
+                                1,
+                                "var"
+                            ],
+                            "BY": [
+                                2,
+                                "expr"
+                            ],
+                            "PASSWORD": [
+                                2,
+                                "var"
+                            ],
+                            "WITH": [
+                                2,
+                                "var"
+                            ],
+                            "ACCOUNT": 1,
+                            "DEFAULT": 1,
+                            "LOCK": 2,
+                            "UNLOCK": 2,
+                            "IDENTIFIED": 3
+                        },
+                        "VIEW_OPTIONS": {
+                            "AS": 1
+                        },
+                        "EVENT_OPTIONS": {
+                            "ON SCHEDULE": 1,
+                            "EVERY": [
+                                2,
+                                "expr"
+                            ],
+                            "AT": [
+                                2,
+                                "expr"
+                            ],
+                            "STARTS": [
+                                3,
+                                "expr"
+                            ],
+                            "ENDS": [
+                                4,
+                                "expr"
+                            ],
+                            "ON COMPLETION PRESERVE": 5,
+                            "ON COMPLETION NOT PRESERVE": 5,
+                            "RENAME": 6,
+                            "TO": [
+                                7,
+                                "expr",
+                                {
+                                    "parseField": "table"
+                                }
+                            ],
+                            "ENABLE": 8,
+                            "DISABLE": 8,
+                            "DISABLE ON SLAVE": 8,
+                            "COMMENT": [
+                                9,
+                                "var"
+                            ],
+                            "DO": 10
+                        },
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        },
+                        "field": null,
+                        "partitions": null,
+                        "unknown": [
+                            {
+                                "@type": "@6"
+                            },
+                            {
+                                "@type": "@7"
+                            },
+                            {
+                                "@type": "@8"
+                            },
+                            {
+                                "@type": "@9"
+                            },
+                            {
+                                "@type": "@10"
+                            },
+                            {
+                                "@type": "@11"
+                            },
+                            {
+                                "@type": "@12"
+                            },
+                            {
+                                "@type": "@13"
+                            }
+                        ]
+                    }
+                ],
+                "OPTIONS": {
+                    "ONLINE": 1,
+                    "OFFLINE": 1,
+                    "IGNORE": 2,
+                    "DATABASE": 3,
+                    "EVENT": 3,
+                    "FUNCTION": 3,
+                    "PROCEDURE": 3,
+                    "SERVER": 3,
+                    "TABLE": 3,
+                    "TABLESPACE": 3,
+                    "USER": 3,
+                    "VIEW": 3
+                },
+                "CLAUSES": [],
+                "END_OPTIONS": [],
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 0,
+                "last": 13
+            },
+            {
+                "@type": "PhpMyAdmin\\SqlParser\\Statements\\AlterStatement",
+                "table": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                    "ALLOWED_KEYWORDS": {
+                        "AND": 1,
+                        "AS": 1,
+                        "BETWEEN": 1,
+                        "CASE": 1,
+                        "DUAL": 1,
+                        "DIV": 1,
+                        "IS": 1,
+                        "MOD": 1,
+                        "NOT": 1,
+                        "NOT NULL": 1,
+                        "NULL": 1,
+                        "OR": 1,
+                        "OVER": 1,
+                        "REGEXP": 1,
+                        "RLIKE": 1,
+                        "XOR": 1
+                    },
+                    "database": null,
+                    "table": "DEFINER",
+                    "column": null,
+                    "expr": "DEFINER",
+                    "alias": null,
+                    "function": null,
+                    "subquery": null
+                },
+                "altered": [
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\AlterOperation",
+                        "DB_OPTIONS": {
+                            "CHARACTER SET": [
+                                1,
+                                "var"
+                            ],
+                            "CHARSET": [
+                                1,
+                                "var"
+                            ],
+                            "DEFAULT CHARACTER SET": [
+                                1,
+                                "var"
+                            ],
+                            "DEFAULT CHARSET": [
+                                1,
+                                "var"
+                            ],
+                            "UPGRADE": [
+                                1,
+                                "var"
+                            ],
+                            "COLLATE": [
+                                2,
+                                "var"
+                            ],
+                            "DEFAULT COLLATE": [
+                                2,
+                                "var"
+                            ]
+                        },
+                        "TABLE_OPTIONS": {
+                            "ENGINE": [
+                                1,
+                                "var="
+                            ],
+                            "AUTO_INCREMENT": [
+                                1,
+                                "var="
+                            ],
+                            "AVG_ROW_LENGTH": [
+                                1,
+                                "var"
+                            ],
+                            "MAX_ROWS": [
+                                1,
+                                "var"
+                            ],
+                            "ROW_FORMAT": [
+                                1,
+                                "var"
+                            ],
+                            "COMMENT": [
+                                1,
+                                "var"
+                            ],
+                            "ADD": 1,
+                            "ALTER": 1,
+                            "ANALYZE": 1,
+                            "CHANGE": 1,
+                            "CHARSET": 1,
+                            "CHECK": 1,
+                            "COALESCE": 1,
+                            "CONVERT": 1,
+                            "DEFAULT CHARSET": 1,
+                            "DISABLE": 1,
+                            "DISCARD": 1,
+                            "DROP": 1,
+                            "ENABLE": 1,
+                            "IMPORT": 1,
+                            "MODIFY": 1,
+                            "OPTIMIZE": 1,
+                            "ORDER": 1,
+                            "REBUILD": 1,
+                            "REMOVE": 1,
+                            "RENAME": 1,
+                            "REORGANIZE": 1,
+                            "REPAIR": 1,
+                            "UPGRADE": 1,
+                            "COLUMN": 2,
+                            "CONSTRAINT": 2,
+                            "DEFAULT": 2,
+                            "BY": 2,
+                            "FOREIGN": 2,
+                            "FULLTEXT": 2,
+                            "KEY": 2,
+                            "KEYS": 2,
+                            "PARTITION": 2,
+                            "PARTITION BY": 2,
+                            "PARTITIONING": 2,
+                            "PRIMARY KEY": 2,
+                            "SPATIAL": 2,
+                            "TABLESPACE": 2,
+                            "INDEX": [
+                                2,
+                                "var"
+                            ],
+                            "CHARACTER SET": 3,
+                            "TO": [
+                                3,
+                                "var"
+                            ]
+                        },
+                        "USER_OPTIONS": {
+                            "ATTRIBUTE": [
+                                1,
+                                "var"
+                            ],
+                            "COMMENT": [
+                                1,
+                                "var"
+                            ],
+                            "REQUIRE": [
+                                1,
+                                "var"
+                            ],
+                            "BY": [
+                                2,
+                                "expr"
+                            ],
+                            "PASSWORD": [
+                                2,
+                                "var"
+                            ],
+                            "WITH": [
+                                2,
+                                "var"
+                            ],
+                            "ACCOUNT": 1,
+                            "DEFAULT": 1,
+                            "LOCK": 2,
+                            "UNLOCK": 2,
+                            "IDENTIFIED": 3
+                        },
+                        "VIEW_OPTIONS": {
+                            "AS": 1
+                        },
+                        "EVENT_OPTIONS": {
+                            "ON SCHEDULE": 1,
+                            "EVERY": [
+                                2,
+                                "expr"
+                            ],
+                            "AT": [
+                                2,
+                                "expr"
+                            ],
+                            "STARTS": [
+                                3,
+                                "expr"
+                            ],
+                            "ENDS": [
+                                4,
+                                "expr"
+                            ],
+                            "ON COMPLETION PRESERVE": 5,
+                            "ON COMPLETION NOT PRESERVE": 5,
+                            "RENAME": 6,
+                            "TO": [
+                                7,
+                                "expr",
+                                {
+                                    "parseField": "table"
+                                }
+                            ],
+                            "ENABLE": 8,
+                            "DISABLE": 8,
+                            "DISABLE ON SLAVE": 8,
+                            "COMMENT": [
+                                9,
+                                "var"
+                            ],
+                            "DO": 10
+                        },
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        },
+                        "field": null,
+                        "partitions": null,
+                        "unknown": [
+                            {
+                                "@type": "@21"
+                            },
+                            {
+                                "@type": "@22"
+                            },
+                            {
+                                "@type": "@23"
+                            },
+                            {
+                                "@type": "@24"
+                            },
+                            {
+                                "@type": "@25"
+                            },
+                            {
+                                "@type": "@26"
+                            },
+                            {
+                                "@type": "@27"
+                            },
+                            {
+                                "@type": "@28"
+                            }
+                        ]
+                    }
+                ],
+                "OPTIONS": {
+                    "ONLINE": 1,
+                    "OFFLINE": 1,
+                    "IGNORE": 2,
+                    "DATABASE": 3,
+                    "EVENT": 3,
+                    "FUNCTION": 3,
+                    "PROCEDURE": 3,
+                    "SERVER": 3,
+                    "TABLE": 3,
+                    "TABLESPACE": 3,
+                    "USER": 3,
+                    "VIEW": 3
+                },
+                "CLAUSES": [],
+                "END_OPTIONS": [],
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 14,
+                "last": 28
+            },
+            {
+                "@type": "PhpMyAdmin\\SqlParser\\Statements\\AlterStatement",
+                "table": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                    "ALLOWED_KEYWORDS": {
+                        "AND": 1,
+                        "AS": 1,
+                        "BETWEEN": 1,
+                        "CASE": 1,
+                        "DUAL": 1,
+                        "DIV": 1,
+                        "IS": 1,
+                        "MOD": 1,
+                        "NOT": 1,
+                        "NOT NULL": 1,
+                        "NULL": 1,
+                        "OR": 1,
+                        "OVER": 1,
+                        "REGEXP": 1,
+                        "RLIKE": 1,
+                        "XOR": 1
+                    },
+                    "database": null,
+                    "table": "DEFINER",
+                    "column": null,
+                    "expr": "DEFINER",
+                    "alias": null,
+                    "function": null,
+                    "subquery": null
+                },
+                "altered": [
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\AlterOperation",
+                        "DB_OPTIONS": {
+                            "CHARACTER SET": [
+                                1,
+                                "var"
+                            ],
+                            "CHARSET": [
+                                1,
+                                "var"
+                            ],
+                            "DEFAULT CHARACTER SET": [
+                                1,
+                                "var"
+                            ],
+                            "DEFAULT CHARSET": [
+                                1,
+                                "var"
+                            ],
+                            "UPGRADE": [
+                                1,
+                                "var"
+                            ],
+                            "COLLATE": [
+                                2,
+                                "var"
+                            ],
+                            "DEFAULT COLLATE": [
+                                2,
+                                "var"
+                            ]
+                        },
+                        "TABLE_OPTIONS": {
+                            "ENGINE": [
+                                1,
+                                "var="
+                            ],
+                            "AUTO_INCREMENT": [
+                                1,
+                                "var="
+                            ],
+                            "AVG_ROW_LENGTH": [
+                                1,
+                                "var"
+                            ],
+                            "MAX_ROWS": [
+                                1,
+                                "var"
+                            ],
+                            "ROW_FORMAT": [
+                                1,
+                                "var"
+                            ],
+                            "COMMENT": [
+                                1,
+                                "var"
+                            ],
+                            "ADD": 1,
+                            "ALTER": 1,
+                            "ANALYZE": 1,
+                            "CHANGE": 1,
+                            "CHARSET": 1,
+                            "CHECK": 1,
+                            "COALESCE": 1,
+                            "CONVERT": 1,
+                            "DEFAULT CHARSET": 1,
+                            "DISABLE": 1,
+                            "DISCARD": 1,
+                            "DROP": 1,
+                            "ENABLE": 1,
+                            "IMPORT": 1,
+                            "MODIFY": 1,
+                            "OPTIMIZE": 1,
+                            "ORDER": 1,
+                            "REBUILD": 1,
+                            "REMOVE": 1,
+                            "RENAME": 1,
+                            "REORGANIZE": 1,
+                            "REPAIR": 1,
+                            "UPGRADE": 1,
+                            "COLUMN": 2,
+                            "CONSTRAINT": 2,
+                            "DEFAULT": 2,
+                            "BY": 2,
+                            "FOREIGN": 2,
+                            "FULLTEXT": 2,
+                            "KEY": 2,
+                            "KEYS": 2,
+                            "PARTITION": 2,
+                            "PARTITION BY": 2,
+                            "PARTITIONING": 2,
+                            "PRIMARY KEY": 2,
+                            "SPATIAL": 2,
+                            "TABLESPACE": 2,
+                            "INDEX": [
+                                2,
+                                "var"
+                            ],
+                            "CHARACTER SET": 3,
+                            "TO": [
+                                3,
+                                "var"
+                            ]
+                        },
+                        "USER_OPTIONS": {
+                            "ATTRIBUTE": [
+                                1,
+                                "var"
+                            ],
+                            "COMMENT": [
+                                1,
+                                "var"
+                            ],
+                            "REQUIRE": [
+                                1,
+                                "var"
+                            ],
+                            "BY": [
+                                2,
+                                "expr"
+                            ],
+                            "PASSWORD": [
+                                2,
+                                "var"
+                            ],
+                            "WITH": [
+                                2,
+                                "var"
+                            ],
+                            "ACCOUNT": 1,
+                            "DEFAULT": 1,
+                            "LOCK": 2,
+                            "UNLOCK": 2,
+                            "IDENTIFIED": 3
+                        },
+                        "VIEW_OPTIONS": {
+                            "AS": 1
+                        },
+                        "EVENT_OPTIONS": {
+                            "ON SCHEDULE": 1,
+                            "EVERY": [
+                                2,
+                                "expr"
+                            ],
+                            "AT": [
+                                2,
+                                "expr"
+                            ],
+                            "STARTS": [
+                                3,
+                                "expr"
+                            ],
+                            "ENDS": [
+                                4,
+                                "expr"
+                            ],
+                            "ON COMPLETION PRESERVE": 5,
+                            "ON COMPLETION NOT PRESERVE": 5,
+                            "RENAME": 6,
+                            "TO": [
+                                7,
+                                "expr",
+                                {
+                                    "parseField": "table"
+                                }
+                            ],
+                            "ENABLE": 8,
+                            "DISABLE": 8,
+                            "DISABLE ON SLAVE": 8,
+                            "COMMENT": [
+                                9,
+                                "var"
+                            ],
+                            "DO": 10
+                        },
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        },
+                        "field": null,
+                        "partitions": null,
+                        "unknown": [
+                            {
+                                "@type": "@36"
+                            },
+                            {
+                                "@type": "@37"
+                            },
+                            {
+                                "@type": "@38"
+                            },
+                            {
+                                "@type": "@39"
+                            },
+                            {
+                                "@type": "@40"
+                            },
+                            {
+                                "@type": "@41"
+                            },
+                            {
+                                "@type": "@42"
+                            },
+                            {
+                                "@type": "@43"
+                            },
+                            {
+                                "@type": "@44"
+                            }
+                        ]
+                    }
+                ],
+                "OPTIONS": {
+                    "ONLINE": 1,
+                    "OFFLINE": 1,
+                    "IGNORE": 2,
+                    "DATABASE": 3,
+                    "EVENT": 3,
+                    "FUNCTION": 3,
+                    "PROCEDURE": 3,
+                    "SERVER": 3,
+                    "TABLE": 3,
+                    "TABLESPACE": 3,
+                    "USER": 3,
+                    "VIEW": 3
+                },
+                "CLAUSES": [],
+                "END_OPTIONS": [],
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 29,
+                "last": 44
+            },
+            {
+                "@type": "PhpMyAdmin\\SqlParser\\Statements\\AlterStatement",
+                "table": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                    "ALLOWED_KEYWORDS": {
+                        "AND": 1,
+                        "AS": 1,
+                        "BETWEEN": 1,
+                        "CASE": 1,
+                        "DUAL": 1,
+                        "DIV": 1,
+                        "IS": 1,
+                        "MOD": 1,
+                        "NOT": 1,
+                        "NOT NULL": 1,
+                        "NULL": 1,
+                        "OR": 1,
+                        "OVER": 1,
+                        "REGEXP": 1,
+                        "RLIKE": 1,
+                        "XOR": 1
+                    },
+                    "database": null,
+                    "table": "DEFINER",
+                    "column": null,
+                    "expr": "DEFINER",
+                    "alias": null,
+                    "function": null,
+                    "subquery": null
+                },
+                "altered": [
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\AlterOperation",
+                        "DB_OPTIONS": {
+                            "CHARACTER SET": [
+                                1,
+                                "var"
+                            ],
+                            "CHARSET": [
+                                1,
+                                "var"
+                            ],
+                            "DEFAULT CHARACTER SET": [
+                                1,
+                                "var"
+                            ],
+                            "DEFAULT CHARSET": [
+                                1,
+                                "var"
+                            ],
+                            "UPGRADE": [
+                                1,
+                                "var"
+                            ],
+                            "COLLATE": [
+                                2,
+                                "var"
+                            ],
+                            "DEFAULT COLLATE": [
+                                2,
+                                "var"
+                            ]
+                        },
+                        "TABLE_OPTIONS": {
+                            "ENGINE": [
+                                1,
+                                "var="
+                            ],
+                            "AUTO_INCREMENT": [
+                                1,
+                                "var="
+                            ],
+                            "AVG_ROW_LENGTH": [
+                                1,
+                                "var"
+                            ],
+                            "MAX_ROWS": [
+                                1,
+                                "var"
+                            ],
+                            "ROW_FORMAT": [
+                                1,
+                                "var"
+                            ],
+                            "COMMENT": [
+                                1,
+                                "var"
+                            ],
+                            "ADD": 1,
+                            "ALTER": 1,
+                            "ANALYZE": 1,
+                            "CHANGE": 1,
+                            "CHARSET": 1,
+                            "CHECK": 1,
+                            "COALESCE": 1,
+                            "CONVERT": 1,
+                            "DEFAULT CHARSET": 1,
+                            "DISABLE": 1,
+                            "DISCARD": 1,
+                            "DROP": 1,
+                            "ENABLE": 1,
+                            "IMPORT": 1,
+                            "MODIFY": 1,
+                            "OPTIMIZE": 1,
+                            "ORDER": 1,
+                            "REBUILD": 1,
+                            "REMOVE": 1,
+                            "RENAME": 1,
+                            "REORGANIZE": 1,
+                            "REPAIR": 1,
+                            "UPGRADE": 1,
+                            "COLUMN": 2,
+                            "CONSTRAINT": 2,
+                            "DEFAULT": 2,
+                            "BY": 2,
+                            "FOREIGN": 2,
+                            "FULLTEXT": 2,
+                            "KEY": 2,
+                            "KEYS": 2,
+                            "PARTITION": 2,
+                            "PARTITION BY": 2,
+                            "PARTITIONING": 2,
+                            "PRIMARY KEY": 2,
+                            "SPATIAL": 2,
+                            "TABLESPACE": 2,
+                            "INDEX": [
+                                2,
+                                "var"
+                            ],
+                            "CHARACTER SET": 3,
+                            "TO": [
+                                3,
+                                "var"
+                            ]
+                        },
+                        "USER_OPTIONS": {
+                            "ATTRIBUTE": [
+                                1,
+                                "var"
+                            ],
+                            "COMMENT": [
+                                1,
+                                "var"
+                            ],
+                            "REQUIRE": [
+                                1,
+                                "var"
+                            ],
+                            "BY": [
+                                2,
+                                "expr"
+                            ],
+                            "PASSWORD": [
+                                2,
+                                "var"
+                            ],
+                            "WITH": [
+                                2,
+                                "var"
+                            ],
+                            "ACCOUNT": 1,
+                            "DEFAULT": 1,
+                            "LOCK": 2,
+                            "UNLOCK": 2,
+                            "IDENTIFIED": 3
+                        },
+                        "VIEW_OPTIONS": {
+                            "AS": 1
+                        },
+                        "EVENT_OPTIONS": {
+                            "ON SCHEDULE": 1,
+                            "EVERY": [
+                                2,
+                                "expr"
+                            ],
+                            "AT": [
+                                2,
+                                "expr"
+                            ],
+                            "STARTS": [
+                                3,
+                                "expr"
+                            ],
+                            "ENDS": [
+                                4,
+                                "expr"
+                            ],
+                            "ON COMPLETION PRESERVE": 5,
+                            "ON COMPLETION NOT PRESERVE": 5,
+                            "RENAME": 6,
+                            "TO": [
+                                7,
+                                "expr",
+                                {
+                                    "parseField": "table"
+                                }
+                            ],
+                            "ENABLE": 8,
+                            "DISABLE": 8,
+                            "DISABLE ON SLAVE": 8,
+                            "COMMENT": [
+                                9,
+                                "var"
+                            ],
+                            "DO": 10
+                        },
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        },
+                        "field": null,
+                        "partitions": null,
+                        "unknown": [
+                            {
+                                "@type": "@52"
+                            },
+                            {
+                                "@type": "@53"
+                            },
+                            {
+                                "@type": "@54"
+                            },
+                            {
+                                "@type": "@55"
+                            },
+                            {
+                                "@type": "@56"
+                            },
+                            {
+                                "@type": "@57"
+                            },
+                            {
+                                "@type": "@58"
+                            },
+                            {
+                                "@type": "@59"
+                            }
+                        ]
+                    }
+                ],
+                "OPTIONS": {
+                    "ONLINE": 1,
+                    "OFFLINE": 1,
+                    "IGNORE": 2,
+                    "DATABASE": 3,
+                    "EVENT": 3,
+                    "FUNCTION": 3,
+                    "PROCEDURE": 3,
+                    "SERVER": 3,
+                    "TABLE": 3,
+                    "TABLESPACE": 3,
+                    "USER": 3,
+                    "VIEW": 3
+                },
+                "CLAUSES": [],
+                "END_OPTIONS": [],
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 45,
+                "last": 59
+            },
+            {
+                "@type": "PhpMyAdmin\\SqlParser\\Statements\\AlterStatement",
+                "table": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                    "ALLOWED_KEYWORDS": {
+                        "AND": 1,
+                        "AS": 1,
+                        "BETWEEN": 1,
+                        "CASE": 1,
+                        "DUAL": 1,
+                        "DIV": 1,
+                        "IS": 1,
+                        "MOD": 1,
+                        "NOT": 1,
+                        "NOT NULL": 1,
+                        "NULL": 1,
+                        "OR": 1,
+                        "OVER": 1,
+                        "REGEXP": 1,
+                        "RLIKE": 1,
+                        "XOR": 1
+                    },
+                    "database": null,
+                    "table": "DEFINER",
+                    "column": null,
+                    "expr": "DEFINER",
+                    "alias": null,
+                    "function": null,
+                    "subquery": null
+                },
+                "altered": [
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\AlterOperation",
+                        "DB_OPTIONS": {
+                            "CHARACTER SET": [
+                                1,
+                                "var"
+                            ],
+                            "CHARSET": [
+                                1,
+                                "var"
+                            ],
+                            "DEFAULT CHARACTER SET": [
+                                1,
+                                "var"
+                            ],
+                            "DEFAULT CHARSET": [
+                                1,
+                                "var"
+                            ],
+                            "UPGRADE": [
+                                1,
+                                "var"
+                            ],
+                            "COLLATE": [
+                                2,
+                                "var"
+                            ],
+                            "DEFAULT COLLATE": [
+                                2,
+                                "var"
+                            ]
+                        },
+                        "TABLE_OPTIONS": {
+                            "ENGINE": [
+                                1,
+                                "var="
+                            ],
+                            "AUTO_INCREMENT": [
+                                1,
+                                "var="
+                            ],
+                            "AVG_ROW_LENGTH": [
+                                1,
+                                "var"
+                            ],
+                            "MAX_ROWS": [
+                                1,
+                                "var"
+                            ],
+                            "ROW_FORMAT": [
+                                1,
+                                "var"
+                            ],
+                            "COMMENT": [
+                                1,
+                                "var"
+                            ],
+                            "ADD": 1,
+                            "ALTER": 1,
+                            "ANALYZE": 1,
+                            "CHANGE": 1,
+                            "CHARSET": 1,
+                            "CHECK": 1,
+                            "COALESCE": 1,
+                            "CONVERT": 1,
+                            "DEFAULT CHARSET": 1,
+                            "DISABLE": 1,
+                            "DISCARD": 1,
+                            "DROP": 1,
+                            "ENABLE": 1,
+                            "IMPORT": 1,
+                            "MODIFY": 1,
+                            "OPTIMIZE": 1,
+                            "ORDER": 1,
+                            "REBUILD": 1,
+                            "REMOVE": 1,
+                            "RENAME": 1,
+                            "REORGANIZE": 1,
+                            "REPAIR": 1,
+                            "UPGRADE": 1,
+                            "COLUMN": 2,
+                            "CONSTRAINT": 2,
+                            "DEFAULT": 2,
+                            "BY": 2,
+                            "FOREIGN": 2,
+                            "FULLTEXT": 2,
+                            "KEY": 2,
+                            "KEYS": 2,
+                            "PARTITION": 2,
+                            "PARTITION BY": 2,
+                            "PARTITIONING": 2,
+                            "PRIMARY KEY": 2,
+                            "SPATIAL": 2,
+                            "TABLESPACE": 2,
+                            "INDEX": [
+                                2,
+                                "var"
+                            ],
+                            "CHARACTER SET": 3,
+                            "TO": [
+                                3,
+                                "var"
+                            ]
+                        },
+                        "USER_OPTIONS": {
+                            "ATTRIBUTE": [
+                                1,
+                                "var"
+                            ],
+                            "COMMENT": [
+                                1,
+                                "var"
+                            ],
+                            "REQUIRE": [
+                                1,
+                                "var"
+                            ],
+                            "BY": [
+                                2,
+                                "expr"
+                            ],
+                            "PASSWORD": [
+                                2,
+                                "var"
+                            ],
+                            "WITH": [
+                                2,
+                                "var"
+                            ],
+                            "ACCOUNT": 1,
+                            "DEFAULT": 1,
+                            "LOCK": 2,
+                            "UNLOCK": 2,
+                            "IDENTIFIED": 3
+                        },
+                        "VIEW_OPTIONS": {
+                            "AS": 1
+                        },
+                        "EVENT_OPTIONS": {
+                            "ON SCHEDULE": 1,
+                            "EVERY": [
+                                2,
+                                "expr"
+                            ],
+                            "AT": [
+                                2,
+                                "expr"
+                            ],
+                            "STARTS": [
+                                3,
+                                "expr"
+                            ],
+                            "ENDS": [
+                                4,
+                                "expr"
+                            ],
+                            "ON COMPLETION PRESERVE": 5,
+                            "ON COMPLETION NOT PRESERVE": 5,
+                            "RENAME": 6,
+                            "TO": [
+                                7,
+                                "expr",
+                                {
+                                    "parseField": "table"
+                                }
+                            ],
+                            "ENABLE": 8,
+                            "DISABLE": 8,
+                            "DISABLE ON SLAVE": 8,
+                            "COMMENT": [
+                                9,
+                                "var"
+                            ],
+                            "DO": 10
+                        },
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        },
+                        "field": null,
+                        "partitions": null,
+                        "unknown": [
+                            {
+                                "@type": "@67"
+                            },
+                            {
+                                "@type": "@68"
+                            },
+                            {
+                                "@type": "@69"
+                            },
+                            {
+                                "@type": "@70"
+                            },
+                            {
+                                "@type": "@71"
+                            },
+                            {
+                                "@type": "@72"
+                            },
+                            {
+                                "@type": "@73"
+                            },
+                            {
+                                "@type": "@74"
+                            }
+                        ]
+                    }
+                ],
+                "OPTIONS": {
+                    "ONLINE": 1,
+                    "OFFLINE": 1,
+                    "IGNORE": 2,
+                    "DATABASE": 3,
+                    "EVENT": 3,
+                    "FUNCTION": 3,
+                    "PROCEDURE": 3,
+                    "SERVER": 3,
+                    "TABLE": 3,
+                    "TABLESPACE": 3,
+                    "USER": 3,
+                    "VIEW": 3
+                },
+                "CLAUSES": [],
+                "END_OPTIONS": [],
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 60,
+                "last": 74
+            }
+        ],
+        "brackets": 0,
+        "strict": false,
+        "errors": []
+    },
+    "errors": {
+        "lexer": [],
+        "parser": [
+            [
+                "Missing comma before start of a new alter operation.",
+                {
+                    "@type": "@14"
+                },
+                0
+            ],
+            [
+                "Unrecognized alter operation.",
+                {
+                    "@type": "@14"
+                },
+                0
+            ],
+            [
+                "Missing comma before start of a new alter operation.",
+                {
+                    "@type": "@29"
+                },
+                0
+            ],
+            [
+                "Unrecognized alter operation.",
+                {
+                    "@type": "@29"
+                },
+                0
+            ],
+            [
+                "Missing comma before start of a new alter operation.",
+                {
+                    "@type": "@45"
+                },
+                0
+            ],
+            [
+                "Unrecognized alter operation.",
+                {
+                    "@type": "@45"
+                },
+                0
+            ],
+            [
+                "Missing comma before start of a new alter operation.",
+                {
+                    "@type": "@60"
+                },
+                0
+            ],
+            [
+                "Unrecognized alter operation.",
+                {
+                    "@type": "@60"
+                },
+                0
+            ],
+            [
+                "Missing comma before start of a new alter operation.",
+                {
+                    "@type": "@75"
+                },
+                0
+            ],
+            [
+                "Unrecognized alter operation.",
+                {
+                    "@type": "@75"
+                },
+                0
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
Fix #418

I also improved the build process of Alter statements by adding a `trim` on it. Adding unit tests about the `ALTER DEFINER=user EVENT` builder gave me the unexpected results that an unwanted space can left at the end of the query, and already existing unit tests about the build of any Alter statement seemed to add that space in the expected value for no other reason that a lack of trimming here.

To see how the `DEFINER=user` is now correctly handle, you can compare the `.out` files from the 2 commits of the PR as the 1st one is the current status (unknown tokens and parsing errors are detected), while the 2nd one doesn't have any unknown token or parsing error.