### PR TITLE
Strict array type

### DIFF
--- a/src/Components/ArrayObj.php
+++ b/src/Components/ArrayObj.php
@@ -24,14 +24,14 @@ final class ArrayObj implements Component
      *
      * @var string[]
      */
-    public $raw = [];
+    public array $raw = [];
 
     /**
      * The array that contains the processed value of each token.
      *
      * @var string[]
      */
-    public $values = [];
+    public array $values = [];
 
     /**
      * @param string[] $raw    the unprocessed values
@@ -168,7 +168,7 @@ final class ArrayObj implements Component
             return implode(', ', $component);
         }
 
-        if (! empty($component->raw)) {
+        if ($component->raw !== []) {
             return '(' . implode(', ', $component->raw) . ')';
         }
 

--- a/src/Components/DataType.php
+++ b/src/Components/DataType.php
@@ -63,7 +63,7 @@ final class DataType implements Component
      *
      * @var int[]|string[]
      */
-    public $parameters = [];
+    public array $parameters = [];
 
     /**
      * The options of this data type.
@@ -162,7 +162,7 @@ final class DataType implements Component
             $component->name : strtolower($component->name);
 
         $parameters = '';
-        if (! empty($component->parameters)) {
+        if ($component->parameters !== []) {
             $parameters = '(' . implode(',', $component->parameters) . ')';
         }
 

--- a/src/Components/Key.php
+++ b/src/Components/Key.php
@@ -198,7 +198,7 @@ final class Key implements Component
                         $state = 3;
                     } elseif (($token->value === ',') || ($token->value === ')')) {
                         $state = $token->value === ',' ? 2 : 4;
-                        if (! empty($lastColumn)) {
+                        if ($lastColumn !== []) {
                             $ret->columns[] = $lastColumn;
                             $lastColumn = [];
                         }

--- a/src/Statements/SelectStatement.php
+++ b/src/Statements/SelectStatement.php
@@ -236,14 +236,14 @@ class SelectStatement extends Statement
      *
      * @var Expression[]
      */
-    public $expr = [];
+    public array $expr = [];
 
     /**
      * Tables used as sources for this statement.
      *
      * @var Expression[]
      */
-    public $from = [];
+    public array $from = [];
 
     /**
      * Index hints
@@ -327,7 +327,7 @@ class SelectStatement extends Statement
      *
      * @var SelectStatement[]
      */
-    public $union = [];
+    public array $union = [];
 
     /**
      * The end options of this query.
@@ -349,7 +349,7 @@ class SelectStatement extends Statement
         // This is a cheap fix for `SELECT` statements that contain `UNION`.
         // The `ORDER BY` and `LIMIT` clauses should be at the end of the
         // statement.
-        if (! empty($this->union)) {
+        if ($this->union !== []) {
             $clauses = static::$clauses;
             unset($clauses['ORDER BY'], $clauses['LIMIT']);
             $clauses['ORDER BY'] = [
@@ -376,7 +376,7 @@ class SelectStatement extends Statement
      */
     public function getAliases(string $database): array
     {
-        if (empty($this->expr) || empty($this->from)) {
+        if ($this->expr === [] || $this->from === []) {
             return [];
         }
 

--- a/src/TokensList.php
+++ b/src/TokensList.php
@@ -47,7 +47,7 @@ class TokensList implements ArrayAccess
      */
     public function __construct(array $tokens = [], $count = -1)
     {
-        if (empty($tokens)) {
+        if ($tokens === []) {
             return;
         }
 

--- a/src/Utils/Query.php
+++ b/src/Utils/Query.php
@@ -287,12 +287,12 @@ class Query
      * @return array<string, bool|string>
      * @psalm-return QueryFlagsType
      */
-    private static function getFlagsSelect($statement, $flags)
+    private static function getFlagsSelect(SelectStatement $statement, $flags)
     {
         $flags['querytype'] = 'SELECT';
         $flags['is_select'] = true;
 
-        if (! empty($statement->from)) {
+        if ($statement->from !== []) {
             $flags['select_from'] = true;
         }
 
@@ -343,7 +343,7 @@ class Query
             $flags['having'] = true;
         }
 
-        if (! empty($statement->union)) {
+        if ($statement->union !== []) {
             $flags['union'] = true;
         }
 


### PR DESCRIPTION
When we know that it's always expected to be an array, we can specify native type and use strict checking instead of loose `empty`