### PR TITLE
Simplify switch

### DIFF
--- a/src/Tools/ContextGenerator.php
+++ b/src/Tools/ContextGenerator.php
@@ -291,13 +291,10 @@ PHP;
 
         /* Format name */
         $base = $parts[1];
-        switch ($base) {
-            case 'MySql':
-                $base = 'MySQL';
-                break;
-            case 'MariaDb':
-                $base = 'MariaDB';
-                break;
+        if ($base == 'MySql') {
+            $base = 'MySQL';
+        } elseif ($base == 'MariaDb') {
+            $base = 'MariaDB';
         }
 
         /* Parse version to array */


### PR DESCRIPTION
This is easier on the eyes. A switch has an extra indentation and is unnecessary here. 