### PR TITLE
Fix build method param types

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1051,11 +1051,6 @@ parameters:
 			path: tests/Parser/SelectStatementTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$component of static method PhpMyAdmin\\\\SqlParser\\\\Components\\\\WithKeyword\\:\\:build\\(\\) expects PhpMyAdmin\\\\SqlParser\\\\Components\\\\WithKeyword, stdClass given\\.$#"
-			count: 1
-			path: tests/Parser/WithStatementTest.php
-
-		-
 			message: "#^Parameter \\#2 \\$list of static method PhpMyAdmin\\\\SqlParser\\\\Utils\\\\Query\\:\\:getClause\\(\\) expects PhpMyAdmin\\\\SqlParser\\\\TokensList, PhpMyAdmin\\\\SqlParser\\\\TokensList\\|null given\\.$#"
 			count: 9
 			path: tests/Utils/QueryTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -76,16 +76,6 @@ parameters:
 			path: src/Components/CaseExpression.php
 
 		-
-			message: "#^Parameter \\#1 \\$component of static method PhpMyAdmin\\\\SqlParser\\\\Components\\\\Condition\\:\\:build\\(\\) expects array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\Condition\\>, \\$this\\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\Condition\\) given\\.$#"
-			count: 1
-			path: src/Components/Condition.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: src/Components/Condition.php
-
-		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\CreateDefinition\\:\\:\\$name \\(string\\|null\\) does not accept mixed\\.$#"
 			count: 2
 			path: src/Components/CreateDefinition.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -806,6 +806,11 @@ parameters:
 			path: src/Utils/Formatter.php
 
 		-
+			message: "#^Binary operation \"&\" between int and int\\|string results in an error\\.$#"
+			count: 1
+			path: src/Utils/Formatter.php
+
+		-
 			message: "#^Binary operation \"&\\=\" between array\\<int, array\\<string, int\\|string\\>\\>\\|bool\\|string\\|null and array\\<int, array\\<string, int\\|string\\>\\>\\|bool\\|string\\|null results in an error\\.$#"
 			count: 1
 			path: src/Utils/Formatter.php
@@ -831,22 +836,17 @@ parameters:
 			path: src/Utils/Formatter.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$alias\\.$#"
+			message: "#^Trying to invoke int\\<min, \\-1\\>\\|int\\<1, max\\>\\|non\\-falsy\\-string but it might not be a callable\\.$#"
 			count: 1
-			path: src/Utils/Query.php
+			path: src/Utils/Formatter.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$expr\\.$#"
+			message: "#^Argument of an invalid type array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|string\\|null\\>\\|null supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Utils/Query.php
 
 		-
 			message: "#^Argument of an invalid type array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\RenameOperation\\>\\|null supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: src/Utils/Query.php
-
-		-
-			message: "#^Argument of an invalid type array\\|null supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Utils/Query.php
 
@@ -867,11 +867,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Utils\\\\Query\\:\\:getClauseStartOffset\\(\\) should return int but returns int\\|null\\.$#"
-			count: 1
-			path: src/Utils/Query.php
-
-		-
-			message: "#^Parameter \\#1 \\$component of static method PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\:\\:build\\(\\) expects array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression, object given\\.$#"
 			count: 1
 			path: src/Utils/Query.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -336,11 +336,6 @@ parameters:
 			path: src/Components/OrderKeyword.php
 
 		-
-			message: "#^Parameter \\#1 \\$component of static method PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\:\\:build\\(\\) expects array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\>, \\$this\\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\) given\\.$#"
-			count: 1
-			path: src/Components/ParameterDefinition.php
-
-		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\:\\:\\$inOut \\(string\\) does not accept string\\|null\\.$#"
 			count: 1
 			path: src/Components/ParameterDefinition.php
@@ -363,11 +358,6 @@ parameters:
 		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\:\\:\\$type \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\DataType\\) does not accept PhpMyAdmin\\\\SqlParser\\\\Components\\\\DataType\\|null\\.$#"
 			count: 2
-			path: src/Components/ParameterDefinition.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
 			path: src/Components/ParameterDefinition.php
 
 		-
@@ -596,7 +586,7 @@ parameters:
 			path: src/Statements/CreateStatement.php
 
 		-
-			message: "#^Parameter \\#1 \\$component of static method PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\:\\:build\\(\\) expects array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\>, array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\>\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$component of static method PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\:\\:build\\(\\) expects array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition, array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\>\\|null given\\.$#"
 			count: 1
 			path: src/Statements/CreateStatement.php
 
@@ -961,7 +951,7 @@ parameters:
 			path: tests/Builder/CreateStatementTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$component of static method PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\:\\:build\\(\\) expects array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\>, array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\>\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$component of static method PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\:\\:build\\(\\) expects array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition, array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\>\\|null given\\.$#"
 			count: 2
 			path: tests/Builder/CreateStatementTest.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1628,11 +1628,6 @@
       <code>has</code>
     </PossiblyNullReference>
   </file>
