### PR TITLE
Restrict param type of OptionsArray::merge

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -493,9 +493,6 @@
       <code><![CDATA[! empty($option['equals']) && $option['equals']]]></code>
       <code><![CDATA[$option['equals']]]></code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType>
-      <code>$options instanceof self</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Components/OrderKeyword.php">
     <MoreSpecificImplementedParamType>

--- a/src/Components/OptionsArray.php
+++ b/src/Components/OptionsArray.php
@@ -351,16 +351,10 @@ final class OptionsArray implements Component
     /**
      * Merges the specified options with these ones. Values with same ID will be
      * replaced.
-     *
-     * @param array<int, mixed>|OptionsArray $options the options to be merged
      */
-    public function merge($options): void
+    public function merge(OptionsArray $options): void
     {
-        if (is_array($options)) {
-            $this->options = array_merge_recursive($this->options, $options);
-        } elseif ($options instanceof self) {
-            $this->options = array_merge_recursive($this->options, $options->options);
-        }
+        $this->options = array_merge_recursive($this->options, $options->options);
     }
 
     /**

--- a/src/Components/OptionsArray.php
+++ b/src/Components/OptionsArray.php
@@ -25,20 +25,12 @@ use function strtoupper;
 final class OptionsArray implements Component
 {
     /**
-     * ArrayObj of selected options.
-     *
-     * @var array<int, mixed>
-     */
-    public array $options = [];
-
-    /**
      * @param array<int, mixed> $options The array of options. Options that have a value
      *                       must be an array with at least two keys `name` and
      *                       `expr` or `value`.
      */
-    public function __construct(array $options = [])
+    public function __construct(public array $options = [])
     {
-        $this->options = $options;
     }
 
     /**

--- a/tests/Components/OptionsArrayTest.php
+++ b/tests/Components/OptionsArrayTest.php
@@ -109,7 +109,7 @@ class OptionsArrayTest extends TestCase
     public function testMerge(): void
     {
         $component = new OptionsArray(['a']);
-        $component->merge(['b', 'c']);
+        $component->merge(new OptionsArray(['b', 'c']));
         $this->assertEquals($component->options, ['a', 'b', 'c']);
     }
 


### PR DESCRIPTION
We have no need to allow this method to take an array. Even upstream PMA doesn't use this method. 