### PR TITLE
Drop $options param from Component::build

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -32,8 +32,7 @@ interface Component extends Stringable
      *
      * In other words, this function represents the inverse function of {@see Component::parse()}.
      *
-     * @param mixed                $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param mixed $component the component to be built
      */
-    public static function build($component, array $options = []): string;
+    public static function build($component): string;
 }

--- a/src/Components/AlterOperation.php
+++ b/src/Components/AlterOperation.php
@@ -520,10 +520,9 @@ final class AlterOperation implements Component
     }
 
     /**
-     * @param AlterOperation       $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param AlterOperation $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         // Specific case of RENAME COLUMN that insert the field between 2 options.
         $afterFieldsOptions = new OptionsArray();

--- a/src/Components/Array2d.php
+++ b/src/Components/Array2d.php
@@ -112,10 +112,9 @@ final class Array2d implements Component
     }
 
     /**
-     * @param ArrayObj[]           $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param ArrayObj[] $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         return ArrayObj::build($component);
     }

--- a/src/Components/ArrayObj.php
+++ b/src/Components/ArrayObj.php
@@ -159,10 +159,9 @@ final class ArrayObj implements Component
     }
 
     /**
-     * @param ArrayObj|ArrayObj[]  $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param ArrayObj|ArrayObj[] $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (is_array($component)) {
             return implode(', ', $component);

--- a/src/Components/CaseExpression.php
+++ b/src/Components/CaseExpression.php
@@ -253,10 +253,9 @@ final class CaseExpression implements Component
     }
 
     /**
-     * @param CaseExpression       $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param CaseExpression $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         $ret = 'CASE ';
         if (isset($component->value)) {

--- a/src/Components/Condition.php
+++ b/src/Components/Condition.php
@@ -221,10 +221,9 @@ final class Condition implements Component
     }
 
     /**
-     * @param Condition[]          $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param Condition[] $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (is_array($component)) {
             return implode(' ', $component);

--- a/src/Components/CreateDefinition.php
+++ b/src/Components/CreateDefinition.php
@@ -319,9 +319,8 @@ final class CreateDefinition implements Component
 
     /**
      * @param CreateDefinition|CreateDefinition[] $component the component to be built
-     * @param array<string, mixed>                $options   parameters for building
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (is_array($component)) {
             return "(\n  " . implode(",\n  ", $component) . "\n)";
@@ -338,10 +337,8 @@ final class CreateDefinition implements Component
         }
 
         if (! empty($component->type)) {
-            $tmp .= DataType::build(
-                $component->type,
-                ['lowercase' => true]
-            ) . ' ';
+            $component->type->lowercase = true;
+            $tmp .= DataType::build($component->type) . ' ';
         }
 
         if (! empty($component->key)) {

--- a/src/Components/DataType.php
+++ b/src/Components/DataType.php
@@ -72,6 +72,8 @@ final class DataType implements Component
      */
     public $options;
 