-  <file src="tests/Parser/WithStatementTest.php">
-    <InvalidArgument>
-      <code>new stdClass()</code>
-    </InvalidArgument>
-  </file>
   <file src="tests/TestCase.php">
     <InvalidReturnStatement>
       <code>$data</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -485,24 +485,9 @@
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="src/Components/ParameterDefinition.php">
-    <InvalidArgument>
-      <code>$this</code>
-    </InvalidArgument>
-    <MixedArgument>
-      <code><![CDATA[$component->name]]></code>
-    </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$expr->name]]></code>
     </MixedAssignment>
-    <MixedOperand>
-      <code><![CDATA[$component->inOut]]></code>
-      <code><![CDATA[$component->type]]></code>
-    </MixedOperand>
-    <MixedPropertyFetch>
-      <code><![CDATA[$component->inOut]]></code>
-      <code><![CDATA[$component->name]]></code>
-      <code><![CDATA[$component->type]]></code>
-    </MixedPropertyFetch>
     <MoreSpecificImplementedParamType>
       <code>$component</code>
     </MoreSpecificImplementedParamType>
@@ -513,7 +498,6 @@
       <code>DataType::parse($parser, $list)</code>
     </PossiblyNullPropertyAssignmentValue>
     <RedundantConditionGivenDocblockType>
-      <code>is_array($component)</code>
       <code><![CDATA[isset($expr->name)]]></code>
     </RedundantConditionGivenDocblockType>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -128,30 +128,15 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Components/Condition.php">
-    <InvalidArgument>
-      <code>$this</code>
-    </InvalidArgument>
     <MixedArrayOffset>
       <code><![CDATA[static::$allowedKeywords[$token->value]]]></code>
     </MixedArrayOffset>
-    <MixedInferredReturnType>
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedPropertyFetch>
-      <code><![CDATA[$component->expr]]></code>
-    </MixedPropertyFetch>
-    <MixedReturnStatement>
-      <code><![CDATA[$component->expr]]></code>
-    </MixedReturnStatement>
     <MoreSpecificImplementedParamType>
       <code>$component</code>
     </MoreSpecificImplementedParamType>
     <PossiblyUnusedProperty>
       <code>$isOperator</code>
     </PossiblyUnusedProperty>
-    <RedundantConditionGivenDocblockType>
-      <code>is_array($component)</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Components/CreateDefinition.php">
     <MixedAssignment>

--- a/src/Components/Condition.php
+++ b/src/Components/Condition.php
@@ -221,7 +221,7 @@ final class Condition implements Component
     }
 
     /**
-     * @param Condition[] $component the component to be built
+     * @param Condition[]|Condition $component the component to be built
      */
     public static function build($component): string
     {

--- a/src/Components/ParameterDefinition.php
+++ b/src/Components/ParameterDefinition.php
@@ -141,7 +141,7 @@ final class ParameterDefinition implements Component
     }
 
     /**
-     * @param ParameterDefinition[] $component the component to be built
+     * @param ParameterDefinition[]|ParameterDefinition $component the component to be built
      */
     public static function build($component): string
     {

--- a/src/Components/WithKeyword.php
+++ b/src/Components/WithKeyword.php
@@ -50,10 +50,6 @@ final class WithKeyword implements Component
      */
     public static function build($component): string
     {
-        if (! $component instanceof WithKeyword) {
-            throw new RuntimeException('Can not build a component that is not a WithKeyword');
-        }
-
         if (! isset($component->statement)) {
             throw new RuntimeException('No statement inside WITH');
         }

--- a/tests/Parser/WithStatementTest.php
+++ b/tests/Parser/WithStatementTest.php
@@ -8,7 +8,6 @@ use PhpMyAdmin\SqlParser\Components\WithKeyword;
 use PhpMyAdmin\SqlParser\Lexer;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
-use stdClass;
 
 class WithStatementTest extends TestCase
 {
@@ -132,12 +131,6 @@ SQL;
         $parser = new Parser($lexer->list);
         $parserErrors = $this->getErrorsAsArray($parser);
         $this->assertEquals($parserErrors[0][0], 'A closing bracket was expected.');
-    }
-
-    public function testBuildWrongWithKeyword(): void
-    {
-        $this->expectExceptionMessage('Can not build a component that is not a WithKeyword');
-        WithKeyword::build(new stdClass());
     }
 
     public function testBuildBadWithKeyword(): void


### PR DESCRIPTION
This is broken polymorphism as the type breaks contravariance. Actually, this method seems to break every rule of OOP. So this is just a small bandaid over the larger issue, which requires a little bit more work. 