### PR TITLE
Use PHPUnit attributes over annotations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheDirectory="build/.phpunit.cache"
          executionOrder="random"
@@ -36,10 +36,12 @@
         </testsuite>
     </testsuites>
 
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
+    </source>
+    <coverage>
         <report>
             <clover outputFile="build/logs/clover.xml"/>
             <xml outputDirectory="build/logs/coverage-xml"/>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
+<files psalm-version="5.14.1@b9d355e0829c397b9b3b47d0c0ed042a8a70284d">
   <file src="src/Components/AlterOperation.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$component->partitions]]></code>
@@ -1481,6 +1481,11 @@
       <code><![CDATA[$list->tokens]]></code>
     </UndefinedPropertyFetch>
   </file>
+  <file src="tests/Builder/AlterStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>provideBuilderForRenameColumn</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="tests/Builder/CreateStatementTest.php">
     <PossiblyInvalidArgument>
       <code><![CDATA[$stmt->fields]]></code>
@@ -1498,8 +1503,19 @@
       <code>isEmpty</code>
       <code>isEmpty</code>
     </PossiblyNullReference>
+    <PossiblyUnusedMethod>
+      <code>partitionQueriesProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Builder/StatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>getAliasesProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="tests/Components/ArrayObjTest.php">
+    <PossiblyUnusedMethod>
+      <code>parseProvider</code>
+    </PossiblyUnusedMethod>
     <UndefinedMethod>
       <code>$components</code>
       <code>$components</code>
@@ -1564,6 +1580,15 @@
       <code><![CDATA[$component->table]]></code>
       <code><![CDATA[$component->table]]></code>
     </PossiblyNullPropertyFetch>
+    <PossiblyUnusedMethod>
+      <code>mysqlCommandsProvider</code>
+      <code>parseErrProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Components/GroupKeywordTest.php">
+    <PossiblyUnusedMethod>
+      <code>provideExpressions</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="tests/Components/JoinKeywordTest.php">
     <DocblockTypeContradiction>
@@ -1578,7 +1603,15 @@
       <code>assertNull</code>
     </DocblockTypeContradiction>
   </file>
+  <file src="tests/Components/LimitTest.php">
+    <PossiblyUnusedMethod>
+      <code>parseProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="tests/Components/LockExpressionTest.php">
+    <PossiblyUnusedMethod>
+      <code>parseErrProvider</code>
+    </PossiblyUnusedMethod>
     <RedundantConditionGivenDocblockType>
       <code>assertNotNull</code>
       <code>assertNotNull</code>
@@ -1595,10 +1628,85 @@
       <code>$component</code>
     </InvalidArgument>
   </file>
+  <file src="tests/Lexer/ContextTest.php">
+    <PossiblyUnusedMethod>
+      <code>contextLoadingProvider</code>
+      <code>contextNamesProvider</code>
+      <code>providerForTestMode</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Lexer/LexerTest.php">
+    <PossiblyUnusedMethod>
+      <code>lexProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Misc/BugsTest.php">
+    <PossiblyUnusedMethod>
+      <code>bugProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Misc/ParameterTest.php">
+    <PossiblyUnusedMethod>
+      <code>parameterProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Misc/UtfStringTest.php">
+    <PossiblyUnusedMethod>
+      <code>utf8StringsProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/AlterStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>alterProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/AnalyzeStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>analyzeProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/CallStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>callProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/CreateStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>createProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/DeleteStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>deleteProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/DropStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>dropProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/ExplainStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>explainProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/InsertStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>insertProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="tests/Parser/LoadStatementTest.php">
     <PossiblyNullReference>
       <code>has</code>
     </PossiblyNullReference>
+    <PossiblyUnusedMethod>
+      <code>loadProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/LockStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>lockProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="tests/Parser/ParserLongExportsTest.php">
     <MixedAssignment>
@@ -1607,11 +1715,62 @@
     <PossiblyNullIterator>
       <code><![CDATA[$statement->statements]]></code>
     </PossiblyNullIterator>
+    <PossiblyUnusedMethod>
+      <code>exportFileProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/ParserTest.php">
+    <PossiblyUnusedMethod>
+      <code>parseProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/PurgeStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>purgeProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/RenameStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>renameProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/ReplaceStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>replaceProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/RestoreStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>restoreProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="tests/Parser/SelectStatementTest.php">
     <PossiblyNullReference>
       <code>has</code>
     </PossiblyNullReference>
