### PR TITLE
Set native types from count

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -581,11 +581,6 @@ parameters:
 			path: src/Statement.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between int\\<1, max\\> and 0 will always evaluate to false\\.$#"
-			count: 1
-			path: src/Statement.php
-
-		-
 			message: "#^Argument of an invalid type array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\AlterOperation\\>\\|null supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Statements/AlterStatement.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -977,9 +977,6 @@
     <RedundantConditionGivenDocblockType>
       <code>$class !== null</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType>
-      <code>count($clauses) === 0</code>
-    </TypeDoesNotContainType>
     <UndefinedAttributeClass>
       <code>\AllowDynamicProperties</code>
     </UndefinedAttributeClass>

--- a/src/Components/OptionsArray.php
+++ b/src/Components/OptionsArray.php
@@ -29,7 +29,7 @@ final class OptionsArray implements Component
      *
      * @var array<int, mixed>
      */
-    public $options = [];
+    public array $options = [];
 
     /**
      * @param array<int, mixed> $options The array of options. Options that have a value

--- a/src/Core.php
+++ b/src/Core.php
@@ -31,7 +31,7 @@ class Core
      *
      * @var Exception[]
      */
-    public $errors = [];
+    public array $errors = [];
 
     public function __construct()
     {

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -9,7 +9,6 @@ use Stringable;
 
 use function array_flip;
 use function array_keys;
-use function count;
 use function in_array;
 use function stripos;
 use function trim;
@@ -443,7 +442,7 @@ abstract class Statement implements Stringable
      * @return array<string, array<int, int|string>>
      * @psalm-return array<string, array{non-empty-string, (1|2|3)}>
      */
-    public function getClauses()
+    public function getClauses(): array
     {
         return static::$clauses;
     }
@@ -476,7 +475,7 @@ abstract class Statement implements Stringable
     {
         $clauses = array_flip(array_keys($this->getClauses()));
 
-        if (empty($clauses) || count($clauses) === 0) {
+        if ($clauses === []) {
             return true;
         }
 

--- a/src/Statements/DeleteStatement.php
+++ b/src/Statements/DeleteStatement.php
@@ -17,7 +17,6 @@ use PhpMyAdmin\SqlParser\Statement;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
 
-use function count;
 use function stripos;
 use function strlen;
 
@@ -107,28 +106,28 @@ class DeleteStatement extends Statement
      *
      * @var Expression[]|null
      */
-    public $from;
+    public array|null $from = null;
 
     /**
      * Joins.
      *
      * @var JoinKeyword[]|null
      */
-    public $join;
+    public array|null $join = null;
 
     /**
      * Tables used as sources for this statement.
      *
      * @var Expression[]|null
      */
-    public $using;
+    public array|null $using = null;
 
     /**
      * Columns used in this statement.
      *
      * @var Expression[]|null
      */
-    public $columns;
+    public array|null $columns = null;
 
     /**
      * Partitions used as source for this statement.
@@ -142,14 +141,14 @@ class DeleteStatement extends Statement
      *
      * @var Condition[]|null
      */
-    public $where;
+    public array|null $where = null;
 
     /**
      * Specifies the order of the rows in the result set.
      *
      * @var OrderKeyword[]|null
      */
-    public $order;
+    public array|null $order = null;
 
     /**
      * Conditions used for limiting the size of the result set.
@@ -165,27 +164,27 @@ class DeleteStatement extends Statement
     {
         $ret = 'DELETE ' . OptionsArray::build($this->options);
 
-        if ($this->columns !== null && count($this->columns) > 0) {
+        if ($this->columns !== null && $this->columns !== []) {
             $ret .= ' ' . ExpressionArray::build($this->columns);
         }
 
-        if ($this->from !== null && count($this->from) > 0) {
+        if ($this->from !== null && $this->from !== []) {
             $ret .= ' FROM ' . ExpressionArray::build($this->from);
         }
 
-        if ($this->join !== null && count($this->join) > 0) {
+        if ($this->join !== null && $this->join !== []) {
             $ret .= ' ' . JoinKeyword::build($this->join);
         }
 
-        if ($this->using !== null && count($this->using) > 0) {
+        if ($this->using !== null && $this->using !== []) {
             $ret .= ' USING ' . ExpressionArray::build($this->using);
         }
 
-        if ($this->where !== null && count($this->where) > 0) {
+        if ($this->where !== null && $this->where !== []) {
             $ret .= ' WHERE ' . Condition::build($this->where);
         }
 
-        if ($this->order !== null && count($this->order) > 0) {
+        if ($this->order !== null && $this->order !== []) {
             $ret .= ' ORDER BY ' . ExpressionArray::build($this->order);
         }
 

--- a/src/Statements/ExplainStatement.php
+++ b/src/Statements/ExplainStatement.php
@@ -12,7 +12,6 @@ use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
 
 use function array_slice;
-use function count;
 
 /**
  * `EXPLAIN` statement.
@@ -201,7 +200,7 @@ class ExplainStatement extends Statement
                 $subList = new TokensList(array_slice($list->tokens, $list->idx));
 
                 $this->bodyParser = new Parser($subList);
-                if (count($this->bodyParser->errors)) {
+                if ($this->bodyParser->errors !== []) {
                     foreach ($this->bodyParser->errors as $error) {
                         $parser->errors[] = $error;
                     }
@@ -252,7 +251,7 @@ class ExplainStatement extends Statement
         $str = $this->statementAlias;
 
         if ($this->options !== null) {
-            if (count($this->options->options)) {
+            if ($this->options->options !== []) {
                 $str .= ' ';
             }
 

--- a/src/Statements/InsertStatement.php
+++ b/src/Statements/InsertStatement.php
@@ -14,7 +14,6 @@ use PhpMyAdmin\SqlParser\Statement;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
 
-use function count;
 use function strlen;
 use function trim;
 
@@ -78,7 +77,7 @@ class InsertStatement extends Statement
      *
      * @var ArrayObj[]|null
      */
-    public $values;
+    public array|null $values = null;
 
     /**
      * If SET clause is present
@@ -86,7 +85,7 @@ class InsertStatement extends Statement
      *
      * @var SetOperation[]|null
      */
-    public $set;
+    public array|null $set = null;
 
     /**
      * If SELECT clause is present
@@ -110,7 +109,7 @@ class InsertStatement extends Statement
      *
      * @var SetOperation[]|null
      */
-    public $onDuplicateSet;
+    public array|null $onDuplicateSet = null;
 
     /**
      * @return string
@@ -120,15 +119,15 @@ class InsertStatement extends Statement
         $ret = 'INSERT ' . $this->options;
         $ret = trim($ret) . ' INTO ' . $this->into;
 
-        if ($this->values !== null && count($this->values) > 0) {
+        if ($this->values !== null && $this->values !== []) {
             $ret .= ' VALUES ' . Array2d::build($this->values);
-        } elseif ($this->set !== null && count($this->set) > 0) {
+        } elseif ($this->set !== null && $this->set !== []) {
             $ret .= ' SET ' . SetOperation::build($this->set);
         } elseif ($this->select !== null && strlen((string) $this->select) > 0) {
             $ret .= ' ' . $this->select->build();
         }
 
-        if ($this->onDuplicateSet !== null && count($this->onDuplicateSet) > 0) {
+        if ($this->onDuplicateSet !== null && $this->onDuplicateSet !== []) {
             $ret .= ' ON DUPLICATE KEY UPDATE ' . SetOperation::build($this->onDuplicateSet);
         }
 

--- a/src/Statements/LoadStatement.php
+++ b/src/Statements/LoadStatement.php
@@ -14,7 +14,6 @@ use PhpMyAdmin\SqlParser\Statement;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
 
-use function count;
 use function strlen;
 use function trim;
 
@@ -150,14 +149,14 @@ class LoadStatement extends Statement
      *
      * @var Expression[]|null
      */
-    public $columnNamesOrUserVariables;
+    public array|null $columnNamesOrUserVariables = null;
 
     /**
      * SET clause's updated values(optional).
      *
      * @var SetOperation[]|null
      */
-    public $set;
+    public array|null $set = null;
 
     /**
      * Ignore 'number' LINES/ROWS.
@@ -214,11 +213,11 @@ class LoadStatement extends Statement
             $ret .= ' IGNORE ' . $this->ignoreNumber . ' ' . $this->linesRows;
         }
 
-        if ($this->columnNamesOrUserVariables !== null && count($this->columnNamesOrUserVariables) > 0) {
+        if ($this->columnNamesOrUserVariables !== null && $this->columnNamesOrUserVariables !== []) {
             $ret .= ' ' . ExpressionArray::build($this->columnNamesOrUserVariables);
         }
 
-        if ($this->set !== null && count($this->set) > 0) {
+        if ($this->set !== null && $this->set !== []) {
             $ret .= ' SET ' . SetOperation::build($this->set);
         }
 

--- a/src/Statements/ReplaceStatement.php
+++ b/src/Statements/ReplaceStatement.php
@@ -13,7 +13,6 @@ use PhpMyAdmin\SqlParser\Statement;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
 
-use function count;
 use function strlen;
 use function trim;
 
@@ -71,7 +70,7 @@ class ReplaceStatement extends Statement
      *
      * @var SetOperation[]|null
      */
-    public $set;
+    public array|null $set = null;
 
     /**
      * If SELECT clause is present
@@ -89,9 +88,9 @@ class ReplaceStatement extends Statement
         $ret = 'REPLACE ' . $this->options;
         $ret = trim($ret) . ' INTO ' . $this->into;
 
-        if ($this->values !== null && count($this->values) > 0) {
+        if ($this->values !== null && $this->values !== []) {
             $ret .= ' VALUES ' . Array2d::build($this->values);
-        } elseif ($this->set !== null && count($this->set) > 0) {
+        } elseif ($this->set !== null && $this->set !== []) {
             $ret .= ' SET ' . SetOperation::build($this->set);
         } elseif ($this->select !== null && strlen((string) $this->select) > 0) {
             $ret .= ' ' . $this->select->build();

--- a/src/Statements/SelectStatement.php
+++ b/src/Statements/SelectStatement.php
@@ -344,7 +344,7 @@ class SelectStatement extends Statement
      * @return array<string, array<int, int|string>>
      * @psalm-return array<string, array{non-empty-string, (1|2|3)}>
      */
-    public function getClauses()
+    public function getClauses(): array
     {
         // This is a cheap fix for `SELECT` statements that contain `UNION`.
         // The `ORDER BY` and `LIMIT` clauses should be at the end of the

--- a/src/Statements/WithStatement.php
+++ b/src/Statements/WithStatement.php
@@ -15,7 +15,6 @@ use PhpMyAdmin\SqlParser\TokensList;
 use PhpMyAdmin\SqlParser\Translator;
 
 use function array_slice;
-use function count;
 
 /**
  * `WITH` statement.
@@ -161,7 +160,7 @@ final class WithStatement extends Statement
 
                 $subParser = new Parser($subList);
 
-                if (count($subParser->errors)) {
+                if ($subParser->errors !== []) {
                     foreach ($subParser->errors as $error) {
                         $parser->errors[] = $error;
                     }
@@ -239,7 +238,7 @@ final class WithStatement extends Statement
 
                 $subList = new TokensList(array_slice($list->tokens, $list->idx, $lengthOfExpressionTokens));
                 $subParser = new Parser($subList);
-                if (count($subParser->errors)) {
+                if ($subParser->errors !== []) {
                     foreach ($subParser->errors as $error) {
                         $parser->errors[] = $error;
                     }

--- a/src/Utils/CLI.php
+++ b/src/Utils/CLI.php
@@ -8,7 +8,6 @@ use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Lexer;
 use PhpMyAdmin\SqlParser\Parser;
 
-use function count;
 use function getopt;
 use function implode;
 use function in_array;
@@ -189,7 +188,7 @@ class CLI
             $lexer = new Lexer($params['q'], false);
             $parser = new Parser($lexer->list);
             $errors = Error::get([$lexer, $parser]);
-            if (count($errors) === 0) {
+            if ($errors === []) {
                 return 0;
             }
 

--- a/src/Utils/Error.php
+++ b/src/Utils/Error.php
@@ -75,8 +75,8 @@ class Error
      * @return string[]
      */
     public static function format(
-        $errors,
-        $format = '#%1$d: %2$s (near "%4$s" at position %5$d)'
+        array $errors,
+        string $format = '#%1$d: %2$s (near "%4$s" at position %5$d)'
     ): array {
         $ret = [];
 


### PR DESCRIPTION
We know that `count()` accepts only `countable` types, so I quickly verified where `count` is used only with arrays and added proper native type. 