### PR TITLE
Fix #226 - Ignore end of comment string at the end of queries with MySQL-specific commands

### DIFF
--- a/src/Components/Expression.php
+++ b/src/Components/Expression.php
@@ -222,7 +222,8 @@ class Expression extends Component
 
             // Skipping whitespaces and comments.
             if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
-                if ($isExpr) {
+                // If the token is a closing C comment from a MySQL command, it must be ignored.
+                if ($isExpr && $token->token !== '*/') {
                     $ret->expr .= $token->token;
                 }
 

--- a/tests/Components/ExpressionTest.php
+++ b/tests/Components/ExpressionTest.php
@@ -92,4 +92,63 @@ class ExpressionTest extends TestCase
             '1 + 2 AS `three`, 1 + 3 AS `four`'
         );
     }
+
+    /**
+     * @return string[][]
+     */
+    public static function mysqlCommandsProvider(): array
+    {
+        return [
+            [
+                '/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;',
+                'SET  @OLD_CHARACTER_SET_CLIENT = @@CHARACTER_SET_CLIENT',
+            ],
+            [
+                '/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;',
+                'SET  @OLD_CHARACTER_SET_RESULTS = @@CHARACTER_SET_RESULTS',
+            ],
+            [
+                '/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;',
+                'SET  @OLD_COLLATION_CONNECTION = @@COLLATION_CONNECTION',
+            ],
+            [
+                '/*!40101 SET NAMES utf8 */;',
+                'SET NAMES utf8',
+            ],
+            [
+                '/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;',
+                'SET  @OLD_TIME_ZONE = @@TIME_ZONE',
+            ],
+            [
+                "/*!40103 SET TIME_ZONE='+00:00' */;",
+                "SET  TIME_ZONE = '+00:00'",
+            ],
+            [
+                '/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;',
+                'SET  @OLD_UNIQUE_CHECKS = @@UNIQUE_CHECKS, UNIQUE_CHECKS = 0',
+            ],
+            [
+                '/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;',
+                'SET  @OLD_FOREIGN_KEY_CHECKS = @@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS = 0',
+            ],
+            [
+                "/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;",
+                "SET  @OLD_SQL_MODE = @@SQL_MODE, SQL_MODE = 'NO_AUTO_VALUE_ON_ZERO'",
+            ],
+            [
+                '/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;',
+                'SET  @OLD_SQL_NOTES = @@SQL_NOTES, SQL_NOTES = 0',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider mysqlCommandsProvider
+     */
+    public function testMysqlCommands(string $expr, string $expected): void
+    {
+        $parser = new Parser($expr, true);
+        $parser->parse();
+        self::assertSame($expected, $parser->statements[0]->build());
+    }
 }

--- a/tests/Parser/ParserLongExportsTest.php
+++ b/tests/Parser/ParserLongExportsTest.php
@@ -33,16 +33,16 @@ class ParserLongExportsTest extends TestCase
 SQL;
 
         $expectedSql = [
-            'SET  @OLD_CHARACTER_SET_CLIENT = @@CHARACTER_SET_CLIENT */',
-            'SET  @OLD_CHARACTER_SET_RESULTS = @@CHARACTER_SET_RESULTS */',
-            'SET  @OLD_COLLATION_CONNECTION = @@COLLATION_CONNECTION */',
+            'SET  @OLD_CHARACTER_SET_CLIENT = @@CHARACTER_SET_CLIENT',
+            'SET  @OLD_CHARACTER_SET_RESULTS = @@CHARACTER_SET_RESULTS',
+            'SET  @OLD_COLLATION_CONNECTION = @@COLLATION_CONNECTION',
             'SET NAMES utf8',
-            'SET  @OLD_TIME_ZONE = @@TIME_ZONE */',
+            'SET  @OLD_TIME_ZONE = @@TIME_ZONE',
             "SET  TIME_ZONE = '+00:00'",
-            'SET  @OLD_UNIQUE_CHECKS = @@UNIQUE_CHECKS, UNIQUE_CHECKS = 0 */',
-            'SET  @OLD_FOREIGN_KEY_CHECKS = @@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS = 0 */',
+            'SET  @OLD_UNIQUE_CHECKS = @@UNIQUE_CHECKS, UNIQUE_CHECKS = 0',
+            'SET  @OLD_FOREIGN_KEY_CHECKS = @@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS = 0',
             "SET  @OLD_SQL_MODE = @@SQL_MODE, SQL_MODE = 'NO_AUTO_VALUE_ON_ZERO'",
-            'SET  @OLD_SQL_NOTES = @@SQL_NOTES, SQL_NOTES = 0 */',
+            'SET  @OLD_SQL_NOTES = @@SQL_NOTES, SQL_NOTES = 0',
         ];
 
         $parser = new Parser($sql, true);
@@ -85,9 +85,9 @@ SQL;
             'SET  SQL_MODE = "NO_AUTO_VALUE_ON_ZERO"',
             'SET  AUTOCOMMIT = 0',
             'SET  time_zone = "+00:00"',
-            'SET  @OLD_CHARACTER_SET_CLIENT = @@CHARACTER_SET_CLIENT */',
-            'SET  @OLD_CHARACTER_SET_RESULTS = @@CHARACTER_SET_RESULTS */',
-            'SET  @OLD_COLLATION_CONNECTION = @@COLLATION_CONNECTION */',
+            'SET  @OLD_CHARACTER_SET_CLIENT = @@CHARACTER_SET_CLIENT',
+            'SET  @OLD_CHARACTER_SET_RESULTS = @@CHARACTER_SET_RESULTS',
+            'SET  @OLD_COLLATION_CONNECTION = @@COLLATION_CONNECTION',
             'SET NAMES utf8mb4',
         ], $collectedSetStatements);
 

--- a/tests/data/parser/parsephpMyAdminExport1.out
+++ b/tests/data/parser/parsephpMyAdminExport1.out
@@ -4641,7 +4641,7 @@
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\SetOperation",
                                 "column": "@OLD_CHARACTER_SET_CLIENT",
-                                "value": "@@CHARACTER_SET_CLIENT *\/"
+                                "value": "@@CHARACTER_SET_CLIENT"
                             }
                         ],
                         "first": 44,
@@ -4658,7 +4658,7 @@
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\SetOperation",
                                 "column": "@OLD_CHARACTER_SET_RESULTS",
-                                "value": "@@CHARACTER_SET_RESULTS *\/"
+                                "value": "@@CHARACTER_SET_RESULTS"
                             }
                         ],
                         "first": 55,
@@ -4675,7 +4675,7 @@
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\SetOperation",
                                 "column": "@OLD_COLLATION_CONNECTION",
-                                "value": "@@COLLATION_CONNECTION *\/"
+                                "value": "@@COLLATION_CONNECTION"
                             }
                         ],
                         "first": 66,


### PR DESCRIPTION
This is an attempt to fix #226 .

If it misses some use-cases to test, please tell me.