+    <PossiblyUnusedMethod>
+      <code>selectProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/SetStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>setProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/TransactionStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>transactionProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/UpdateStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>updateProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Parser/WithStatementTest.php">
+    <PossiblyUnusedMethod>
+      <code>parseWith</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="tests/TestCase.php">
     <InvalidReturnStatement>
@@ -1635,7 +1794,27 @@
       <code>TestContext</code>
     </UnusedClass>
   </file>
+  <file src="tests/Utils/BufferedQueryTest.php">
+    <PossiblyUnusedMethod>
+      <code>extractProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="tests/Utils/CLITest.php">
+    <PossiblyUnusedMethod>
+      <code>highlightParamsProvider</code>
+      <code>highlightParamsStdInProvider</code>
+      <code>lintParamsProvider</code>
+      <code>lintParamsStdInProvider</code>
+      <code>stdinParamsProvider</code>
+      <code>tokenizeParamsProvider</code>
+      <code>tokenizeParamsStdInProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="tests/Utils/FormatterTest.php">
+    <PossiblyUnusedMethod>
+      <code>formatQueriesProviders</code>
+      <code>mergeFormatsProvider</code>
+    </PossiblyUnusedMethod>
     <UnusedMethodCall>
       <code>setAccessible</code>
     </UnusedMethodCall>
@@ -1659,6 +1838,10 @@
       <code><![CDATA[$parser->list]]></code>
       <code><![CDATA[$parser->list]]></code>
     </PossiblyNullArgument>
+    <PossiblyUnusedMethod>
+      <code>getFlagsProvider</code>
+      <code>getTablesProvider</code>
+    </PossiblyUnusedMethod>
     <UnusedVariable>
       <code>$delimiter</code>
       <code>$delimiter</code>
@@ -1669,6 +1852,11 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$parser->statements[0]]]></code>
     </ArgumentTypeCoercion>
+    <PossiblyUnusedMethod>
+      <code>getParameterProvider</code>
+      <code>getParametersProvider</code>
+      <code>getReturnTypeProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="tests/Utils/TableTest.php">
     <ArgumentTypeCoercion>
@@ -1777,11 +1965,19 @@
      *   expr?: string
      * }>}>]]></code>
     </InvalidReturnType>
+    <PossiblyUnusedMethod>
+      <code>getFieldsProvider</code>
+      <code>getForeignKeysProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="tests/Utils/TokensTest.php">
     <InvalidArgument>
       <code>$find</code>
     </InvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>matchProvider</code>
+      <code>replaceTokensProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="tests/benchmarks/UtfStringBench.php">
     <MissingConstructor>

--- a/tests/Builder/AlterStatementTest.php
+++ b/tests/Builder/AlterStatementTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Builder;
 use Generator;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AlterStatementTest extends TestCase
 {
@@ -184,9 +185,7 @@ class AlterStatementTest extends TestCase
         yield 'Mixed RENAME table + RENAME INDEX + RENAME COLUMNS' => [$query];
     }
 
-    /**
-     * @dataProvider provideBuilderForRenameColumn
-     */
+    #[DataProvider('provideBuilderForRenameColumn')]
     public function testBuilderRenameColumn(string $query): void
     {
         $parser = new Parser($query);

--- a/tests/Builder/CreateStatementTest.php
+++ b/tests/Builder/CreateStatementTest.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statements\CreateStatement;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\TokensList;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CreateStatementTest extends TestCase
 {
@@ -299,9 +300,7 @@ EOT
         ];
     }
 
