### PR TITLE
Drop USE_UTF_STRINGS constant

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,5 +12,3 @@ parameters:
     reportUnmatchedIgnoredErrors: true
     excludePaths:
         - tools/doctum-config.php
-    dynamicConstantNames:
-        - USE_UTF_STRINGS

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4841,9 +4841,6 @@
       <code>parseOperator</code>
       <code>parseSymbol</code>
     </PossiblyUnusedMethod>
-    <RedundantCondition>
-      <code>USE_UTF_STRINGS</code>
-    </RedundantCondition>
   </file>
   <file src="src/Parser.php">
     <InvalidPropertyAssignmentValue>

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -6,29 +6,12 @@ namespace PhpMyAdmin\SqlParser;
 
 use PhpMyAdmin\SqlParser\Exceptions\LexerException;
 
-use function define;
-use function defined;
 use function in_array;
 use function mb_strlen;
 use function sprintf;
 use function str_ends_with;
 use function strlen;
 use function substr;
-
-if (! defined('USE_UTF_STRINGS')) {
-    // NOTE: In previous versions of PHP (5.5 and older) the default
-    // internal encoding is "ISO-8859-1".
-    // All `mb_` functions must specify the correct encoding, which is
-    // 'UTF-8' in order to work properly.
-
-    /*
-     * Forces usage of `UtfString` if the string is multibyte.
-     * `UtfString` may be slower, but it gives better results.
-     *
-     * @var bool
-     */
-    define('USE_UTF_STRINGS', true);
-}
 
 /**
  * Defines the lexer of the library.
@@ -199,9 +182,8 @@ class Lexer extends Core
         // parse each byte of the input.
         $len = $str instanceof UtfString ? $str->length() : strlen($str);
 
-        // For multi-byte strings, a new instance of `UtfString` is
-        // initialized (only if `UtfString` usage is forced.
-        if (! $str instanceof UtfString && USE_UTF_STRINGS && $len !== mb_strlen($str, 'UTF-8')) {
+        // For multi-byte strings, a new instance of `UtfString` is initialized.
+        if (! $str instanceof UtfString && $len !== mb_strlen($str, 'UTF-8')) {
             $str = new UtfString($str);
         }
 


### PR DESCRIPTION
The days of PHP 5.5 are long gone. A constant by its definition should never change value. I assume it was meant to be a config option, but of course we don't expect anyone to change some obscure line of code. So let's remove this code as it serves no purpose anymore. 