### PR TITLE
Add new method TokensList::getPreviousOfType + manage list of types in TokensList::getPreviousOfType and TokensList::getNextOfType

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -109,6 +109,23 @@ class Token
      */
     public const TYPE_LABEL = 10;
 
+    /**
+     *  All tokens types
+     */
+    public const TYPE_ALL = [
+        Token::TYPE_NONE,
+        Token::TYPE_KEYWORD,
+        Token::TYPE_OPERATOR,
+        Token::TYPE_WHITESPACE,
+        Token::TYPE_COMMENT,
+        Token::TYPE_BOOL,
+        Token::TYPE_NUMBER,
+        Token::TYPE_STRING,
+        Token::TYPE_SYMBOL,
+        Token::TYPE_DELIMITER,
+        Token::TYPE_LABEL,
+    ];
+
     // Flags that describe the tokens in more detail.
     // All keywords must have flag 1 so `Context::isKeyword` method doesn't
     // require strict comparison.

--- a/src/TokensList.php
+++ b/src/TokensList.php
@@ -132,16 +132,40 @@ class TokensList implements ArrayAccess
     }
 
     /**
+     * Gets the previous token.
+     *
+     * @param int|int[] $type the type
+     *
+     * @return Token|null
+     */
+    public function getPreviousOfType($type)
+    {
+        if (!is_array($type)) {
+            $type = [$type];
+        }
+        for (; $this->idx >= 0; --$this->idx) {
+            if (in_array($this->tokens[$this->idx]->type, $type, true)) {
+                return $this->tokens[$this->idx--];
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Gets the next token.
      *
-     * @param int $type the type
+     * @param int|int[] $type the type
      *
      * @return Token|null
      */
     public function getNextOfType($type)
     {
+        if (!is_array($type)) {
+            $type = [$type];
+        }
         for (; $this->idx < $this->count; ++$this->idx) {
-            if ($this->tokens[$this->idx]->type === $type) {
+            if (in_array($this->tokens[$this->idx]->type, $type, true)) {
                 return $this->tokens[$this->idx++];
             }
         }

--- a/src/TokensList.php
+++ b/src/TokensList.php
@@ -119,7 +119,7 @@ class TokensList implements ArrayAccess
      */
     public function getPrevious(): ?Token
     {
-        for (; $this->idx > 0; --$this->idx) {
+        for (; $this->idx >= 0; --$this->idx) {
             if (
                 ($this->tokens[$this->idx]->type !== Token::TYPE_WHITESPACE)
                 && ($this->tokens[$this->idx]->type !== Token::TYPE_COMMENT)

--- a/tests/Lexer/TokensListTest.php
+++ b/tests/Lexer/TokensListTest.php
@@ -87,9 +87,21 @@ class TokensListTest extends TestCase
     {
         $list = new TokensList($this->tokens);
         $this->assertEquals($this->tokens[0], $list->getNextOfType(Token::TYPE_KEYWORD));
-        $this->assertEquals($this->tokens[4], $list->getNextOfType(Token::TYPE_KEYWORD));
-        $this->assertEquals($this->tokens[8], $list->getNextOfType(Token::TYPE_KEYWORD));
+        $this->assertEquals($this->tokens[4], $list->getNextOfType([Token::TYPE_KEYWORD]));
+        $this->assertEquals($this->tokens[6], $list->getNextOfType([Token::TYPE_KEYWORD, Token::TYPE_SYMBOL]));
+        $this->assertEquals($this->tokens[8], $list->getNextOfType([Token::TYPE_KEYWORD, Token::TYPE_SYMBOL]));
         $this->assertNull($list->getNextOfType(Token::TYPE_KEYWORD));
+    }
+
+    public function testGetPreviousOfType(): void
+    {
+        $list = new TokensList($this->tokens);
+        $list->idx = 9;
+        $this->assertEquals($this->tokens[8], $list->getPreviousOfType([Token::TYPE_KEYWORD, Token::TYPE_SYMBOL]));
+        $this->assertEquals($this->tokens[6], $list->getPreviousOfType([Token::TYPE_KEYWORD, Token::TYPE_SYMBOL]));
+        $this->assertEquals($this->tokens[4], $list->getPreviousOfType([Token::TYPE_KEYWORD]));
+        $this->assertEquals($this->tokens[0], $list->getPreviousOfType(Token::TYPE_KEYWORD));
+        $this->assertNull($list->getPreviousOfType(Token::TYPE_KEYWORD));
     }
 
     public function testGetNextOfTypeAndFlag(): void

--- a/tests/Lexer/TokensListTest.php
+++ b/tests/Lexer/TokensListTest.php
@@ -79,6 +79,7 @@ class TokensListTest extends TestCase
         $this->assertEquals($this->tokens[6], $list->getPrevious());
         $this->assertEquals($this->tokens[4], $list->getPrevious());
         $this->assertEquals($this->tokens[2], $list->getPrevious());
+        $this->assertEquals($this->tokens[0], $list->getPrevious());
         $this->assertNull($list->getPrevious());
     }
 


### PR DESCRIPTION
These changes aims to:
* support new request for a previous token based on a set of types
* support request for a next token based on a set of types, not only one

Changes were done in a backward compatible way.

I intentionally didn't change all the `getNextOfType*` methods, as other methods have an additional filter which does not always make sense to combine with an array of types.

Additionally, this PR relies on changes done in PR https://github.com/phpmyadmin/sql-parser/pull/428.