### PR TITLE
Escape identifiers that need it

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -926,16 +926,6 @@ parameters:
 			path: tests/Components/PartitionDefinitionTest.php
 
 		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) with 2 and PhpMyAdmin\\\\SqlParser\\\\TokensList will always evaluate to false\\.$#"
-			count: 1
-			path: tests/Lexer/TokensListTest.php
-
-		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) with 112 and PhpMyAdmin\\\\SqlParser\\\\UtfString will always evaluate to false\\.$#"
-			count: 1
-			path: tests/Misc/UtfStringTest.php
-
-		-
 			message: "#^Cannot call method has\\(\\) on PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
 			count: 1
 			path: tests/Parser/LoadStatementTest.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.14.1@b9d355e0829c397b9b3b47d0c0ed042a8a70284d">
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="src/Components/AlterOperation.php">
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[[

--- a/src/Context.php
+++ b/src/Context.php
@@ -10,6 +10,7 @@ use function in_array;
 use function intval;
 use function is_int;
 use function is_numeric;
+use function preg_match;
 use function str_replace;
 use function str_starts_with;
 use function strlen;
@@ -675,7 +676,11 @@ abstract class Context
      */
     public static function escape(string $str, string $quote = '`')
     {
-        if ((static::$mode & self::SQL_MODE_NO_ENCLOSING_QUOTES) && (! static::isKeyword($str, true))) {
+        if (
+            (static::$mode & self::SQL_MODE_NO_ENCLOSING_QUOTES) && ! (
+                static::isKeyword($str, true) || self::doesIdentifierRequireQuoting($str)
+            )
+        ) {
             return $str;
         }
 
@@ -726,5 +731,10 @@ abstract class Context
         }
 
         return (self::$mode & $flag) === $flag;
+    }
+
+    private static function doesIdentifierRequireQuoting(string $identifier): bool
+    {
+        return preg_match('/^[$]|^\d+$|[^0-9a-zA-Z$_\x80-\xffff]/', $identifier) === 1;
     }
 }

--- a/tests/Lexer/ContextTest.php
+++ b/tests/Lexer/ContextTest.php
@@ -217,6 +217,10 @@ class ContextTest extends TestCase
     {
         Context::setMode(Context::SQL_MODE_NO_ENCLOSING_QUOTES);
         $this->assertEquals('test', Context::escape('test'));
+        $this->assertEquals('`123`', Context::escape('123'));
+        $this->assertEquals('`$test`', Context::escape('$test'));
+        $this->assertEquals('`te st`', Context::escape('te st'));
+        $this->assertEquals('`te.st`', Context::escape('te.st'));
 
         Context::setMode(Context::SQL_MODE_ANSI_QUOTES);
         $this->assertEquals('"test"', Context::escape('test'));


### PR DESCRIPTION
This should prevent more issues with unescaped identifiers. 

Ref https://dev.mysql.com/doc/refman/8.0/en/identifiers.html