+    public bool $lowercase = false;
+
     /**
      * @param string         $name       the name of this data type
      * @param int[]|string[] $parameters the parameters (size or possible values)
@@ -153,13 +155,11 @@ final class DataType implements Component
     }
 
     /**
-     * @param DataType             $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param DataType $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
-        $name = empty($options['lowercase']) ?
-            $component->name : strtolower($component->name);
+        $name = $component->lowercase ? strtolower($component->name) : $component->name;
 
         $parameters = '';
         if ($component->parameters !== []) {

--- a/src/Components/Expression.php
+++ b/src/Components/Expression.php
@@ -448,9 +448,8 @@ final class Expression implements Component
 
     /**
      * @param Expression|Expression[] $component the component to be built
-     * @param array<string, mixed>    $options   parameters for building
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (is_array($component)) {
             return implode(', ', $component);

--- a/src/Components/ExpressionArray.php
+++ b/src/Components/ExpressionArray.php
@@ -117,10 +117,9 @@ final class ExpressionArray implements Component
     }
 
     /**
-     * @param Expression[]         $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param Expression[] $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         $ret = [];
         foreach ($component as $frag) {

--- a/src/Components/FunctionCall.php
+++ b/src/Components/FunctionCall.php
@@ -103,10 +103,9 @@ final class FunctionCall implements Component
     }
 
     /**
-     * @param FunctionCall         $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param FunctionCall $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         return $component->name . $component->parameters;
     }

--- a/src/Components/GroupKeyword.php
+++ b/src/Components/GroupKeyword.php
@@ -113,9 +113,8 @@ final class GroupKeyword implements Component
 
     /**
      * @param GroupKeyword|GroupKeyword[] $component the component to be built
-     * @param array<string, mixed>        $options   parameters for building
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (is_array($component)) {
             return implode(', ', $component);

--- a/src/Components/IndexHint.php
+++ b/src/Components/IndexHint.php
@@ -179,9 +179,8 @@ final class IndexHint implements Component
 
     /**
      * @param IndexHint|IndexHint[] $component the component to be built
-     * @param array<string, mixed>  $options   parameters for building
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (is_array($component)) {
             return implode(' ', $component);

--- a/src/Components/IntoKeyword.php
+++ b/src/Components/IntoKeyword.php
@@ -259,10 +259,9 @@ final class IntoKeyword implements Component
     }
 
     /**
-     * @param IntoKeyword          $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param IntoKeyword $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if ($component->dest instanceof Expression) {
             $columns = ! empty($component->columns) ? '(`' . implode('`, `', $component->columns) . '`)' : '';
@@ -282,7 +281,7 @@ final class IntoKeyword implements Component
             $ret .= ' ' . $fieldsOptionsString;
         }
 
-        $linesOptionsString = OptionsArray::build($component->linesOptions, ['expr' => true]);
+        $linesOptionsString = OptionsArray::build($component->linesOptions);
         if (trim($linesOptionsString) !== '') {
             $ret .= ' LINES ' . $linesOptionsString;
         }

--- a/src/Components/JoinKeyword.php
+++ b/src/Components/JoinKeyword.php
@@ -198,10 +198,9 @@ final class JoinKeyword implements Component
     }
 
     /**
-     * @param JoinKeyword[]        $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param JoinKeyword[] $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         $ret = [];
         foreach ($component as $c) {

--- a/src/Components/Key.php
+++ b/src/Components/Key.php
@@ -264,10 +264,9 @@ final class Key implements Component
     }
 
     /**
-     * @param Key                  $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param Key $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         $ret = $component->type . ' ';
         if (! empty($component->name)) {

--- a/src/Components/Limit.php
+++ b/src/Components/Limit.php
@@ -109,10 +109,9 @@ final class Limit implements Component
     }
 
     /**
-     * @param Limit                $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param Limit $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         return $component->offset . ', ' . $component->rowCount;
     }

--- a/src/Components/LockExpression.php
+++ b/src/Components/LockExpression.php
@@ -96,9 +96,8 @@ final class LockExpression implements Component
 
     /**
      * @param LockExpression|LockExpression[] $component the component to be built
-     * @param array<string, mixed>            $options   parameters for building
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (is_array($component)) {
             return implode(', ', $component);

--- a/src/Components/OptionsArray.php
+++ b/src/Components/OptionsArray.php
@@ -275,10 +275,9 @@ final class OptionsArray implements Component
     }
 
     /**
-     * @param OptionsArray         $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param OptionsArray $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (empty($component->options)) {
             return '';

--- a/src/Components/OrderKeyword.php
+++ b/src/Components/OrderKeyword.php
@@ -118,9 +118,8 @@ final class OrderKeyword implements Component
 
     /**
      * @param OrderKeyword|OrderKeyword[] $component the component to be built
-     * @param array<string, mixed>        $options   parameters for building
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (is_array($component)) {
             return implode(', ', $component);

--- a/src/Components/ParameterDefinition.php
+++ b/src/Components/ParameterDefinition.php
@@ -142,9 +142,8 @@ final class ParameterDefinition implements Component
 
     /**
      * @param ParameterDefinition[] $component the component to be built
-     * @param array<string, mixed>  $options   parameters for building
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (is_array($component)) {
             return '(' . implode(', ', $component) . ')';

--- a/src/Components/PartitionDefinition.php
+++ b/src/Components/PartitionDefinition.php
@@ -225,9 +225,8 @@ final class PartitionDefinition implements Component
 
     /**
      * @param PartitionDefinition|PartitionDefinition[] $component the component to be built
-     * @param array<string, mixed>                      $options   parameters for building
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (is_array($component)) {
             return "(\n" . implode(",\n", $component) . "\n)";

--- a/src/Components/Reference.php
+++ b/src/Components/Reference.php
@@ -140,10 +140,9 @@ final class Reference implements Component
     }
 
     /**
-     * @param Reference            $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param Reference $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         return trim(
             $component->table

--- a/src/Components/RenameOperation.php
+++ b/src/Components/RenameOperation.php
@@ -149,10 +149,9 @@ final class RenameOperation implements Component
     }
 
     /**
-     * @param RenameOperation      $component the component to be built
-     * @param array<string, mixed> $options   parameters for building
+     * @param RenameOperation $component the component to be built
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (is_array($component)) {
             return implode(', ', $component);

--- a/src/Components/SetOperation.php
+++ b/src/Components/SetOperation.php
@@ -141,9 +141,8 @@ final class SetOperation implements Component
 
     /**
      * @param SetOperation|SetOperation[] $component the component to be built
-     * @param array<string, mixed>        $options   parameters for building
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (is_array($component)) {
             return implode(', ', $component);

--- a/src/Components/UnionKeyword.php
+++ b/src/Components/UnionKeyword.php
@@ -35,9 +35,8 @@ final class UnionKeyword implements Component
 
     /**
      * @param array<UnionKeyword[]> $component the component to be built
-     * @param array<string, mixed>  $options   parameters for building
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         $tmp = [];
         foreach ($component as $componentPart) {

--- a/src/Components/WithKeyword.php
+++ b/src/Components/WithKeyword.php
@@ -46,10 +46,9 @@ final class WithKeyword implements Component
     }
 
     /**
-     * @param WithKeyword          $component
-     * @param array<string, mixed> $options
+     * @param WithKeyword $component
      */
-    public static function build($component, array $options = []): string
+    public static function build($component): string
     {
         if (! $component instanceof WithKeyword) {
             throw new RuntimeException('Can not build a component that is not a WithKeyword');


### PR DESCRIPTION
Only `DataType` was using it. `OptionsArray` pretended to use it, but it didn't. This can be easily achieved with a public mutable property. 