-    /**
-     * @dataProvider partitionQueriesProvider
-     */
+    #[DataProvider('partitionQueriesProvider')]
     public function testBuilderPartitionsEngine(string $query): void
     {
         $parser = new Parser($query);

--- a/tests/Builder/StatementTest.php
+++ b/tests/Builder/StatementTest.php
@@ -11,6 +11,7 @@ use PhpMyAdmin\SqlParser\Components\OptionsArray;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statements\SelectStatement;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class StatementTest extends TestCase
 {
@@ -46,9 +47,8 @@ class StatementTest extends TestCase
      *   alias: (string|null),
      *   tables: array<string, array{alias: (string|null), columns: array<string, string>}>
      * }> $expected
-     *
-     * @dataProvider getAliasesProvider
      */
+    #[DataProvider('getAliasesProvider')]
     public function testGetAliases(string $query, string $db, array $expected): void
     {
         $parser = new Parser($query);

--- a/tests/Components/ArrayObjTest.php
+++ b/tests/Components/ArrayObjTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\SqlParser\Components\ArrayObj;
 use PhpMyAdmin\SqlParser\Components\Expression;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ArrayObjTest extends TestCase
 {
@@ -39,9 +40,7 @@ class ArrayObjTest extends TestCase
         $this->assertEquals($components[1]->expr, '3 + 4');
     }
 
-    /**
-     * @dataProvider parseProvider
-     */
+    #[DataProvider('parseProvider')]
     public function testParse(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Components/ExpressionTest.php
+++ b/tests/Components/ExpressionTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Components;
 use PhpMyAdmin\SqlParser\Components\Expression;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ExpressionTest extends TestCase
 {
@@ -39,9 +40,7 @@ class ExpressionTest extends TestCase
         $this->assertEquals($component->expr, 'x.id');
     }
 
-    /**
-     * @dataProvider parseErrProvider
-     */
+    #[DataProvider('parseErrProvider')]
     public function testParseErr(string $expr, string $error): void
     {
         $parser = new Parser();
@@ -142,9 +141,7 @@ class ExpressionTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider mysqlCommandsProvider
-     */
+    #[DataProvider('mysqlCommandsProvider')]
     public function testMysqlCommands(string $expr, string $expected): void
     {
         $parser = new Parser($expr, true);

--- a/tests/Components/GroupKeywordTest.php
+++ b/tests/Components/GroupKeywordTest.php
@@ -8,6 +8,7 @@ use Generator;
 use PhpMyAdmin\SqlParser\Components\Expression;
 use PhpMyAdmin\SqlParser\Components\GroupKeyword;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function array_map;
 
@@ -53,9 +54,8 @@ class GroupKeywordTest extends TestCase
 
     /**
      * @param GroupKeyword|array<GroupKeyword> $component
-     *
-     * @dataProvider provideExpressions
      */
+    #[DataProvider('provideExpressions')]
     public function testBuild($component, string $expected): void
     {
         $this->assertSame($expected, GroupKeyword::build($component));

--- a/tests/Components/LimitTest.php
+++ b/tests/Components/LimitTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Components;
 
 use PhpMyAdmin\SqlParser\Components\Limit;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class LimitTest extends TestCase
 {
@@ -21,9 +22,7 @@ class LimitTest extends TestCase
         $this->assertEquals(Limit::build($component), '2, 1');
     }
 
-    /**
-     * @dataProvider parseProvider
-     */
+    #[DataProvider('parseProvider')]
     public function testParse(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Components/LockExpressionTest.php
+++ b/tests/Components/LockExpressionTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Components;
 use PhpMyAdmin\SqlParser\Components\LockExpression;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class LockExpressionTest extends TestCase
 {
@@ -27,9 +28,7 @@ class LockExpressionTest extends TestCase
         $this->assertEquals($component->type, 'LOW_PRIORITY WRITE');
     }
 
-    /**
-     * @dataProvider parseErrProvider
-     */
+    #[DataProvider('parseErrProvider')]
     public function testParseErr(string $expr, string $error): void
     {
         $parser = new Parser();

--- a/tests/Lexer/ContextTest.php
+++ b/tests/Lexer/ContextTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Lexer;
 
 use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function class_exists;
 
@@ -27,9 +28,8 @@ class ContextTest extends TestCase
 
     /**
      * Test for loading closest SQL context
-     *
-     * @dataProvider contextLoadingProvider
      */
+    #[DataProvider('contextLoadingProvider')]
     public function testLoadClosest(string $context, string|null $expected): void
     {
         $this->assertEquals($expected, Context::loadClosest($context));
@@ -80,9 +80,7 @@ class ContextTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider contextNamesProvider
-     */
+    #[DataProvider('contextNamesProvider')]
     public function testLoadAll(string $context): void
     {
         Context::load($context);
@@ -118,9 +116,8 @@ class ContextTest extends TestCase
 
     /**
      * @param int|string $mode
-     *
-     * @dataProvider providerForTestMode
      */
+    #[DataProvider('providerForTestMode')]
     public function testMode($mode, int $expected): void
     {
         Context::setMode($mode);

--- a/tests/Lexer/LexerTest.php
+++ b/tests/Lexer/LexerTest.php
@@ -7,15 +7,16 @@ namespace PhpMyAdmin\SqlParser\Tests\Lexer;
 use PhpMyAdmin\SqlParser\Exceptions\LexerException;
 use PhpMyAdmin\SqlParser\Lexer;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 use function sprintf;
 
 class LexerTest extends TestCase
 {
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testError(): void
     {
         $lexer = new Lexer('');
@@ -48,9 +49,7 @@ class LexerTest extends TestCase
         $lexer->error('strict error', 'foo', 1, 4);
     }
 
-    /**
-     * @dataProvider lexProvider
-     */
+    #[DataProvider('lexProvider')]
     public function testLex(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Misc/BugsTest.php
+++ b/tests/Misc/BugsTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Misc;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BugsTest extends TestCase
 {
-    /**
-     * @dataProvider bugProvider
-     */
+    #[DataProvider('bugProvider')]
     public function testBug(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Misc/ParameterTest.php
+++ b/tests/Misc/ParameterTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Misc;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ParameterTest extends TestCase
 {
-    /**
-     * @dataProvider parameterProvider
-     */
+    #[DataProvider('parameterProvider')]
     public function testParameter(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Misc/UtfStringTest.php
+++ b/tests/Misc/UtfStringTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Misc;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\UtfString;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Throwable;
 
 use function chr;
@@ -83,9 +84,8 @@ class UtfStringTest extends TestCase
 
     /**
      * Test access to string.
-     *
-     * @dataProvider utf8StringsProvider
      */
+    #[DataProvider('utf8StringsProvider')]
     public function testAccess(string $text, string|null $pos10, string|null $pos20): void
     {
         $str = new UtfString($text);

--- a/tests/Parser/AlterStatementTest.php
+++ b/tests/Parser/AlterStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AlterStatementTest extends TestCase
 {
-    /**
-     * @dataProvider alterProvider
-     */
+    #[DataProvider('alterProvider')]
     public function testAlter(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/AnalyzeStatementTest.php
+++ b/tests/Parser/AnalyzeStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AnalyzeStatementTest extends TestCase
 {
-    /**
-     * @dataProvider analyzeProvider
-     */
+    #[DataProvider('analyzeProvider')]
     public function testAnalyze(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/CallStatementTest.php
+++ b/tests/Parser/CallStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CallStatementTest extends TestCase
 {
-    /**
-     * @dataProvider callProvider
-     */
+    #[DataProvider('callProvider')]
     public function testCall(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/CreateStatementTest.php
+++ b/tests/Parser/CreateStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CreateStatementTest extends TestCase
 {
-    /**
-     * @dataProvider createProvider
-     */
+    #[DataProvider('createProvider')]
     public function testCreate(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/DeleteStatementTest.php
+++ b/tests/Parser/DeleteStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DeleteStatementTest extends TestCase
 {
-    /**
-     * @dataProvider deleteProvider
-     */
+    #[DataProvider('deleteProvider')]
     public function testDelete(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/DropStatementTest.php
+++ b/tests/Parser/DropStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DropStatementTest extends TestCase
 {
-    /**
-     * @dataProvider dropProvider
-     */
+    #[DataProvider('dropProvider')]
     public function testDrop(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/ExplainStatementTest.php
+++ b/tests/Parser/ExplainStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ExplainStatementTest extends TestCase
 {
-    /**
-     * @dataProvider explainProvider
-     */
+    #[DataProvider('explainProvider')]
     public function testExplain(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/InsertStatementTest.php
+++ b/tests/Parser/InsertStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class InsertStatementTest extends TestCase
 {
-    /**
-     * @dataProvider insertProvider
-     */
+    #[DataProvider('insertProvider')]
     public function testInsert(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/LoadStatementTest.php
+++ b/tests/Parser/LoadStatementTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class LoadStatementTest extends TestCase
 {
@@ -17,9 +18,7 @@ class LoadStatementTest extends TestCase
         $this->assertEquals(10, $stmt->options->has('CONCURRENT'));
     }
 
-    /**
-     * @dataProvider loadProvider
-     */
+    #[DataProvider('loadProvider')]
     public function testLoad(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/LockStatementTest.php
+++ b/tests/Parser/LockStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class LockStatementTest extends TestCase
 {
-    /**
-     * @dataProvider lockProvider
-     */
+    #[DataProvider('lockProvider')]
     public function testLock(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/ParserLongExportsTest.php
+++ b/tests/Parser/ParserLongExportsTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statements\SetStatement;
 use PhpMyAdmin\SqlParser\Statements\TransactionStatement;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ParserLongExportsTest extends TestCase
 {
@@ -100,9 +101,7 @@ SQL;
         }
     }
 
-    /**
-     * @dataProvider exportFileProvider
-     */
+    #[DataProvider('exportFileProvider')]
     public function testParseExport(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -9,14 +9,15 @@ use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 use function sprintf;
 
 class ParserTest extends TestCase
 {
-    /**
-     * @dataProvider parseProvider
-     */
+    #[DataProvider('parseProvider')]
     public function testParse(string $test): void
     {
         $this->runParserTest($test);
@@ -52,10 +53,8 @@ class ParserTest extends TestCase
         );
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testError(): void
     {
         $parser = new Parser(new TokensList());

--- a/tests/Parser/PurgeStatementTest.php
+++ b/tests/Parser/PurgeStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class PurgeStatementTest extends TestCase
 {
-    /**
-     * @dataProvider purgeProvider
-     */
+    #[DataProvider('purgeProvider')]
     public function testPurge(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/RenameStatementTest.php
+++ b/tests/Parser/RenameStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RenameStatementTest extends TestCase
 {
-    /**
-     * @dataProvider renameProvider
-     */
+    #[DataProvider('renameProvider')]
     public function testRename(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/ReplaceStatementTest.php
+++ b/tests/Parser/ReplaceStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceStatementTest extends TestCase
 {
-    /**
-     * @dataProvider replaceProvider
-     */
+    #[DataProvider('replaceProvider')]
     public function testReplace(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/RestoreStatementTest.php
+++ b/tests/Parser/RestoreStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RestoreStatementTest extends TestCase
 {
-    /**
-     * @dataProvider restoreProvider
-     */
+    #[DataProvider('restoreProvider')]
     public function testRestore(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/SelectStatementTest.php
+++ b/tests/Parser/SelectStatementTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SelectStatementTest extends TestCase
 {
@@ -17,9 +18,7 @@ class SelectStatementTest extends TestCase
         $this->assertEquals(10, $stmt->options->has('MAX_STATEMENT_TIME'));
     }
 
-    /**
-     * @dataProvider selectProvider
-     */
+    #[DataProvider('selectProvider')]
     public function testSelect(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/SetStatementTest.php
+++ b/tests/Parser/SetStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SetStatementTest extends TestCase
 {
-    /**
-     * @dataProvider setProvider
-     */
+    #[DataProvider('setProvider')]
     public function testSet(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/TransactionStatementTest.php
+++ b/tests/Parser/TransactionStatementTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TransactionStatementTest extends TestCase
 {
@@ -20,9 +21,7 @@ class TransactionStatementTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider transactionProvider
-     */
+    #[DataProvider('transactionProvider')]
     public function testTransaction(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/UpdateStatementTest.php
+++ b/tests/Parser/UpdateStatementTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Parser;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UpdateStatementTest extends TestCase
 {
-    /**
-     * @dataProvider updateProvider
-     */
+    #[DataProvider('updateProvider')]
     public function testUpdate(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Parser/WithStatementTest.php
+++ b/tests/Parser/WithStatementTest.php
@@ -8,12 +8,11 @@ use PhpMyAdmin\SqlParser\Components\WithKeyword;
 use PhpMyAdmin\SqlParser\Lexer;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class WithStatementTest extends TestCase
 {
-    /**
-     * @dataProvider parseWith
-     */
+    #[DataProvider('parseWith')]
     public function testParse(string $test): void
     {
         $this->runParserTest($test);

--- a/tests/Utils/BufferedQueryTest.php
+++ b/tests/Utils/BufferedQueryTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Utils;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Utils\BufferedQuery;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function count;
 use function str_split;
@@ -17,9 +18,8 @@ class BufferedQueryTest extends TestCase
      * @param string[]            $expected
      * @psalm-param array{delimiter?: non-empty-string, parse_delimiter?: bool, add_delimiter?: bool} $options
      * @psalm-param positive-int $chunkSize
-     *
-     * @dataProvider extractProvider
      */
+    #[DataProvider('extractProvider')]
     public function testExtract(
         string $query,
         int $chunkSize,

--- a/tests/Utils/CLITest.php
+++ b/tests/Utils/CLITest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Utils;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Utils\CLI;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function dirname;
 use function exec;
@@ -53,9 +54,8 @@ class CLITest extends TestCase
 
     /**
      * @param array<string, bool|string>|false $getopt
-     *
-     * @dataProvider highlightParamsProvider
      */
+    #[DataProvider('highlightParamsProvider')]
     public function testRunHighlight($getopt, string $output, int $result): void
     {
         $cli = $this->getCLI($getopt);
@@ -128,9 +128,8 @@ class CLITest extends TestCase
 
     /**
      * @param array<string, bool|string>|false $getopt
-     *
-     * @dataProvider highlightParamsStdInProvider
      */
+    #[DataProvider('highlightParamsStdInProvider')]
     public function testRunHighlightStdIn(string $input, $getopt, string $output, int $result): void
     {
         $cli = $this->getCLIStdIn($input, $getopt);
@@ -196,9 +195,8 @@ class CLITest extends TestCase
 
     /**
      * @param array<string, bool|string>|false $getopt
-     *
-     * @dataProvider lintParamsStdInProvider
      */
+    #[DataProvider('lintParamsStdInProvider')]
     public function testRunLintFromStdIn(string $input, $getopt, string $output, int $result): void
     {
         $cli = $this->getCLIStdIn($input, $getopt);
@@ -261,9 +259,8 @@ class CLITest extends TestCase
 
     /**
      * @param array<string, bool|string>|false $getopt
-     *
-     * @dataProvider lintParamsProvider
      */
+    #[DataProvider('lintParamsProvider')]
     public function testRunLint($getopt, string $output, int $result): void
     {
         $cli = $this->getCLI($getopt);
@@ -328,9 +325,8 @@ class CLITest extends TestCase
 
     /**
      * @param array<string, bool|string>|false $getopt
-     *
-     * @dataProvider tokenizeParamsProvider
      */
+    #[DataProvider('tokenizeParamsProvider')]
     public function testRunTokenize($getopt, string $output, int $result): void
     {
         $cli = $this->getCLI($getopt);
@@ -383,9 +379,8 @@ class CLITest extends TestCase
 
     /**
      * @param array<string, bool|string>|false $getopt
-     *
-     * @dataProvider tokenizeParamsStdInProvider
      */
+    #[DataProvider('tokenizeParamsStdInProvider')]
     public function testRunTokenizeStdIn(string $input, $getopt, string $output, int $result): void
     {
         $cli = $this->getCLIStdIn($input, $getopt);
@@ -435,9 +430,7 @@ class CLITest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider stdinParamsProvider
-     */
+    #[DataProvider('stdinParamsProvider')]
     public function testStdinPipe(string $cmd, int $result): void
     {
         exec($cmd, $out, $ret);

--- a/tests/Utils/FormatterTest.php
+++ b/tests/Utils/FormatterTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Utils;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Utils\Formatter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
 
 class FormatterTest extends TestCase
@@ -17,9 +18,8 @@ class FormatterTest extends TestCase
      * @psalm-param list<array{type: int, flags: int, html: string, cli: string, function?: string}> $default
      * @psalm-param list<array{type?: int, flags?: int, html?: string, cli?: string, function?: string}> $overriding
      * @psalm-param list<array{type: int, flags: int, html: string, cli: string, function?: string}> $expected
-     *
-     * @dataProvider mergeFormatsProvider
      */
+    #[DataProvider('mergeFormatsProvider')]
     public function testMergeFormats(array $default, array $overriding, array $expected): void
     {
         $formatter = $this->createPartialMock(Formatter::class, ['getDefaultOptions', 'getDefaultFormats']);
@@ -245,9 +245,8 @@ class FormatterTest extends TestCase
 
     /**
      * @param array<string, bool> $options
-     *
-     * @dataProvider formatQueriesProviders
      */
+    #[DataProvider('formatQueriesProviders')]
     public function testFormat(string $query, string $text, string $cli, string $html, array $options = []): void
     {
         // Test TEXT format

--- a/tests/Utils/QueryTest.php
+++ b/tests/Utils/QueryTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Utils;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Utils\Query;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function array_merge;
 
@@ -18,9 +19,8 @@ class QueryTest extends TestCase
     /**
      * @param array<string, bool|string> $expected
      * @psalm-param QueryFlagsType $expected
-     *
-     * @dataProvider getFlagsProvider
      */
+    #[DataProvider('getFlagsProvider')]
     public function testGetFlags(string $query, array $expected): void
     {
         $parser = new Parser($query);
@@ -400,9 +400,8 @@ class QueryTest extends TestCase
 
     /**
      * @param string[] $expected
-     *
-     * @dataProvider getTablesProvider
      */
+    #[DataProvider('getTablesProvider')]
     public function testGetTables(string $query, array $expected): void
     {
         $parser = new Parser($query);

--- a/tests/Utils/RoutineTest.php
+++ b/tests/Utils/RoutineTest.php
@@ -7,14 +7,14 @@ namespace PhpMyAdmin\SqlParser\Tests\Utils;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Utils\Routine;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RoutineTest extends TestCase
 {
     /**
      * @param string[] $expected
-     *
-     * @dataProvider getReturnTypeProvider
      */
+    #[DataProvider('getReturnTypeProvider')]
     public function testGetReturnType(string $def, array $expected): void
     {
         $this->assertEquals($expected, Routine::getReturnType($def));
@@ -112,9 +112,8 @@ class RoutineTest extends TestCase
 
     /**
      * @param string[] $expected
-     *
-     * @dataProvider getParameterProvider
      */
+    #[DataProvider('getParameterProvider')]
     public function testGetParameter(string $def, array $expected): void
     {
         $this->assertEquals($expected, Routine::getParameter($def));
@@ -221,9 +220,8 @@ class RoutineTest extends TestCase
      *   length_arr: string[][],
      *   opts: string[]
      * } $expected
-     *
-     * @dataProvider getParametersProvider
      */
+    #[DataProvider('getParametersProvider')]
     public function testGetParameters(string $query, array $expected): void
     {
         $parser = new Parser($query);

--- a/tests/Utils/TableTest.php
+++ b/tests/Utils/TableTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Utils;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Utils\Table;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TableTest extends TestCase
 {
@@ -21,9 +22,8 @@ class TableTest extends TestCase
      *   on_update: string,
      *   on_delete?: string
      * }> $expected
-     *
-     * @dataProvider getForeignKeysProvider
      */
+    #[DataProvider('getForeignKeysProvider')]
     public function testGetForeignKeys(string $query, array $expected): void
     {
         $parser = new Parser($query);
@@ -146,9 +146,8 @@ class TableTest extends TestCase
      *   on_update_current_timestamp?: bool,
      *   expr?: string
      * }> $expected
-     *
-     * @dataProvider getFieldsProvider
      */
+    #[DataProvider('getFieldsProvider')]
     public function testGetFields(string $query, array $expected): void
     {
         $parser = new Parser($query);

--- a/tests/Utils/TokensTest.php
+++ b/tests/Utils/TokensTest.php
@@ -7,15 +7,15 @@ namespace PhpMyAdmin\SqlParser\Tests\Utils;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\Utils\Tokens;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TokensTest extends TestCase
 {
     /**
      * @param array<string, string>[] $find
      * @param Token[]                 $replace
-     *
-     * @dataProvider replaceTokensProvider
      */
+    #[DataProvider('replaceTokensProvider')]
     public function testReplaceTokens(string $list, array $find, array $replace, string $expected): void
     {
         $this->assertEquals($expected, Tokens::replaceTokens($list, $find, $replace));
@@ -45,9 +45,8 @@ class TokensTest extends TestCase
 
     /**
      * @param array<string, int|string> $pattern
-     *
-     * @dataProvider matchProvider
      */
+    #[DataProvider('matchProvider')]
     public function testMatch(Token $token, array $pattern, bool $expected): void
     {
         $this->assertSame($expected, Tokens::match($token, $pattern));


### PR DESCRIPTION
Since this project is PHPUnit 10, we might as well use the new attributes instead of the annotations