### PR TITLE
Fix #260 - implement support for `LEFT JOIN`, `JOIN`,`INNER JOIN` on `UpdateStatement`

### DIFF
--- a/src/Statements/UpdateStatement.php
+++ b/src/Statements/UpdateStatement.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser\Statements;
 
 use PhpMyAdmin\SqlParser\Components\Condition;
 use PhpMyAdmin\SqlParser\Components\Expression;
+use PhpMyAdmin\SqlParser\Components\JoinKeyword;
 use PhpMyAdmin\SqlParser\Components\Limit;
 use PhpMyAdmin\SqlParser\Components\OrderKeyword;
 use PhpMyAdmin\SqlParser\Components\SetOperation;
@@ -15,6 +16,7 @@ use PhpMyAdmin\SqlParser\Statement;
  * `UPDATE` statement.
  *
  * UPDATE [LOW_PRIORITY] [IGNORE] table_reference
+ *     [INNER JOIN | LEFT JOIN | JOIN] T1 ON T1.C1 = T2.C1
  *     SET col_name1={expr1|DEFAULT} [, col_name2={expr2|DEFAULT}] ...
  *     [WHERE where_condition]
  *     [ORDER BY ...]
@@ -60,6 +62,18 @@ class UpdateStatement extends Statement
         // Used for updated tables.
         '_UPDATE' => [
             'UPDATE',
+            1,
+        ],
+        'JOIN' => [
+            'JOIN',
+            1,
+        ],
+        'LEFT JOIN' => [
+            'LEFT JOIN',
+            1,
+        ],
+        'INNER JOIN' => [
+            'INNER JOIN',
             1,
         ],
         'SET' => [
@@ -114,4 +128,11 @@ class UpdateStatement extends Statement
      * @var Limit|null
      */
     public $limit;
+
+    /**
+     * Joins.
+     *
+     * @var JoinKeyword[]|null
+     */
+    public $join;
 }

--- a/tests/Builder/UpdateStatementTest.php
+++ b/tests/Builder/UpdateStatementTest.php
@@ -17,14 +17,14 @@ class UpdateStatementTest extends TestCase
         );
         $stmt = $parser->statements[0];
         $this->assertEquals(
-            'UPDATE user AS `u` SET ud.ip = \'33\' WHERE u.id = 1',
+            'UPDATE user AS `u` LEFT JOIN user_detail AS `ud` ON u.id = ud.user_id SET ud.ip = \'33\' WHERE u.id = 1',
             $stmt->build()
         );
         /* Assertion 2 */
         $parser = new Parser('update user u join user_detail ud on u.id = ud.user_id set ud.ip =\'33\' where u.id = 1');
         $stmt = $parser->statements[0];
         $this->assertEquals(
-            'UPDATE user AS `u` SET ud.ip = \'33\' WHERE u.id = 1',
+            'UPDATE user AS `u` JOIN user_detail AS `ud` ON u.id = ud.user_id SET ud.ip = \'33\' WHERE u.id = 1',
             $stmt->build()
         );
         /* Assertion 3 */
@@ -33,7 +33,7 @@ class UpdateStatementTest extends TestCase
         );
         $stmt = $parser->statements[0];
         $this->assertEquals(
-            'UPDATE user AS `u` SET ud.ip = \'33\' WHERE u.id = 1',
+            'UPDATE user AS `u` INNER JOIN user_detail AS `ud` ON u.id = ud.user_id SET ud.ip = \'33\' WHERE u.id = 1',
             $stmt->build()
         );
     }

--- a/tests/data/parser/parseTransaction.out
+++ b/tests/data/parser/parseTransaction.out
@@ -502,6 +502,7 @@
                         ],
                         "order": null,
                         "limit": null,
+                        "join": null,
                         "options": {
                             "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
                             "options": []

--- a/tests/data/parser/parseTransaction2.out
+++ b/tests/data/parser/parseTransaction2.out
@@ -502,6 +502,7 @@
                         ],
                         "order": null,
                         "limit": null,
+                        "join": null,
                         "options": {
                             "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
                             "options": []

--- a/tests/data/parser/parseUpdate1.out
+++ b/tests/data/parser/parseUpdate1.out
@@ -214,6 +214,7 @@
                 "where": null,
                 "order": null,
                 "limit": null,
+                "join": null,
                 "options": {
                     "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
                     "options": []

--- a/tests/data/parser/parseUpdate2.out
+++ b/tests/data/parser/parseUpdate2.out
@@ -372,6 +372,7 @@
                     "offset": 2,
                     "rowCount": 1
                 },
+                "join": null,
                 "options": {
                     "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
                     "options": []

--- a/tests/data/parser/parseUpdate3.out
+++ b/tests/data/parser/parseUpdate3.out
@@ -221,6 +221,7 @@
                 ],
                 "order": null,
                 "limit": null,
+                "join": null,
                 "options": {
                     "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
                     "options": []

--- a/tests/data/parser/parseUpdate4.out
+++ b/tests/data/parser/parseUpdate4.out
@@ -357,6 +357,7 @@
                 ],
                 "order": null,
                 "limit": null,
+                "join": null,
                 "options": {
                     "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
                     "options": []

--- a/tests/data/parser/parseUpdate5.out
+++ b/tests/data/parser/parseUpdate5.out
@@ -444,12 +444,6 @@
                 ],
                 "order": null,
                 "limit": null,
-                "options": {
-                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
-                },
-                "first": 0,
-                "last": 41,
                 "join": [
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
@@ -479,7 +473,13 @@
                         ],
                         "using": null
                     }
-                ]
+                ],
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 0,
+                "last": 41
             }
         ],
         "brackets": 0,

--- a/tests/data/parser/parseUpdate6.out
+++ b/tests/data/parser/parseUpdate6.out
@@ -625,12 +625,6 @@
                 ],
                 "order": null,
                 "limit": null,
-                "options": {
-                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
-                },
-                "first": 0,
-                "last": 60,
                 "join": [
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
@@ -686,7 +680,13 @@
                         ],
                         "using": null
                     }
-                ]
+                ],
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 0,
+                "last": 60
             }
         ],
         "brackets": 0,

--- a/tests/data/parser/parseUpdate7.out
+++ b/tests/data/parser/parseUpdate7.out
@@ -625,12 +625,6 @@
                 ],
                 "order": null,
                 "limit": null,
-                "options": {
-                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
-                },
-                "first": 0,
-                "last": 60,
                 "join": [
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\JoinKeyword",
@@ -686,7 +680,13 @@
                         ],
                         "using": null
                     }
-                ]
+                ],
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 0,
+                "last": 60
             }
         ],
         "brackets": 0,

--- a/tests/data/parser/parseUpdateErr.out
+++ b/tests/data/parser/parseUpdateErr.out
@@ -320,6 +320,7 @@
                 ],
                 "order": null,
                 "limit": null,
+                "join": null,
                 "options": {
                     "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
                     "options": []


### PR DESCRIPTION
Fixes: #260 - implements support for `LEFT JOIN`, `JOIN`,`INNER JOIN` on `UpdateStatement`