### PR TITLE
Reset sql mode after context tests

### DIFF
--- a/tests/Lexer/ContextTest.php
+++ b/tests/Lexer/ContextTest.php
@@ -11,6 +11,11 @@ use function class_exists;
 
 class ContextTest extends TestCase
 {
+    public static function tearDownAfterClass(): void
+    {
+        Context::setMode();
+    }
+
     public function testLoad(): void
     {
         // Default context is 5.7.0.


### PR DESCRIPTION
Some tests failed with this seed:
`composer phpunit -- --random-order-seed=1690673874`