### PR TITLE
Fix TokensList::getPrevious which was not able to reach very first token

### DIFF
--- a/src/TokensList.php
+++ b/src/TokensList.php
@@ -119,7 +119,7 @@ class TokensList implements ArrayAccess
      */
     public function getPrevious(): ?Token
     {
-        for (; $this->idx > 0; --$this->idx) {
+        for (; $this->idx >= 0; --$this->idx) {
             if (
                 ($this->tokens[$this->idx]->type !== Token::TYPE_WHITESPACE)
                 && ($this->tokens[$this->idx]->type !== Token::TYPE_COMMENT)

--- a/tests/Lexer/TokensListTest.php
+++ b/tests/Lexer/TokensListTest.php
@@ -79,6 +79,7 @@ class TokensListTest extends TestCase
         $this->assertEquals($this->tokens[6], $list->getPrevious());
         $this->assertEquals($this->tokens[4], $list->getPrevious());
         $this->assertEquals($this->tokens[2], $list->getPrevious());
+        $this->assertEquals($this->tokens[0], $list->getPrevious());
         $this->assertNull($list->getPrevious());
     }
 


### PR DESCRIPTION
This change aims to fix a bug in the TokensList::getPrivious method which was not able to reach the very first token. As you can see in the test case, the method returned `null` before returning the `SELECT` token.

If it was not a bug, but an expected behavior, please let me know.

Maybe such a bugfix should be backported to 5.7 as well, but I can't find a maintenance branch for this version.

Thank you.