### PR TITLE
Fix #330 - Add `KEY` to `CreateDefinition`

### DIFF
--- a/src/Components/CreateDefinition.php
+++ b/src/Components/CreateDefinition.php
@@ -56,6 +56,7 @@ class CreateDefinition extends Component
             'var',
         ],
         'AUTO_INCREMENT' => 3,
+        'KEY' => 4,
         'PRIMARY' => 4,
         'PRIMARY KEY' => 4,
         'UNIQUE' => 4,

--- a/tests/data/parser/parseCreateTable13.out
+++ b/tests/data/parser/parseCreateTable13.out
@@ -430,8 +430,71 @@
                             "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
                             "options": {
                                 "1": "NOT NULL",
-                                "3": "AUTO_INCREMENT"
+                                "3": "AUTO_INCREMENT",
+                                "4": "KEY"
                             }
+                        }
+                    },
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\CreateDefinition",
+                        "name": "make",
+                        "isConstraint": null,
+                        "type": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\DataType",
+                            "name": "VARCHAR",
+                            "parameters": [
+                                "128"
+                            ],
+                            "options": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                                "options": []
+                            }
+                        },
+                        "key": null,
+                        "references": null,
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        }
+                    },
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\CreateDefinition",
+                        "name": "year",
+                        "isConstraint": null,
+                        "type": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\DataType",
+                            "name": "INTEGER",
+                            "parameters": [],
+                            "options": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                                "options": []
+                            }
+                        },
+                        "key": null,
+                        "references": null,
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        }
+                    },
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\CreateDefinition",
+                        "name": "mileage",
+                        "isConstraint": null,
+                        "type": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\DataType",
+                            "name": "INTEGER",
+                            "parameters": [],
+                            "options": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                                "options": []
+                            }
+                        },
+                        "key": null,
+                        "references": null,
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
                         }
                     }
                 ],
@@ -454,7 +517,7 @@
                     }
                 },
                 "first": 0,
-                "last": 24
+                "last": 39
             }
         ],
         "brackets": 0,
@@ -463,28 +526,6 @@
     },
     "errors": {
         "lexer": [],
-        "parser": [
-            [
-                "A comma or a closing bracket was expected.",
-                {
-                    "@type": "@20"
-                },
-                0
-            ],
-            [
-                "Unexpected beginning of statement.",
-                {
-                    "@type": "@27"
-                },
-                0
-            ],
-            [
-                "Unrecognized statement type.",
-                {
-                    "@type": "@31"
-                },
-                0
-            ]
-        ]
+        "parser": []
     }
 }

--- a/tests/data/parser/parseCreateTable14.out
+++ b/tests/data/parser/parseCreateTable14.out
@@ -411,8 +411,71 @@
                         "options": {
                             "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
                             "options": {
-                                "1": "NOT NULL"
+                                "1": "NOT NULL",
+                                "4": "KEY"
                             }
+                        }
+                    },
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\CreateDefinition",
+                        "name": "make",
+                        "isConstraint": null,
+                        "type": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\DataType",
+                            "name": "VARCHAR",
+                            "parameters": [
+                                "128"
+                            ],
+                            "options": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                                "options": []
+                            }
+                        },
+                        "key": null,
+                        "references": null,
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        }
+                    },
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\CreateDefinition",
+                        "name": "year",
+                        "isConstraint": null,
+                        "type": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\DataType",
+                            "name": "INTEGER",
+                            "parameters": [],
+                            "options": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                                "options": []
+                            }
+                        },
+                        "key": null,
+                        "references": null,
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        }
+                    },
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\CreateDefinition",
+                        "name": "mileage",
+                        "isConstraint": null,
+                        "type": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\DataType",
+                            "name": "INTEGER",
+                            "parameters": [],
+                            "options": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                                "options": []
+                            }
+                        },
+                        "key": null,
+                        "references": null,
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
                         }
                     }
                 ],
@@ -435,7 +498,7 @@
                     }
                 },
                 "first": 0,
-                "last": 22
+                "last": 37
             }
         ],
         "brackets": 0,
@@ -444,28 +507,6 @@
     },
     "errors": {
         "lexer": [],
-        "parser": [
-            [
-                "A comma or a closing bracket was expected.",
-                {
-                    "@type": "@18"
-                },
-                0
-            ],
-            [
-                "Unexpected beginning of statement.",
-                {
-                    "@type": "@25"
-                },
-                0
-            ],
-            [
-                "Unrecognized statement type.",
-                {
-                    "@type": "@29"
-                },
-                0
-            ]
-        ]
+        "parser": []
     }
 }

--- a/tests/data/parser/parseCreateTable15.out
+++ b/tests/data/parser/parseCreateTable15.out
@@ -430,8 +430,71 @@
                         "options": {
                             "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
                             "options": {
-                                "1": "NOT NULL"
+                                "1": "NOT NULL",
+                                "4": "KEY"
                             }
+                        }
+                    },
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\CreateDefinition",
+                        "name": "make",
+                        "isConstraint": null,
+                        "type": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\DataType",
+                            "name": "VARCHAR",
+                            "parameters": [
+                                "128"
+                            ],
+                            "options": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                                "options": []
+                            }
+                        },
+                        "key": null,
+                        "references": null,
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        }
+                    },
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\CreateDefinition",
+                        "name": "year",
+                        "isConstraint": null,
+                        "type": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\DataType",
+                            "name": "INTEGER",
+                            "parameters": [],
+                            "options": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                                "options": []
+                            }
+                        },
+                        "key": null,
+                        "references": null,
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        }
+                    },
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\CreateDefinition",
+                        "name": "mileage",
+                        "isConstraint": null,
+                        "type": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\DataType",
+                            "name": "INTEGER",
+                            "parameters": [],
+                            "options": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                                "options": []
+                            }
+                        },
+                        "key": null,
+                        "references": null,
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
                         }
                     }
                 ],
@@ -454,7 +517,7 @@
                     }
                 },
                 "first": 0,
-                "last": 24
+                "last": 39
             }
         ],
         "brackets": 0,
@@ -463,28 +526,6 @@
     },
     "errors": {
         "lexer": [],
-        "parser": [
-            [
-                "A comma or a closing bracket was expected.",
-                {
-                    "@type": "@20"
-                },
-                0
-            ],
-            [
-                "Unexpected beginning of statement.",
-                {
-                    "@type": "@27"
-                },
-                0
-            ],
-            [
-                "Unrecognized statement type.",
-                {
-                    "@type": "@31"
-                },
-                0
-            ]
-        ]
+        "parser": []
     }
 }


### PR DESCRIPTION
Fixes: #330

