### PR TITLE
Introduce the TokenType enum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phpunit/phpunit": "^10.0",
         "psalm/plugin-phpunit": "^0.18.4",
         "vimeo/psalm": "^5.7",
-        "zumba/json-serializer": "^3.0"
+        "zumba/json-serializer": "^3.2"
     },
     "conflict": {
         "phpmyadmin/motranslator": "<5.2"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1260,7 +1260,7 @@
       <code>$i</code>
     </PossiblyNullOperand>
     <PossiblyNullPropertyFetch>
-      <code><![CDATA[$lexer->list->getNextOfType(Token::TYPE_KEYWORD)->keyword]]></code>
+      <code><![CDATA[$lexer->list->getNextOfType(TokenType::Keyword)->keyword]]></code>
       <code><![CDATA[$statement->into->dest]]></code>
     </PossiblyNullPropertyFetch>
     <PossiblyNullReference>

--- a/src/Components/Array2d.php
+++ b/src/Components/Array2d.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 use PhpMyAdmin\SqlParser\Translator;
 use RuntimeException;
 
@@ -58,17 +59,17 @@ final class Array2d implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             // No keyword is expected.
-            if (($token->type === Token::TYPE_KEYWORD) && ($token->flags & Token::FLAG_KEYWORD_RESERVED)) {
+            if (($token->type === TokenType::Keyword) && ($token->flags & Token::FLAG_KEYWORD_RESERVED)) {
                 break;
             }
 

--- a/src/Components/ArrayObj.php
+++ b/src/Components/ArrayObj.php
@@ -6,8 +6,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function strlen;
@@ -88,7 +88,7 @@ final class ArrayObj implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 if ($brackets > 0) {
                     $parser->error('A closing bracket was expected.', $token);
                 }
@@ -97,18 +97,18 @@ final class ArrayObj implements Component
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 $lastRaw .= $token->token;
                 $lastValue = trim($lastValue) . ' ';
                 continue;
             }
 
-            if (($brackets === 0) && (($token->type !== Token::TYPE_OPERATOR) || ($token->value !== '('))) {
+            if (($brackets === 0) && (($token->type !== TokenType::Operator) || ($token->value !== '('))) {
                 $parser->error('An opening bracket was expected.', $token);
                 break;
             }
 
-            if ($token->type === Token::TYPE_OPERATOR) {
+            if ($token->type === TokenType::Operator) {
                 if ($token->value === '(') {
                     if (++$brackets === 1) { // 1 is the base level.
                         continue;

--- a/src/Components/CaseExpression.php
+++ b/src/Components/CaseExpression.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function count;
 
@@ -98,12 +99,12 @@ final class CaseExpression implements Component
             $token = $list->tokens[$list->idx];
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             if ($state === 0) {
-                if ($token->type === Token::TYPE_KEYWORD) {
+                if ($token->type === TokenType::Keyword) {
                     switch ($token->keyword) {
                         case 'WHEN':
                             ++$list->idx; // Skip 'WHEN'
@@ -132,7 +133,7 @@ final class CaseExpression implements Component
                 }
             } elseif ($state === 1) {
                 if ($type === 0) {
-                    if ($token->type === Token::TYPE_KEYWORD) {
+                    if ($token->type === TokenType::Keyword) {
                         switch ($token->keyword) {
                             case 'WHEN':
                                 ++$list->idx; // Skip 'WHEN'
@@ -154,23 +155,23 @@ final class CaseExpression implements Component
                                 break 2;
                         }
                     }
-                } elseif ($token->type === Token::TYPE_KEYWORD && $token->keyword === 'THEN') {
+                } elseif ($token->type === TokenType::Keyword && $token->keyword === 'THEN') {
                     ++$list->idx; // Skip 'THEN'
                     $newResult = Expression::parse($parser, $list);
                     $state = 0;
                     $ret->results[] = $newResult;
-                } elseif ($token->type === Token::TYPE_KEYWORD) {
+                } elseif ($token->type === TokenType::Keyword) {
                     $parser->error('Unexpected keyword.', $token);
                     break;
                 }
             } elseif ($state === 2) {
                 if ($type === 0) {
-                    if ($token->type === Token::TYPE_KEYWORD && $token->keyword === 'THEN') {
+                    if ($token->type === TokenType::Keyword && $token->keyword === 'THEN') {
                         ++$list->idx; // Skip 'THEN'
                         $newResult = Expression::parse($parser, $list);
                         $ret->results[] = $newResult;
                         $state = 1;
-                    } elseif ($token->type === Token::TYPE_KEYWORD) {
+                    } elseif ($token->type === TokenType::Keyword) {
                         $parser->error('Unexpected keyword.', $token);
                         break;
                     }
@@ -187,17 +188,17 @@ final class CaseExpression implements Component
                 $token = $list->tokens[$list->idx];
 
                 // End of statement.
-                if ($token->type === Token::TYPE_DELIMITER) {
+                if ($token->type === TokenType::Delimiter) {
                     break;
                 }
 
                 // Skipping whitespaces and comments.
-                if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+                if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                     continue;
                 }
 
                 // Handle optional AS keyword before alias
-                if ($token->type === Token::TYPE_KEYWORD && $token->keyword === 'AS') {
+                if ($token->type === TokenType::Keyword && $token->keyword === 'AS') {
                     if ($asFound || ! empty($ret->alias)) {
                         $parser->error('Potential duplicate alias of CASE expression.', $token);
                         break;
@@ -209,7 +210,7 @@ final class CaseExpression implements Component
 
                 if (
                     $asFound
-                    && $token->type === Token::TYPE_KEYWORD
+                    && $token->type === TokenType::Keyword
                     && ($token->flags & Token::FLAG_KEYWORD_RESERVED || $token->flags & Token::FLAG_KEYWORD_FUNCTION)
                 ) {
                     $parser->error('An alias expected after AS but got ' . $token->value, $token);
@@ -219,9 +220,9 @@ final class CaseExpression implements Component
 
                 if (
                     $asFound
-                    || $token->type === Token::TYPE_STRING
-                    || ($token->type === Token::TYPE_SYMBOL && ! $token->flags & Token::FLAG_SYMBOL_VARIABLE)
-                    || $token->type === Token::TYPE_NONE
+                    || $token->type === TokenType::String
+                    || ($token->type === TokenType::Symbol && ! $token->flags & Token::FLAG_SYMBOL_VARIABLE)
+                    || $token->type === TokenType::None
                 ) {
                     // An alias is expected (the keyword `AS` was previously found).
                     if (! empty($ret->alias)) {

--- a/src/Components/Condition.php
+++ b/src/Components/Condition.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function in_array;
@@ -122,18 +123,18 @@ final class Condition implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if ($token->type === Token::TYPE_COMMENT) {
+            if ($token->type === TokenType::Comment) {
                 continue;
             }
 
             // Replacing all whitespaces (new lines, tabs, etc.) with a single
             // space character.
-            if ($token->type === Token::TYPE_WHITESPACE) {
+            if ($token->type === TokenType::Whitespace) {
                 $expr->expr .= ' ';
                 continue;
             }
@@ -162,7 +163,7 @@ final class Condition implements Component
             }
 
             if (
-                ($token->type === Token::TYPE_KEYWORD)
+                ($token->type === TokenType::Keyword)
                 && ($token->flags & Token::FLAG_KEYWORD_RESERVED)
                 && ! ($token->flags & Token::FLAG_KEYWORD_FUNCTION)
             ) {
@@ -175,7 +176,7 @@ final class Condition implements Component
                 }
             }
 
-            if ($token->type === Token::TYPE_OPERATOR) {
+            if ($token->type === TokenType::Operator) {
                 if ($token->value === '(') {
                     ++$brackets;
                 } elseif ($token->value === ')') {
@@ -189,11 +190,11 @@ final class Condition implements Component
 
             $expr->expr .= $token->token;
             if (
-                ($token->type !== Token::TYPE_NONE)
-                && (($token->type !== Token::TYPE_KEYWORD)
+                ($token->type !== TokenType::None)
+                && (($token->type !== TokenType::Keyword)
                 || ($token->flags & Token::FLAG_KEYWORD_RESERVED))
-                && ($token->type !== Token::TYPE_STRING)
-                && ($token->type !== Token::TYPE_SYMBOL)
+                && ($token->type !== TokenType::String)
+                && ($token->type !== TokenType::Symbol)
             ) {
                 continue;
             }

--- a/src/Components/CreateDefinition.php
+++ b/src/Components/CreateDefinition.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function trim;
@@ -210,17 +211,17 @@ final class CreateDefinition implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             if ($state === 0) {
-                if (($token->type !== Token::TYPE_OPERATOR) || ($token->value !== '(')) {
+                if (($token->type !== TokenType::Operator) || ($token->value !== '(')) {
                     $parser->error('An opening bracket was expected.', $token);
 
                     break;
@@ -228,17 +229,17 @@ final class CreateDefinition implements Component
 
                 $state = 1;
             } elseif ($state === 1) {
-                if ($token->type === Token::TYPE_KEYWORD && $token->keyword === 'CONSTRAINT') {
+                if ($token->type === TokenType::Keyword && $token->keyword === 'CONSTRAINT') {
                     $expr->isConstraint = true;
-                } elseif (($token->type === Token::TYPE_KEYWORD) && ($token->flags & Token::FLAG_KEYWORD_KEY)) {
+                } elseif (($token->type === TokenType::Keyword) && ($token->flags & Token::FLAG_KEYWORD_KEY)) {
                     $expr->key = Key::parse($parser, $list);
                     $state = 4;
-                } elseif ($token->type === Token::TYPE_SYMBOL || $token->type === Token::TYPE_NONE) {
+                } elseif ($token->type === TokenType::Symbol || $token->type === TokenType::None) {
                     $expr->name = $token->value;
                     if (! $expr->isConstraint) {
                         $state = 2;
                     }
-                } elseif ($token->type === Token::TYPE_KEYWORD) {
+                } elseif ($token->type === TokenType::Keyword) {
                     if ($token->flags & Token::FLAG_KEYWORD_RESERVED) {
                         // Reserved keywords can't be used
                         // as field names without backquotes
@@ -267,7 +268,7 @@ final class CreateDefinition implements Component
                 $expr->options = OptionsArray::parse($parser, $list, self::FIELD_OPTIONS);
                 $state = 4;
             } elseif ($state === 4) {
-                if ($token->type === Token::TYPE_KEYWORD && $token->keyword === 'REFERENCES') {
+                if ($token->type === TokenType::Keyword && $token->keyword === 'REFERENCES') {
                     ++$list->idx; // Skipping keyword 'REFERENCES'.
                     $expr->references = Reference::parse($parser, $list);
                 } else {

--- a/src/Components/DataType.php
+++ b/src/Components/DataType.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function strtolower;
@@ -115,19 +116,19 @@ final class DataType implements Component
             $token = $list->tokens[$list->idx];
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             if ($state === 0) {
                 $ret->name = strtoupper((string) $token->value);
-                if (($token->type !== Token::TYPE_KEYWORD) || (! ($token->flags & Token::FLAG_KEYWORD_DATA_TYPE))) {
+                if (($token->type !== TokenType::Keyword) || (! ($token->flags & Token::FLAG_KEYWORD_DATA_TYPE))) {
                     $parser->error('Unrecognized data type.', $token);
                 }
 
                 $state = 1;
             } elseif ($state === 1) {
-                if (($token->type === Token::TYPE_OPERATOR) && ($token->value === '(')) {
+                if (($token->type === TokenType::Operator) && ($token->value === '(')) {
                     $parameters = ArrayObj::parse($parser, $list);
                     ++$list->idx;
                     $ret->parameters = ($ret->name === 'ENUM') || ($ret->name === 'SET') ?

--- a/src/Components/Expression.php
+++ b/src/Components/Expression.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\SqlParser\Exceptions\ParserException;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function rtrim;
@@ -209,12 +210,12 @@ final class Expression implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 // If the token is a closing C comment from a MySQL command, it must be ignored.
                 if ($isExpr && $token->token !== '*/') {
                     $ret->expr .= $token->token;
@@ -223,7 +224,7 @@ final class Expression implements Component
                 continue;
             }
 
-            if ($token->type === Token::TYPE_KEYWORD) {
+            if ($token->type === TokenType::Keyword) {
                 if (($brackets > 0) && empty($ret->subquery) && ! empty(Parser::STATEMENT_PARSERS[$token->keyword])) {
                     // A `(` was previously found and this keyword is the
                     // beginning of a statement, so this is a subquery.
@@ -273,13 +274,13 @@ final class Expression implements Component
             }
 
             if (
-                ($token->type === Token::TYPE_NUMBER)
-                || ($token->type === Token::TYPE_BOOL)
-                || (($token->type === Token::TYPE_SYMBOL)
+                ($token->type === TokenType::Number)
+                || ($token->type === TokenType::Bool)
+                || (($token->type === TokenType::Symbol)
                 && ($token->flags & Token::FLAG_SYMBOL_VARIABLE))
-                || (($token->type === Token::TYPE_SYMBOL)
+                || (($token->type === TokenType::Symbol)
                 && ($token->flags & Token::FLAG_SYMBOL_PARAMETER))
-                || (($token->type === Token::TYPE_OPERATOR)
+                || (($token->type === TokenType::Operator)
                 && ($token->value !== '.'))
             ) {
                 if (! empty($options['parseField'])) {
@@ -291,7 +292,7 @@ final class Expression implements Component
                 $isExpr = true;
             }
 
-            if ($token->type === Token::TYPE_OPERATOR) {
+            if ($token->type === TokenType::Operator) {
                 if (! empty($options['breakOnParentheses']) && (($token->value === '(') || ($token->value === ')'))) {
                     // No brackets were expected.
                     break;
@@ -301,9 +302,9 @@ final class Expression implements Component
                     ++$brackets;
                     if (
                         empty($ret->function) && ($prev[1] !== null)
-                        && (($prev[1]->type === Token::TYPE_NONE)
-                        || ($prev[1]->type === Token::TYPE_SYMBOL)
-                        || (($prev[1]->type === Token::TYPE_KEYWORD)
+                        && (($prev[1]->type === TokenType::None)
+                        || ($prev[1]->type === TokenType::Symbol)
+                        || (($prev[1]->type === TokenType::Keyword)
                         && ($prev[1]->flags & Token::FLAG_KEYWORD_FUNCTION)))
                     ) {
                         $ret->function = $prev[1]->value;
@@ -354,13 +355,13 @@ final class Expression implements Component
                 if (
                     $brackets === 0
                     && ($prev[0] === null
-                        || (($prev[0]->type !== Token::TYPE_OPERATOR || $prev[0]->token === ')')
-                            && ($prev[0]->type !== Token::TYPE_KEYWORD
+                        || (($prev[0]->type !== TokenType::Operator || $prev[0]->token === ')')
+                            && ($prev[0]->type !== TokenType::Keyword
                                 || ! ($prev[0]->flags & Token::FLAG_KEYWORD_RESERVED))))
-                    && (($prev[1]->type === Token::TYPE_STRING)
-                        || ($prev[1]->type === Token::TYPE_SYMBOL
+                    && (($prev[1]->type === TokenType::String)
+                        || ($prev[1]->type === TokenType::Symbol
                             && ! ($prev[1]->flags & Token::FLAG_SYMBOL_VARIABLE))
-                        || ($prev[1]->type === Token::TYPE_NONE
+                        || ($prev[1]->type === TokenType::None
                             && $prev[1]->token !== 'OVER'))
                 ) {
                     if (! empty($ret->alias)) {
@@ -380,9 +381,9 @@ final class Expression implements Component
                     if (
                         $ret->expr !== null &&
                         $beforeToken &&
-                        ($beforeToken->type === Token::TYPE_NONE ||
-                        $beforeToken->type === Token::TYPE_SYMBOL || $beforeToken->type === Token::TYPE_STRING) &&
-                        $token->type === Token::TYPE_KEYWORD
+                        ($beforeToken->type === TokenType::None ||
+                        $beforeToken->type === TokenType::Symbol || $beforeToken->type === TokenType::String) &&
+                        $token->type === TokenType::Keyword
                     ) {
                         $ret->expr = rtrim($ret->expr, ' ') . ' ';
                     }
@@ -390,7 +391,7 @@ final class Expression implements Component
                     $ret->expr .= $token->token;
                 }
             } else {
-                if (($token->type === Token::TYPE_OPERATOR) && ($token->value === '.')) {
+                if (($token->type === TokenType::Operator) && ($token->value === '.')) {
                     // Found a `.` which means we expect a column name and
                     // the column name we parsed is actually the table name
                     // and the table name is actually a database name.

--- a/src/Components/ExpressionArray.php
+++ b/src/Components/ExpressionArray.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\SqlParser\Exceptions\ParserException;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 use PhpMyAdmin\SqlParser\Translator;
 use RuntimeException;
 
@@ -57,17 +58,17 @@ final class ExpressionArray implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             if (
-                ($token->type === Token::TYPE_KEYWORD)
+                ($token->type === TokenType::Keyword)
                 && ($token->flags & Token::FLAG_KEYWORD_RESERVED)
                 && ((~$token->flags & Token::FLAG_KEYWORD_FUNCTION))
                 && ($token->value !== 'DUAL')
@@ -80,7 +81,7 @@ final class ExpressionArray implements Component
             }
 
             if ($state === 0) {
-                if ($token->type === Token::TYPE_KEYWORD && $token->value === 'CASE') {
+                if ($token->type === TokenType::Keyword && $token->value === 'CASE') {
                     $expr = CaseExpression::parse($parser, $list, $options);
                 } else {
                     $expr = Expression::parse($parser, $list, $options);

--- a/src/Components/FunctionCall.php
+++ b/src/Components/FunctionCall.php
@@ -6,8 +6,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function is_array;
 
@@ -73,18 +73,18 @@ final class FunctionCall implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 --$list->idx; // Let last token to previous one to avoid "This type of clause was previously parsed."
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             if ($state === 0) {
-                if ($token->type === Token::TYPE_OPERATOR && $token->value === '(') {
+                if ($token->type === TokenType::Operator && $token->value === '(') {
                     --$list->idx; // ArrayObj needs to start with `(`
                     $state = 1;
                     continue;// do not add this token to the name

--- a/src/Components/GroupKeyword.php
+++ b/src/Components/GroupKeyword.php
@@ -6,8 +6,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function trim;
@@ -69,12 +69,12 @@ final class GroupKeyword implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
@@ -83,11 +83,11 @@ final class GroupKeyword implements Component
                 $state = 1;
             } elseif ($state === 1) {
                 if (
-                    ($token->type === Token::TYPE_KEYWORD)
+                    ($token->type === TokenType::Keyword)
                     && (($token->keyword === 'ASC') || ($token->keyword === 'DESC'))
                 ) {
                     $expr->type = $token->keyword;
-                } elseif (($token->type === Token::TYPE_OPERATOR) && ($token->value === ',')) {
+                } elseif (($token->type === TokenType::Operator) && ($token->value === ',')) {
                     if (! empty($expr->expr)) {
                         $ret[] = $expr;
                     }

--- a/src/Components/IndexHint.php
+++ b/src/Components/IndexHint.php
@@ -6,8 +6,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 
@@ -96,18 +96,18 @@ final class IndexHint implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             switch ($state) {
                 case 0:
-                    if ($token->type === Token::TYPE_KEYWORD) {
+                    if ($token->type === TokenType::Keyword) {
                         if ($token->keyword !== 'USE' && $token->keyword !== 'IGNORE' && $token->keyword !== 'FORCE') {
                             break 2;
                         }
@@ -118,7 +118,7 @@ final class IndexHint implements Component
 
                     break;
                 case 1:
-                    if ($token->type === Token::TYPE_KEYWORD) {
+                    if ($token->type === TokenType::Keyword) {
                         if ($token->keyword === 'INDEX' || $token->keyword === 'KEY') {
                             $expr->indexOrKey = $token->keyword;
                         } else {
@@ -133,7 +133,7 @@ final class IndexHint implements Component
 
                     break;
                 case 2:
-                    if ($token->type === Token::TYPE_KEYWORD && $token->keyword === 'FOR') {
+                    if ($token->type === TokenType::Keyword && $token->keyword === 'FOR') {
                         $state = 3;
                     } else {
                         $expr->indexes = ExpressionArray::parse($parser, $list);
@@ -144,7 +144,7 @@ final class IndexHint implements Component
 
                     break;
                 case 3:
-                    if ($token->type === Token::TYPE_KEYWORD) {
+                    if ($token->type === TokenType::Keyword) {
                         if (
                             $token->keyword === 'JOIN'
                             || $token->keyword === 'GROUP BY'

--- a/src/Components/IntoKeyword.php
+++ b/src/Components/IntoKeyword.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function trim;
@@ -159,16 +160,16 @@ final class IntoKeyword implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
-            if (($token->type === Token::TYPE_KEYWORD) && ($token->flags & Token::FLAG_KEYWORD_RESERVED)) {
+            if (($token->type === TokenType::Keyword) && ($token->flags & Token::FLAG_KEYWORD_RESERVED)) {
                 if (($state === 0) && ($token->keyword === 'OUTFILE')) {
                     $ret->type = 'OUTFILE';
                     $state = 2;
@@ -202,7 +203,7 @@ final class IntoKeyword implements Component
 
                 $state = 1;
             } elseif ($state === 1) {
-                if (($token->type === Token::TYPE_OPERATOR) && ($token->value === '(')) {
+                if (($token->type === TokenType::Operator) && ($token->value === '(')) {
                     $ret->columns = ArrayObj::parse($parser, $list)->values;
                     ++$list->idx;
                 }
@@ -216,7 +217,7 @@ final class IntoKeyword implements Component
                 $ret->parseFileOptions($parser, $list, $token->keyword);
                 $state = 4;
             } elseif ($state === 4) {
-                if ($token->type === Token::TYPE_KEYWORD && $token->keyword !== 'LINES') {
+                if ($token->type === TokenType::Keyword && $token->keyword !== 'LINES') {
                     break;
                 }
 

--- a/src/Components/JoinKeyword.php
+++ b/src/Components/JoinKeyword.php
@@ -6,8 +6,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 use PhpMyAdmin\SqlParser\Translator;
 use RuntimeException;
 
@@ -133,17 +133,17 @@ final class JoinKeyword implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             if ($state === 0) {
-                if (($token->type !== Token::TYPE_KEYWORD) || empty(self::JOINS[$token->keyword])) {
+                if (($token->type !== TokenType::Keyword) || empty(self::JOINS[$token->keyword])) {
                     break;
                 }
 
@@ -153,7 +153,7 @@ final class JoinKeyword implements Component
                 $expr->expr = Expression::parse($parser, $list, ['field' => 'table']);
                 $state = 2;
             } elseif ($state === 2) {
-                if ($token->type === Token::TYPE_KEYWORD) {
+                if ($token->type === TokenType::Keyword) {
                     switch ($token->keyword) {
                         case 'ON':
                             $state = 3;

--- a/src/Components/Key.php
+++ b/src/Components/Key.php
@@ -7,8 +7,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function trim;
@@ -159,12 +159,12 @@ final class Key implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
@@ -172,7 +172,7 @@ final class Key implements Component
                 $ret->type = $token->value;
                 $state = 1;
             } elseif ($state === 1) {
-                if (($token->type === Token::TYPE_OPERATOR) && ($token->value === '(')) {
+                if (($token->type === TokenType::Operator) && ($token->value === '(')) {
                     $positionBeforeSearch = $list->idx;
                     $list->idx++;// Ignore the current token "(" or the search condition will always be true
                     $nextToken = $list->getNext();
@@ -188,7 +188,7 @@ final class Key implements Component
                     $ret->name = $token->value;
                 }
             } elseif ($state === 2) {
-                if ($token->type === Token::TYPE_OPERATOR) {
+                if ($token->type === TokenType::Operator) {
                     if ($token->value === '(') {
                         $state = 3;
                     } elseif (($token->value === ',') || ($token->value === ')')) {
@@ -200,7 +200,7 @@ final class Key implements Component
                     }
                 } elseif (
                     (
-                        $token->type === Token::TYPE_KEYWORD
+                        $token->type === TokenType::Keyword
                     )
                     &&
                     (
@@ -212,7 +212,7 @@ final class Key implements Component
                     $lastColumn['name'] = $token->value;
                 }
             } elseif ($state === 3) {
-                if (($token->type === Token::TYPE_OPERATOR) && ($token->value === ')')) {
+                if (($token->type === TokenType::Operator) && ($token->value === ')')) {
                     $state = 2;
                 } else {
                     $lastColumn['length'] = $token->value;
@@ -222,7 +222,7 @@ final class Key implements Component
                 ++$list->idx;
                 break;
             } elseif ($state === 5) {
-                if ($token->type === Token::TYPE_OPERATOR) {
+                if ($token->type === TokenType::Operator) {
                     // This got back to here and we reached the end of the expression
                     if ($token->value === ')') {
                         $state = 4;// go back to state 4 to fetch options

--- a/src/Components/Limit.php
+++ b/src/Components/Limit.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 /**
  * `LIMIT` keyword parser.
@@ -56,20 +57,20 @@ final class Limit implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
-            if (($token->type === Token::TYPE_KEYWORD) && ($token->flags & Token::FLAG_KEYWORD_RESERVED)) {
+            if (($token->type === TokenType::Keyword) && ($token->flags & Token::FLAG_KEYWORD_RESERVED)) {
                 break;
             }
 
-            if ($token->type === Token::TYPE_KEYWORD && $token->keyword === 'OFFSET') {
+            if ($token->type === TokenType::Keyword && $token->keyword === 'OFFSET') {
                 if ($offset) {
                     $parser->error('An offset was expected.', $token);
                 }
@@ -78,14 +79,14 @@ final class Limit implements Component
                 continue;
             }
 
-            if (($token->type === Token::TYPE_OPERATOR) && ($token->value === ',')) {
+            if (($token->type === TokenType::Operator) && ($token->value === ',')) {
                 $ret->offset = $ret->rowCount;
                 $ret->rowCount = 0;
                 continue;
             }
 
             // Skip if not a number
-            if (($token->type !== Token::TYPE_NUMBER)) {
+            if (($token->type !== TokenType::Number)) {
                 break;
             }
 

--- a/src/Components/LockExpression.php
+++ b/src/Components/LockExpression.php
@@ -6,8 +6,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 
@@ -62,8 +62,8 @@ final class LockExpression implements Component
 
             // End of statement.
             if (
-                $token->type === Token::TYPE_DELIMITER
-                || ($token->type === Token::TYPE_OPERATOR
+                $token->type === TokenType::Delimiter
+                || ($token->type === TokenType::Operator
                 && $token->value === ',')
             ) {
                 break;
@@ -133,8 +133,8 @@ final class LockExpression implements Component
 
             // End of statement.
             if (
-                $token->type === Token::TYPE_DELIMITER
-                || ($token->type === Token::TYPE_OPERATOR
+                $token->type === TokenType::Delimiter
+                || ($token->type === TokenType::Operator
                 && $token->value === ',')
             ) {
                 --$list->idx;
@@ -142,12 +142,12 @@ final class LockExpression implements Component
             }
 
             // Skipping whitespaces and comments.
-            if ($token->type === Token::TYPE_WHITESPACE || $token->type === Token::TYPE_COMMENT) {
+            if ($token->type === TokenType::Whitespace || $token->type === TokenType::Comment) {
                 continue;
             }
 
             // We only expect keywords
-            if ($token->type !== Token::TYPE_KEYWORD) {
+            if ($token->type !== TokenType::Keyword) {
                 $parser->error('Unexpected token.', $token);
                 break;
             }

--- a/src/Components/OptionsArray.php
+++ b/src/Components/OptionsArray.php
@@ -6,8 +6,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 use PhpMyAdmin\SqlParser\Translator;
 
 use function array_merge_recursive;
@@ -90,17 +90,17 @@ final class OptionsArray implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping comments.
-            if ($token->type === Token::TYPE_COMMENT) {
+            if ($token->type === TokenType::Comment) {
                 continue;
             }
 
             // Skipping whitespace if not parsing value.
-            if (($token->type === Token::TYPE_WHITESPACE) && ($brackets === 0)) {
+            if (($token->type === TokenType::Whitespace) && ($brackets === 0)) {
                 continue;
             }
 

--- a/src/Components/OrderKeyword.php
+++ b/src/Components/OrderKeyword.php
@@ -6,8 +6,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 
@@ -74,12 +74,12 @@ final class OrderKeyword implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
@@ -88,11 +88,11 @@ final class OrderKeyword implements Component
                 $state = 1;
             } elseif ($state === 1) {
                 if (
-                    ($token->type === Token::TYPE_KEYWORD)
+                    ($token->type === TokenType::Keyword)
                     && (($token->keyword === 'ASC') || ($token->keyword === 'DESC'))
                 ) {
                     $expr->type = $token->keyword;
-                } elseif (($token->type === Token::TYPE_OPERATOR) && ($token->value === ',')) {
+                } elseif (($token->type === TokenType::Operator) && ($token->value === ',')) {
                     if (! empty($expr->expr)) {
                         $ret[] = $expr;
                     }

--- a/src/Components/ParameterDefinition.php
+++ b/src/Components/ParameterDefinition.php
@@ -7,8 +7,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function trim;
@@ -90,17 +90,17 @@ final class ParameterDefinition implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             if ($state === 0) {
-                if (($token->type === Token::TYPE_OPERATOR) && ($token->value === '(')) {
+                if (($token->type === TokenType::Operator) && ($token->value === '(')) {
                     $state = 1;
                 }
             } elseif ($state === 1) {

--- a/src/Components/PartitionDefinition.php
+++ b/src/Components/PartitionDefinition.php
@@ -6,8 +6,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function trim;
@@ -146,17 +146,17 @@ final class PartitionDefinition implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             if ($state === 0) {
-                $ret->isSubpartition = ($token->type === Token::TYPE_KEYWORD) && ($token->keyword === 'SUBPARTITION');
+                $ret->isSubpartition = ($token->type === TokenType::Keyword) && ($token->keyword === 'SUBPARTITION');
                 $state = 1;
             } elseif ($state === 1) {
                 $ret->name = $token->value;
@@ -164,7 +164,7 @@ final class PartitionDefinition implements Component
                 // Looking ahead for a 'VALUES' keyword.
                 // Loop until the end of the partition name (delimited by a whitespace)
                 while ($nextToken = $list->tokens[++$list->idx]) {
-                    if ($nextToken->type !== Token::TYPE_NONE) {
+                    if ($nextToken->type !== TokenType::None) {
                         break;
                     }
 
@@ -175,7 +175,7 @@ final class PartitionDefinition implements Component
                 // Get the first token after the white space.
                 $nextToken = $list->tokens[++$idx];
 
-                $state = ($nextToken->type === Token::TYPE_KEYWORD)
+                $state = ($nextToken->type === TokenType::Keyword)
                     && ($nextToken->value === 'VALUES')
                     ? 2 : 5;
             } elseif ($state === 2) {
@@ -202,7 +202,7 @@ final class PartitionDefinition implements Component
                 $ret->options = OptionsArray::parse($parser, $list, static::$partitionOptions);
                 $state = 6;
             } elseif ($state === 6) {
-                if (($token->type === Token::TYPE_OPERATOR) && ($token->value === '(')) {
+                if (($token->type === TokenType::Operator) && ($token->value === '(')) {
                     $ret->subpartitions = ArrayObj::parse(
                         $parser,
                         $list,

--- a/src/Components/Reference.php
+++ b/src/Components/Reference.php
@@ -7,8 +7,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function trim;
@@ -100,12 +100,12 @@ final class Reference implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 

--- a/src/Components/RenameOperation.php
+++ b/src/Components/RenameOperation.php
@@ -6,8 +6,8 @@ namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 
@@ -78,12 +78,12 @@ final class RenameOperation implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
@@ -102,7 +102,7 @@ final class RenameOperation implements Component
 
                 $state = 1;
             } elseif ($state === 1) {
-                if ($token->type !== Token::TYPE_KEYWORD || $token->keyword !== 'TO') {
+                if ($token->type !== TokenType::Keyword || $token->keyword !== 'TO') {
                     $parser->error('Keyword "TO" was expected.', $token);
                     break;
                 }
@@ -123,7 +123,7 @@ final class RenameOperation implements Component
 
                 $state = 3;
             } elseif ($state === 3) {
-                if (($token->type !== Token::TYPE_OPERATOR) || ($token->value !== ',')) {
+                if (($token->type !== TokenType::Operator) || ($token->value !== ',')) {
                     break;
                 }
 

--- a/src/Components/SetOperation.php
+++ b/src/Components/SetOperation.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function in_array;
@@ -83,18 +84,18 @@ final class SetOperation implements Component
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             // No keyword is expected.
             if (
-                ($token->type === Token::TYPE_KEYWORD)
+                ($token->type === TokenType::Keyword)
                 && ($token->flags & Token::FLAG_KEYWORD_RESERVED)
                 && ($state === 0)
             ) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -428,9 +428,9 @@ class Parser extends Core
 
             // `DELIMITER` is not an actual statement and it requires
             // special handling.
-            if (($token->type === Token::TYPE_NONE) && (strtoupper($token->token) === 'DELIMITER')) {
+            if (($token->type === TokenType::None) && (strtoupper($token->token) === 'DELIMITER')) {
                 // Skipping to the end of this statement.
-                $list->getNextOfType(Token::TYPE_DELIMITER);
+                $list->getNextOfType(TokenType::Delimiter);
                 $prevLastIdx = $list->idx;
                 continue;
             }
@@ -443,12 +443,12 @@ class Parser extends Core
 
             // Statements can start with keywords only.
             // Comments, whitespaces, etc. are ignored.
-            if ($token->type !== Token::TYPE_KEYWORD) {
+            if ($token->type !== TokenType::Keyword) {
                 if (
-                    ($token->type !== Token::TYPE_COMMENT)
-                    && ($token->type !== Token::TYPE_WHITESPACE)
-                    && ($token->type !== Token::TYPE_OPERATOR) // `(` and `)`
-                    && ($token->type !== Token::TYPE_DELIMITER)
+                    ($token->type !== TokenType::Comment)
+                    && ($token->type !== TokenType::Whitespace)
+                    && ($token->type !== TokenType::Operator) // `(` and `)`
+                    && ($token->type !== TokenType::Delimiter)
                 ) {
                     $this->error('Unexpected beginning of statement.', $token);
                 }
@@ -473,8 +473,8 @@ class Parser extends Core
             if ($token->keyword === 'ANALYZE') {
                 ++$list->idx; // Skip ANALYZE
 
-                $first = $list->getNextOfType(Token::TYPE_KEYWORD);
-                $second = $list->getNextOfType(Token::TYPE_KEYWORD);
+                $first = $list->getNextOfType(TokenType::Keyword);
+                $second = $list->getNextOfType(TokenType::Keyword);
 
                 // ANALYZE keyword can be an indication of two cases:
                 // 1 - ANALYZE TABLE statements, in both MariaDB and MySQL
@@ -496,7 +496,7 @@ class Parser extends Core
                 }
 
                 // Skipping to the end of this statement.
-                $list->getNextOfType(Token::TYPE_DELIMITER);
+                $list->getNextOfType(TokenType::Delimiter);
                 $prevLastIdx = $list->idx;
                 continue;
             }

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -225,7 +225,7 @@ abstract class Statement implements Stringable
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
@@ -238,8 +238,8 @@ abstract class Statement implements Stringable
 
             // Only keywords are relevant here. Other parts of the query are
             // processed in the functions below.
-            if ($token->type !== Token::TYPE_KEYWORD) {
-                if (($token->type !== Token::TYPE_COMMENT) && ($token->type !== Token::TYPE_WHITESPACE)) {
+            if ($token->type !== TokenType::Keyword) {
+                if (($token->type !== TokenType::Comment) && ($token->type !== TokenType::Whitespace)) {
                     $parser->error('Unexpected token.', $token);
                 }
 
@@ -267,9 +267,9 @@ abstract class Statement implements Stringable
                 ++$list->idx; // Skip ON
 
                 // look for ON DUPLICATE KEY UPDATE
-                $first = $list->getNextOfType(Token::TYPE_KEYWORD);
-                $second = $list->getNextOfType(Token::TYPE_KEYWORD);
-                $third = $list->getNextOfType(Token::TYPE_KEYWORD);
+                $first = $list->getNextOfType(TokenType::Keyword);
+                $second = $list->getNextOfType(TokenType::Keyword);
+                $third = $list->getNextOfType(TokenType::Keyword);
 
                 if (
                     $first && $second && $third

--- a/src/Statements/AlterStatement.php
+++ b/src/Statements/AlterStatement.php
@@ -9,8 +9,8 @@ use PhpMyAdmin\SqlParser\Components\Expression;
 use PhpMyAdmin\SqlParser\Components\OptionsArray;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function implode;
 use function trim;
@@ -108,12 +108,12 @@ class AlterStatement extends Statement
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
@@ -134,7 +134,7 @@ class AlterStatement extends Statement
                 $this->altered[] = AlterOperation::parse($parser, $list, $options);
                 $state = 1;
             } elseif ($state === 1) {
-                if (($token->type === Token::TYPE_OPERATOR) && ($token->value === ',')) {
+                if (($token->type === TokenType::Operator) && ($token->value === ',')) {
                     $state = 0;
                 }
             }

--- a/src/Statements/DeleteStatement.php
+++ b/src/Statements/DeleteStatement.php
@@ -14,8 +14,8 @@ use PhpMyAdmin\SqlParser\Components\OptionsArray;
 use PhpMyAdmin\SqlParser\Components\OrderKeyword;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function stripos;
 use function strlen;
@@ -235,12 +235,12 @@ class DeleteStatement extends Statement
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             if ($state === 0) {
-                if ($token->type === Token::TYPE_KEYWORD) {
+                if ($token->type === TokenType::Keyword) {
                     if ($token->keyword !== 'FROM') {
                         $parser->error('Unexpected keyword.', $token);
                         break;
@@ -255,7 +255,7 @@ class DeleteStatement extends Statement
                     $state = 1;
                 }
             } elseif ($state === 1) {
-                if ($token->type !== Token::TYPE_KEYWORD) {
+                if ($token->type !== TokenType::Keyword) {
                     $parser->error('Unexpected token.', $token);
                     break;
                 }
@@ -270,7 +270,7 @@ class DeleteStatement extends Statement
 
                 $state = 2;
             } elseif ($state === 2) {
-                if ($token->type === Token::TYPE_KEYWORD) {
+                if ($token->type === TokenType::Keyword) {
                     if (stripos($token->keyword, 'JOIN') !== false) {
                         ++$list->idx;
                         $this->join = JoinKeyword::parse($parser, $list);
@@ -307,7 +307,7 @@ class DeleteStatement extends Statement
                     }
                 }
             } elseif ($state === 3) {
-                if ($token->type !== Token::TYPE_KEYWORD) {
+                if ($token->type !== TokenType::Keyword) {
                     $parser->error('Unexpected token.', $token);
                     break;
                 }
@@ -321,12 +321,12 @@ class DeleteStatement extends Statement
                 $this->where = Condition::parse($parser, $list);
                 $state = 4;
             } elseif ($state === 4) {
-                if ($multiTable === true && $token->type === Token::TYPE_KEYWORD) {
+                if ($multiTable === true && $token->type === TokenType::Keyword) {
                     $parser->error('This type of clause is not valid in Multi-table queries.', $token);
                     break;
                 }
 
-                if ($token->type === Token::TYPE_KEYWORD) {
+                if ($token->type === TokenType::Keyword) {
                     switch ($token->keyword) {
                         case 'ORDER BY':
                             ++$list->idx; // Skip 'ORDER  BY'
@@ -344,7 +344,7 @@ class DeleteStatement extends Statement
                     }
                 }
             } elseif ($state === 5) {
-                if ($token->type === Token::TYPE_KEYWORD) {
+                if ($token->type === TokenType::Keyword) {
                     if ($token->keyword !== 'LIMIT') {
                         $parser->error('Unexpected keyword.', $token);
                         break;

--- a/src/Statements/ExplainStatement.php
+++ b/src/Statements/ExplainStatement.php
@@ -8,8 +8,8 @@ use PhpMyAdmin\SqlParser\Components\OptionsArray;
 use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function array_slice;
 
@@ -116,13 +116,13 @@ class ExplainStatement extends Statement
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 --$list->idx; // Back up one token, no real reasons to document
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if ($token->type === Token::TYPE_WHITESPACE || $token->type === Token::TYPE_COMMENT) {
+            if ($token->type === TokenType::Whitespace || $token->type === TokenType::Comment) {
                 continue;
             }
 
@@ -139,7 +139,7 @@ class ExplainStatement extends Statement
 
                     $lastIdx = $list->idx;
                     $list->idx++; // Ignore the current token
-                    $nextKeyword = $list->getNextOfType(Token::TYPE_KEYWORD);
+                    $nextKeyword = $list->getNextOfType(TokenType::Keyword);
                     $list->idx = $lastIdx;
 
                     // There is no other keyword, we must be describing a table
@@ -151,7 +151,7 @@ class ExplainStatement extends Statement
                     $miniState = 1;
 
                     $lastIdx = $list->idx;
-                    $nextKeyword = $list->getNextOfTypeAndValue(Token::TYPE_KEYWORD, 'ANALYZE');
+                    $nextKeyword = $list->getNextOfTypeAndValue(TokenType::Keyword, 'ANALYZE');
                     if ($nextKeyword && $nextKeyword->keyword !== null) {
                         $miniState = 2;
                         $this->statementAlias .= ' ANALYZE';
@@ -208,13 +208,13 @@ class ExplainStatement extends Statement
                 $list->idx = $idxOfLastParsedToken;
                 break;
             } elseif ($state === 3) {
-                if (($token->type === Token::TYPE_OPERATOR) && ($token->value === '.')) {
+                if (($token->type === TokenType::Operator) && ($token->value === '.')) {
                     continue;
                 }
 
                 if ($this->explainedDatabase === null) {
                     $lastIdx = $list->idx;
-                    $nextDot = $list->getNextOfTypeAndValue(Token::TYPE_OPERATOR, '.');
+                    $nextDot = $list->getNextOfTypeAndValue(TokenType::Operator, '.');
                     $list->idx = $lastIdx;
                     if ($nextDot !== null) {// We found a dot, so it must be a db.table name format
                         $this->explainedDatabase = $token->value;

--- a/src/Statements/InsertStatement.php
+++ b/src/Statements/InsertStatement.php
@@ -11,8 +11,8 @@ use PhpMyAdmin\SqlParser\Components\OptionsArray;
 use PhpMyAdmin\SqlParser\Components\SetOperation;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function strlen;
 use function trim;
@@ -171,17 +171,17 @@ class InsertStatement extends Statement
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             if ($state === 0) {
-                if ($token->type === Token::TYPE_KEYWORD && $token->keyword !== 'INTO') {
+                if ($token->type === TokenType::Keyword && $token->keyword !== 'INTO') {
                     $parser->error('Unexpected keyword.', $token);
                     break;
                 }
@@ -195,7 +195,7 @@ class InsertStatement extends Statement
 
                 $state = 1;
             } elseif ($state === 1) {
-                if ($token->type !== Token::TYPE_KEYWORD) {
+                if ($token->type !== TokenType::Keyword) {
                     $parser->error('Unexpected token.', $token);
                     break;
                 }

--- a/src/Statements/LoadStatement.php
+++ b/src/Statements/LoadStatement.php
@@ -11,8 +11,8 @@ use PhpMyAdmin\SqlParser\Components\OptionsArray;
 use PhpMyAdmin\SqlParser\Components\SetOperation;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function strlen;
 use function trim;
@@ -241,22 +241,22 @@ class LoadStatement extends Statement
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             if ($state === 0) {
-                if ($token->type === Token::TYPE_KEYWORD && $token->keyword !== 'INFILE') {
+                if ($token->type === TokenType::Keyword && $token->keyword !== 'INFILE') {
                     $parser->error('Unexpected keyword.', $token);
                     break;
                 }
 
-                if ($token->type !== Token::TYPE_KEYWORD) {
+                if ($token->type !== TokenType::Keyword) {
                     $parser->error('Unexpected token.', $token);
                     break;
                 }
@@ -269,7 +269,7 @@ class LoadStatement extends Statement
                 );
                 $state = 1;
             } elseif ($state === 1) {
-                if ($token->type === Token::TYPE_KEYWORD) {
+                if ($token->type === TokenType::Keyword) {
                     if ($token->keyword === 'REPLACE' || $token->keyword === 'IGNORE') {
                         $this->replaceIgnore = trim($token->keyword);
                     } elseif ($token->keyword === 'INTO') {
@@ -277,7 +277,7 @@ class LoadStatement extends Statement
                     }
                 }
             } elseif ($state === 2) {
-                if ($token->type !== Token::TYPE_KEYWORD || $token->keyword !== 'TABLE') {
+                if ($token->type !== TokenType::Keyword || $token->keyword !== 'TABLE') {
                     $parser->error('Unexpected token.', $token);
                     break;
                 }
@@ -286,13 +286,13 @@ class LoadStatement extends Statement
                 $this->table = Expression::parse($parser, $list, ['parseField' => 'table']);
                 $state = 3;
             } elseif ($state >= 3 && $state <= 7) {
-                if ($token->type === Token::TYPE_KEYWORD) {
+                if ($token->type === TokenType::Keyword) {
                     $newState = $this->parseKeywordsAccordingToState($parser, $list, $state);
                     if ($newState === $state) {
                         // Avoid infinite loop
                         break;
                     }
-                } elseif ($token->type === Token::TYPE_OPERATOR && $token->token === '(') {
+                } elseif ($token->type === TokenType::Operator && $token->token === '(') {
                     $this->columnNamesOrUserVariables
                         = ExpressionArray::parse($parser, $list);
                     $state = 7;
@@ -367,10 +367,10 @@ class LoadStatement extends Statement
                     ++$list->idx;
 
                     $this->ignoreNumber = Expression::parse($parser, $list);
-                    $nextToken = $list->getNextOfType(Token::TYPE_KEYWORD);
+                    $nextToken = $list->getNextOfType(TokenType::Keyword);
 
                     if (
-                        $nextToken->type === Token::TYPE_KEYWORD
+                        $nextToken->type === TokenType::Keyword
                         && (($nextToken->keyword === 'LINES')
                         || ($nextToken->keyword === 'ROWS'))
                     ) {

--- a/src/Statements/LockStatement.php
+++ b/src/Statements/LockStatement.php
@@ -7,8 +7,8 @@ namespace PhpMyAdmin\SqlParser\Statements;
 use PhpMyAdmin\SqlParser\Components\LockExpression;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function trim;
 
@@ -70,17 +70,17 @@ class LockStatement extends Statement
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             if ($state === 0) {
-                if ($token->type === Token::TYPE_KEYWORD) {
+                if ($token->type === TokenType::Keyword) {
                     if ($token->keyword !== 'TABLES') {
                         $parser->error('Unexpected keyword.', $token);
                         break;

--- a/src/Statements/NotImplementedStatement.php
+++ b/src/Statements/NotImplementedStatement.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 /**
  * Not implemented (yet) statements.
@@ -43,7 +44,7 @@ class NotImplementedStatement extends Statement
     public function parse(Parser $parser, TokensList $list): void
     {
         for (; $list->idx < $list->count; ++$list->idx) {
-            if ($list->tokens[$list->idx]->type === Token::TYPE_DELIMITER) {
+            if ($list->tokens[$list->idx]->type === TokenType::Delimiter) {
                 break;
             }
 

--- a/src/Statements/PurgeStatement.php
+++ b/src/Statements/PurgeStatement.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function in_array;
 use function trim;
@@ -73,12 +74,12 @@ class PurgeStatement extends Statement
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
@@ -125,7 +126,7 @@ class PurgeStatement extends Statement
      */
     private static function parseExpectedKeyword($parser, $token, $expectedKeywords): mixed
     {
-        if ($token->type === Token::TYPE_KEYWORD) {
+        if ($token->type === TokenType::Keyword) {
             if (in_array($token->keyword, $expectedKeywords)) {
                 return $token->keyword;
             }

--- a/src/Statements/RenameStatement.php
+++ b/src/Statements/RenameStatement.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 /**
  * `RENAME` statement.
@@ -36,12 +37,12 @@ class RenameStatement extends Statement
      */
     public function before(Parser $parser, TokensList $list, Token $token): void
     {
-        if (($token->type !== Token::TYPE_KEYWORD) || ($token->keyword !== 'RENAME')) {
+        if (($token->type !== TokenType::Keyword) || ($token->keyword !== 'RENAME')) {
             return;
         }
 
         // Checking if it is the beginning of the query.
-        $list->getNextOfTypeAndValue(Token::TYPE_KEYWORD, 'TABLE');
+        $list->getNextOfTypeAndValue(TokenType::Keyword, 'TABLE');
     }
 
     public function build(): string

--- a/src/Statements/ReplaceStatement.php
+++ b/src/Statements/ReplaceStatement.php
@@ -11,8 +11,8 @@ use PhpMyAdmin\SqlParser\Components\OptionsArray;
 use PhpMyAdmin\SqlParser\Components\SetOperation;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function strlen;
 use function trim;
@@ -130,17 +130,17 @@ class ReplaceStatement extends Statement
             $token = $list->tokens[$list->idx];
 
             // End of statement.
-            if ($token->type === Token::TYPE_DELIMITER) {
+            if ($token->type === TokenType::Delimiter) {
                 break;
             }
 
             // Skipping whitespaces and comments.
-            if (($token->type === Token::TYPE_WHITESPACE) || ($token->type === Token::TYPE_COMMENT)) {
+            if (($token->type === TokenType::Whitespace) || ($token->type === TokenType::Comment)) {
                 continue;
             }
 
             if ($state === 0) {
-                if ($token->type === Token::TYPE_KEYWORD && $token->keyword !== 'INTO') {
+                if ($token->type === TokenType::Keyword && $token->keyword !== 'INTO') {
                     $parser->error('Unexpected keyword.', $token);
                     break;
                 }
@@ -154,7 +154,7 @@ class ReplaceStatement extends Statement
 
                 $state = 1;
             } elseif ($state === 1) {
-                if ($token->type !== Token::TYPE_KEYWORD) {
+                if ($token->type !== TokenType::Keyword) {
                     $parser->error('Unexpected token.', $token);
                     break;
                 }

--- a/src/Statements/WithStatement.php
+++ b/src/Statements/WithStatement.php
@@ -10,8 +10,8 @@ use PhpMyAdmin\SqlParser\Components\WithKeyword;
 use PhpMyAdmin\SqlParser\Exceptions\ParserException;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 use PhpMyAdmin\SqlParser\Translator;
 
 use function array_slice;
@@ -107,12 +107,12 @@ final class WithStatement extends Statement
             $token = $list->tokens[$list->idx];
 
             // Skipping whitespaces and comments.
-            if ($token->type === Token::TYPE_WHITESPACE || $token->type === Token::TYPE_COMMENT) {
+            if ($token->type === TokenType::Whitespace || $token->type === TokenType::Comment) {
                 continue;
             }
 
             if ($state === 0) {
-                if ($token->type !== Token::TYPE_NONE || ! preg_match('/^[a-zA-Z0-9_$]+$/', $token->token)) {
+                if ($token->type !== TokenType::None || ! preg_match('/^[a-zA-Z0-9_$]+$/', $token->token)) {
                     $parser->error('The name of the CTE was expected.', $token);
                     break;
                 }
@@ -121,7 +121,7 @@ final class WithStatement extends Statement
                 $this->withers[$wither] = new WithKeyword($wither);
                 $state = 1;
             } elseif ($state === 1) {
-                if ($token->type === Token::TYPE_OPERATOR && $token->value === '(') {
+                if ($token->type === TokenType::Operator && $token->value === '(') {
                     $columns = Array2d::parse($parser, $list);
                     if ($parser->errors !== []) {
                         break;
@@ -129,14 +129,14 @@ final class WithStatement extends Statement
 
                     $this->withers[$wither]->columns = $columns;
                     $state = 2;
-                } elseif ($token->type === Token::TYPE_KEYWORD && $token->keyword === 'AS') {
+                } elseif ($token->type === TokenType::Keyword && $token->keyword === 'AS') {
                     $state = 3;
                 } else {
                     $parser->error('Unexpected token.', $token);
                     break;
                 }
             } elseif ($state === 2) {
-                if (! ($token->type === Token::TYPE_KEYWORD && $token->keyword === 'AS')) {
+                if (! ($token->type === TokenType::Keyword && $token->keyword === 'AS')) {
                     $parser->error('AS keyword was expected.', $token);
                     break;
                 }
@@ -185,7 +185,7 @@ final class WithStatement extends Statement
                 }
 
                 if (
-                    $token->type === Token::TYPE_KEYWORD && (
+                    $token->type === TokenType::Keyword && (
                     $token->value === 'SELECT'
                     || $token->value === 'INSERT'
                     || $token->value === 'UPDATE'
@@ -218,7 +218,7 @@ final class WithStatement extends Statement
                 // from $list->idx to the end of the $list.
                 $lengthOfExpressionTokens = null;
 
-                if ($list->getNextOfTypeAndValue(Token::TYPE_KEYWORD, 'ON')) {
+                if ($list->getNextOfTypeAndValue(TokenType::Keyword, 'ON')) {
                     // (-1) because getNextOfTypeAndValue returned ON and increased the index.
                     $idxOfOn = $list->idx - 1;
                     // We want to make sure that it's `ON DUPLICATE KEY UPDATE`

--- a/src/TokenType.php
+++ b/src/TokenType.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\SqlParser;
+
+enum TokenType: int
+{
+    /**
+     * This type is used when the token is invalid or its type cannot be
+     * determined because of the ambiguous context. Further analysis might be
+     * required to detect its type.
+     */
+    case None = 0;
+
+    /**
+     * SQL specific keywords: SELECT, UPDATE, INSERT, etc.
+     */
+    case Keyword = 1;
+
+    /**
+     * Any type of legal operator.
+     *
+     * Arithmetic operators: +, -, *, /, etc.
+     * Logical operators: ===, <>, !==, etc.
+     * Bitwise operators: &, |, ^, etc.
+     * Assignment operators: =, +=, -=, etc.
+     * SQL specific operators: . (e.g. .. WHERE database.table ..),
+     *                         * (e.g. SELECT * FROM ..)
+     */
+    case Operator = 2;
+
+    /**
+     * Spaces, tabs, new lines, etc.
+     */
+    case Whitespace = 3;
+
+    /**
+     * Any type of legal comment.
+     *
+     * Bash (#), C (/* *\/) or SQL (--) comments:
+     *
+     *      -- SQL-comment
+     *
+     *      #Bash-like comment
+     *
+     *      /*C-like comment*\/
+     *
+     * or:
+     *
+     *      /*C-like
+     *        comment*\/
+     *
+     * Backslashes were added to respect PHP's comments syntax.
+     */
+    case Comment = 4;
+
+    /**
+     * Boolean values: true or false.
+     */
+    case Bool = 5;
+
+    /**
+     * Numbers: 4, 0x8, 15.16, 23e42, etc.
+     */
+    case Number = 6;
+
+    /**
+     * Literal strings: 'string', "test".
+     * Some of these strings are actually symbols.
+     */
+    case String = 7;
+
+    /**
+     * Database, table names, variables, etc.
+     * For example: ```SELECT `foo`, `bar` FROM `database`.`table`;```.
+     */
+    case Symbol = 8;
+
+    /**
+     * Delimits an unknown string.
+     * For example: ```SELECT * FROM test;```, `test` is a delimiter.
+     */
+    case Delimiter = 9;
+
+    /**
+     * Labels in LOOP statement, ITERATE statement etc.
+     * For example (only for begin label):
+     *  begin_label: BEGIN [statement_list] END [end_label]
+     *  begin_label: LOOP [statement_list] END LOOP [end_label]
+     *  begin_label: REPEAT [statement_list] ... END REPEAT [end_label]
+     *  begin_label: WHILE ... DO [statement_list] END WHILE [end_label].
+     */
+    case Label = 10;
+}

--- a/src/TokensList.php
+++ b/src/TokensList.php
@@ -82,8 +82,8 @@ class TokensList implements ArrayAccess
     {
         for (; $this->idx < $this->count; ++$this->idx) {
             if (
-                ($this->tokens[$this->idx]->type !== Token::TYPE_WHITESPACE)
-                && ($this->tokens[$this->idx]->type !== Token::TYPE_COMMENT)
+                ($this->tokens[$this->idx]->type !== TokenType::Whitespace)
+                && ($this->tokens[$this->idx]->type !== TokenType::Comment)
             ) {
                 return $this->tokens[$this->idx++];
             }
@@ -100,8 +100,8 @@ class TokensList implements ArrayAccess
     {
         for (; $this->idx >= 0; --$this->idx) {
             if (
-                ($this->tokens[$this->idx]->type !== Token::TYPE_WHITESPACE)
-                && ($this->tokens[$this->idx]->type !== Token::TYPE_COMMENT)
+                ($this->tokens[$this->idx]->type !== TokenType::Whitespace)
+                && ($this->tokens[$this->idx]->type !== TokenType::Comment)
             ) {
                 return $this->tokens[$this->idx--];
             }
@@ -113,9 +113,9 @@ class TokensList implements ArrayAccess
     /**
      * Gets the previous token.
      *
-     * @param int|int[] $type the type
+     * @param TokenType|TokenType[] $type the type
      */
-    public function getPreviousOfType($type): Token|null
+    public function getPreviousOfType(TokenType|array $type): Token|null
     {
         if (! is_array($type)) {
             $type = [$type];
@@ -133,9 +133,9 @@ class TokensList implements ArrayAccess
     /**
      * Gets the next token.
      *
-     * @param int|int[] $type the type
+     * @param TokenType|TokenType[] $type the type
      */
-    public function getNextOfType($type): Token|null
+    public function getNextOfType(TokenType|array $type): Token|null
     {
         if (! is_array($type)) {
             $type = [$type];
@@ -153,10 +153,10 @@ class TokensList implements ArrayAccess
     /**
      * Gets the next token.
      *
-     * @param int    $type  the type of the token
-     * @param string $value the value of the token
+     * @param TokenType $type  the type of the token
+     * @param string    $value the value of the token
      */
-    public function getNextOfTypeAndValue($type, $value): Token|null
+    public function getNextOfTypeAndValue(TokenType $type, $value): Token|null
     {
         for (; $this->idx < $this->count; ++$this->idx) {
             if (($this->tokens[$this->idx]->type === $type) && ($this->tokens[$this->idx]->value === $value)) {
@@ -170,10 +170,10 @@ class TokensList implements ArrayAccess
     /**
      * Gets the next token.
      *
-     * @param int $type the type of the token
-     * @param int $flag the flag of the token
+     * @param TokenType $type the type of the token
+     * @param int       $flag the flag of the token
      */
-    public function getNextOfTypeAndFlag(int $type, int $flag): Token|null
+    public function getNextOfTypeAndFlag(TokenType $type, int $flag): Token|null
     {
         for (; $this->idx < $this->count; ++$this->idx) {
             if (($this->tokens[$this->idx]->type === $type) && ($this->tokens[$this->idx]->flags === $flag)) {

--- a/src/Utils/CLI.php
+++ b/src/Utils/CLI.php
@@ -256,7 +256,7 @@ class CLI
             $lexer = new Lexer($params['q'], false);
             foreach ($lexer->list->tokens as $idx => $token) {
                 echo '[TOKEN ', $idx, "]\n";
-                echo 'Type = ', $token->type, "\n";
+                echo 'Type = ', $token->type->value, "\n";
                 echo 'Flags = ', $token->flags, "\n";
                 echo 'Value = ';
                 var_export($token->value);

--- a/src/Utils/Query.php
+++ b/src/Utils/Query.php
@@ -27,8 +27,8 @@ use PhpMyAdmin\SqlParser\Statements\SetStatement;
 use PhpMyAdmin\SqlParser\Statements\ShowStatement;
 use PhpMyAdmin\SqlParser\Statements\TruncateStatement;
 use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
-use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function array_flip;
 use function array_keys;
@@ -650,7 +650,7 @@ class Query
          *
          * @var string
          */
-        $clauseType = $lexer->list->getNextOfType(Token::TYPE_KEYWORD)->keyword;
+        $clauseType = $lexer->list->getNextOfType(TokenType::Keyword)->keyword;
 
         /**
          * The index of this clause.
@@ -685,11 +685,11 @@ class Query
         for ($i = $statement->first; $i <= $statement->last; ++$i) {
             $token = $list->tokens[$i];
 
-            if ($token->type === Token::TYPE_COMMENT) {
+            if ($token->type === TokenType::Comment) {
                 continue;
             }
 
-            if ($token->type === Token::TYPE_OPERATOR) {
+            if ($token->type === TokenType::Operator) {
                 if ($token->value === '(') {
                     ++$brackets;
                 } elseif ($token->value === ')') {
@@ -700,7 +700,7 @@ class Query
             if ($brackets === 0) {
                 // Checking if the section was changed.
                 if (
-                    ($token->type === Token::TYPE_KEYWORD)
+                    ($token->type === TokenType::Keyword)
                     && isset($clauses[$token->keyword])
                     && ($clauses[$token->keyword] >= $currIdx)
                 ) {
@@ -838,13 +838,13 @@ class Query
         for ($list->idx = 0; $list->idx < $list->count; ++$list->idx) {
             $token = $list->tokens[$list->idx];
 
-            if ($token->type === Token::TYPE_COMMENT) {
+            if ($token->type === TokenType::Comment) {
                 continue;
             }
 
             $statement .= $token->token;
 
-            if (($token->type === Token::TYPE_DELIMITER) && ! empty($token->token)) {
+            if (($token->type === TokenType::Delimiter) && ! empty($token->token)) {
                 $delimiter = $token->token;
                 $fullStatement = true;
                 break;
@@ -900,11 +900,11 @@ class Query
         for ($i = $statement->first; $i <= $statement->last; ++$i) {
             $token = $list->tokens[$i];
 
-            if ($token->type === Token::TYPE_COMMENT) {
+            if ($token->type === TokenType::Comment) {
                 continue;
             }
 
-            if ($token->type === Token::TYPE_OPERATOR) {
+            if ($token->type === TokenType::Operator) {
                 if ($token->value === '(') {
                     ++$brackets;
                 } elseif ($token->value === ')') {
@@ -917,7 +917,7 @@ class Query
             }
 
             if (
-                ($token->type === Token::TYPE_KEYWORD)
+                ($token->type === TokenType::Keyword)
                 && isset($clauses[$token->keyword])
                 && ($clause === $token->keyword)
             ) {

--- a/tests/Builder/CreateStatementTest.php
+++ b/tests/Builder/CreateStatementTest.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\SqlParser\Statements\CreateStatement;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class CreateStatementTest extends TestCase
@@ -666,19 +667,19 @@ EOT
         $stmt->entityOptions = new OptionsArray(['BEFORE', 'INSERT']);
         $stmt->table = new Expression('account');
         $stmt->body = [
-            new Token('SET', Token::TYPE_KEYWORD),
-            new Token(' ', Token::TYPE_WHITESPACE),
-            new Token('@sum', Token::TYPE_NONE),
-            new Token(' ', Token::TYPE_WHITESPACE),
-            new Token('=', Token::TYPE_OPERATOR),
-            new Token(' ', Token::TYPE_WHITESPACE),
-            new Token('@sum', Token::TYPE_NONE),
-            new Token(' ', Token::TYPE_WHITESPACE),
-            new Token('+', Token::TYPE_OPERATOR),
-            new Token(' ', Token::TYPE_WHITESPACE),
-            new Token('NEW', Token::TYPE_KEYWORD),
-            new Token('.', Token::TYPE_OPERATOR),
-            new Token('amount', Token::TYPE_NONE),
+            new Token('SET', TokenType::Keyword),
+            new Token(' ', TokenType::Whitespace),
+            new Token('@sum', TokenType::None),
+            new Token(' ', TokenType::Whitespace),
+            new Token('=', TokenType::Operator),
+            new Token(' ', TokenType::Whitespace),
+            new Token('@sum', TokenType::None),
+            new Token(' ', TokenType::Whitespace),
+            new Token('+', TokenType::Operator),
+            new Token(' ', TokenType::Whitespace),
+            new Token('NEW', TokenType::Keyword),
+            new Token('.', TokenType::Operator),
+            new Token('amount', TokenType::None),
         ];
 
         $this->assertEquals(

--- a/tests/Components/KeyTest.php
+++ b/tests/Components/KeyTest.php
@@ -11,6 +11,7 @@ use PhpMyAdmin\SqlParser\Exceptions\ParserException;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Token;
+use PhpMyAdmin\SqlParser\TokenType;
 
 class KeyTest extends TestCase
 {
@@ -266,7 +267,7 @@ class KeyTest extends TestCase
         $this->assertEquals(new OptionsArray(
             []
         ), $component->options);
-        $t = new Token('convert_tz', Token::TYPE_KEYWORD, 33);
+        $t = new Token('convert_tz', TokenType::Keyword, 33);
         $t->position = 25;
 
         $this->assertEquals([

--- a/tests/Lexer/TokenTest.php
+++ b/tests/Lexer/TokenTest.php
@@ -6,81 +6,82 @@ namespace PhpMyAdmin\SqlParser\Tests\Lexer;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Token;
+use PhpMyAdmin\SqlParser\TokenType;
 
 class TokenTest extends TestCase
 {
     public function testExtractKeyword(): void
     {
-        $tok = new Token('SelecT', Token::TYPE_KEYWORD, Token::FLAG_KEYWORD_RESERVED);
+        $tok = new Token('SelecT', TokenType::Keyword, Token::FLAG_KEYWORD_RESERVED);
         $this->assertEquals($tok->value, 'SELECT');
 
-        $tok = new Token('aS', Token::TYPE_KEYWORD, Token::FLAG_KEYWORD_RESERVED);
+        $tok = new Token('aS', TokenType::Keyword, Token::FLAG_KEYWORD_RESERVED);
         $this->assertEquals($tok->value, 'AS');
     }
 
     public function testExtractWhitespace(): void
     {
-        $tok = new Token(" \t \r \n ", Token::TYPE_WHITESPACE);
+        $tok = new Token(" \t \r \n ", TokenType::Whitespace);
         $this->assertEquals($tok->value, ' ');
     }
 
     public function testExtractBool(): void
     {
-        $tok = new Token('false', Token::TYPE_BOOL);
+        $tok = new Token('false', TokenType::Bool);
         $this->assertFalse($tok->value);
 
-        $tok = new Token('True', Token::TYPE_BOOL);
+        $tok = new Token('True', TokenType::Bool);
         $this->assertTrue($tok->value);
     }
 
     public function testExtractNumber(): void
     {
-        $tok = new Token('--42', Token::TYPE_NUMBER, Token::FLAG_NUMBER_NEGATIVE);
+        $tok = new Token('--42', TokenType::Number, Token::FLAG_NUMBER_NEGATIVE);
         $this->assertEquals($tok->value, 42);
 
-        $tok = new Token('---42', Token::TYPE_NUMBER, Token::FLAG_NUMBER_NEGATIVE);
+        $tok = new Token('---42', TokenType::Number, Token::FLAG_NUMBER_NEGATIVE);
         $this->assertEquals($tok->value, -42);
 
-        $tok = new Token('0xFE', Token::TYPE_NUMBER, Token::FLAG_NUMBER_HEX);
+        $tok = new Token('0xFE', TokenType::Number, Token::FLAG_NUMBER_HEX);
         $this->assertEquals($tok->value, 0xFE);
 
-        $tok = new Token('-0xEF', Token::TYPE_NUMBER, Token::FLAG_NUMBER_NEGATIVE | Token::FLAG_NUMBER_HEX);
+        $tok = new Token('-0xEF', TokenType::Number, Token::FLAG_NUMBER_NEGATIVE | Token::FLAG_NUMBER_HEX);
         $this->assertEquals($tok->value, -0xEF);
 
-        $tok = new Token('3.14', Token::TYPE_NUMBER, Token::FLAG_NUMBER_FLOAT);
+        $tok = new Token('3.14', TokenType::Number, Token::FLAG_NUMBER_FLOAT);
         $this->assertEquals($tok->value, 3.14);
     }
 
     public function testExtractString(): void
     {
-        $tok = new Token('"foo bar "', Token::TYPE_STRING);
+        $tok = new Token('"foo bar "', TokenType::String);
         $this->assertEquals($tok->value, 'foo bar ');
 
-        $tok = new Token("' bar foo '", Token::TYPE_STRING);
+        $tok = new Token("' bar foo '", TokenType::String);
         $this->assertEquals($tok->value, ' bar foo ');
 
-        $tok = new Token("'\''", Token::TYPE_STRING);
+        $tok = new Token("'\''", TokenType::String);
         $this->assertEquals($tok->value, '\'');
 
-        $tok = new Token('"\c\d\e\f\g\h\i\j\k\l\m\p\q\s\u\v\w\x\y\z"', Token::TYPE_STRING);
+        $tok = new Token('"\c\d\e\f\g\h\i\j\k\l\m\p\q\s\u\v\w\x\y\z"', TokenType::String);
         $this->assertEquals($tok->value, 'cdefghijklmpqsuvwxyz');
     }
 
     public function testExtractSymbol(): void
     {
-        $tok = new Token('@foo', Token::TYPE_SYMBOL, Token::FLAG_SYMBOL_VARIABLE);
+        $tok = new Token('@foo', TokenType::Symbol, Token::FLAG_SYMBOL_VARIABLE);
         $this->assertEquals($tok->value, 'foo');
 
-        $tok = new Token('`foo`', Token::TYPE_SYMBOL, Token::FLAG_SYMBOL_BACKTICK);
+        $tok = new Token('`foo`', TokenType::Symbol, Token::FLAG_SYMBOL_BACKTICK);
         $this->assertEquals($tok->value, 'foo');
 
-        $tok = new Token('@`foo`', Token::TYPE_SYMBOL, Token::FLAG_SYMBOL_VARIABLE);
+        $tok = new Token('@`foo`', TokenType::Symbol, Token::FLAG_SYMBOL_VARIABLE);
         $this->assertEquals($tok->value, 'foo');
 
-        $tok = new Token(':foo', Token::TYPE_SYMBOL, Token::FLAG_SYMBOL_PARAMETER);
+        $tok = new Token(':foo', TokenType::Symbol, Token::FLAG_SYMBOL_PARAMETER);
         $this->assertEquals($tok->value, 'foo');
 
-        $tok = new Token('?', Token::TYPE_SYMBOL, Token::FLAG_SYMBOL_PARAMETER);
+        $tok = new Token('?', TokenType::Symbol, Token::FLAG_SYMBOL_PARAMETER);
         $this->assertEquals($tok->value, '?');
     }
 

--- a/tests/Lexer/TokensListTest.php
+++ b/tests/Lexer/TokensListTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Lexer;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
 
 use function count;
 
@@ -26,19 +27,19 @@ class TokensListTest extends TestCase
     {
         parent::setUp();
         $this->tokens = [
-            new Token('SELECT', Token::TYPE_KEYWORD),
-            new Token(' ', Token::TYPE_WHITESPACE),
-            new Token('*', Token::TYPE_OPERATOR),
-            new Token(' ', Token::TYPE_WHITESPACE),
-            new Token('FROM', Token::TYPE_KEYWORD, Token::FLAG_KEYWORD_RESERVED),
-            new Token(' ', Token::TYPE_WHITESPACE),
-            new Token('`test`', Token::TYPE_SYMBOL),
-            new Token(' ', Token::TYPE_WHITESPACE),
-            new Token('WHERE', Token::TYPE_KEYWORD, Token::FLAG_KEYWORD_RESERVED),
-            new Token(' ', Token::TYPE_WHITESPACE),
-            new Token('name', Token::TYPE_NONE),
-            new Token('=', Token::TYPE_OPERATOR),
-            new Token('fa', Token::TYPE_NONE),
+            new Token('SELECT', TokenType::Keyword),
+            new Token(' ', TokenType::Whitespace),
+            new Token('*', TokenType::Operator),
+            new Token(' ', TokenType::Whitespace),
+            new Token('FROM', TokenType::Keyword, Token::FLAG_KEYWORD_RESERVED),
+            new Token(' ', TokenType::Whitespace),
+            new Token('`test`', TokenType::Symbol),
+            new Token(' ', TokenType::Whitespace),
+            new Token('WHERE', TokenType::Keyword, Token::FLAG_KEYWORD_RESERVED),
+            new Token(' ', TokenType::Whitespace),
+            new Token('name', TokenType::None),
+            new Token('=', TokenType::Operator),
+            new Token('fa', TokenType::None),
         ];
     }
 
@@ -87,43 +88,43 @@ class TokensListTest extends TestCase
     public function testGetNextOfType(): void
     {
         $list = new TokensList($this->tokens);
-        $this->assertEquals($this->tokens[0], $list->getNextOfType(Token::TYPE_KEYWORD));
-        $this->assertEquals($this->tokens[4], $list->getNextOfType([Token::TYPE_KEYWORD]));
-        $this->assertEquals($this->tokens[6], $list->getNextOfType([Token::TYPE_KEYWORD, Token::TYPE_SYMBOL]));
-        $this->assertEquals($this->tokens[8], $list->getNextOfType([Token::TYPE_KEYWORD, Token::TYPE_SYMBOL]));
-        $this->assertNull($list->getNextOfType(Token::TYPE_KEYWORD));
+        $this->assertEquals($this->tokens[0], $list->getNextOfType(TokenType::Keyword));
+        $this->assertEquals($this->tokens[4], $list->getNextOfType([TokenType::Keyword]));
+        $this->assertEquals($this->tokens[6], $list->getNextOfType([TokenType::Keyword, TokenType::Symbol]));
+        $this->assertEquals($this->tokens[8], $list->getNextOfType([TokenType::Keyword, TokenType::Symbol]));
+        $this->assertNull($list->getNextOfType(TokenType::Keyword));
     }
 
     public function testGetPreviousOfType(): void
     {
         $list = new TokensList($this->tokens);
         $list->idx = 9;
-        $this->assertEquals($this->tokens[8], $list->getPreviousOfType([Token::TYPE_KEYWORD, Token::TYPE_SYMBOL]));
-        $this->assertEquals($this->tokens[6], $list->getPreviousOfType([Token::TYPE_KEYWORD, Token::TYPE_SYMBOL]));
-        $this->assertEquals($this->tokens[4], $list->getPreviousOfType([Token::TYPE_KEYWORD]));
-        $this->assertEquals($this->tokens[0], $list->getPreviousOfType(Token::TYPE_KEYWORD));
-        $this->assertNull($list->getPreviousOfType(Token::TYPE_KEYWORD));
+        $this->assertEquals($this->tokens[8], $list->getPreviousOfType([TokenType::Keyword, TokenType::Symbol]));
+        $this->assertEquals($this->tokens[6], $list->getPreviousOfType([TokenType::Keyword, TokenType::Symbol]));
+        $this->assertEquals($this->tokens[4], $list->getPreviousOfType([TokenType::Keyword]));
+        $this->assertEquals($this->tokens[0], $list->getPreviousOfType(TokenType::Keyword));
+        $this->assertNull($list->getPreviousOfType(TokenType::Keyword));
     }
 
     public function testGetNextOfTypeAndFlag(): void
     {
         $list = new TokensList($this->tokens);
         $this->assertEquals($this->tokens[4], $list->getNextOfTypeAndFlag(
-            Token::TYPE_KEYWORD,
+            TokenType::Keyword,
             Token::FLAG_KEYWORD_RESERVED
         ));
         $this->assertEquals($this->tokens[8], $list->getNextOfTypeAndFlag(
-            Token::TYPE_KEYWORD,
+            TokenType::Keyword,
             Token::FLAG_KEYWORD_RESERVED
         ));
-        $this->assertNull($list->getNextOfTypeAndFlag(Token::TYPE_KEYWORD, Token::FLAG_KEYWORD_RESERVED));
+        $this->assertNull($list->getNextOfTypeAndFlag(TokenType::Keyword, Token::FLAG_KEYWORD_RESERVED));
     }
 
     public function testGetNextOfTypeAndValue(): void
     {
         $list = new TokensList($this->tokens);
-        $this->assertEquals($this->tokens[0], $list->getNextOfTypeAndValue(Token::TYPE_KEYWORD, 'SELECT'));
-        $this->assertNull($list->getNextOfTypeAndValue(Token::TYPE_KEYWORD, 'SELECT'));
+        $this->assertEquals($this->tokens[0], $list->getNextOfTypeAndValue(TokenType::Keyword, 'SELECT'));
+        $this->assertNull($list->getNextOfTypeAndValue(TokenType::Keyword, 'SELECT'));
     }
 
     public function testArrayAccess(): void

--- a/tests/Tools/ContextGeneratorTest.php
+++ b/tests/Tools/ContextGeneratorTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser\Tests\Tools;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Token;
+use PhpMyAdmin\SqlParser\TokenType;
 use PhpMyAdmin\SqlParser\Tools\ContextGenerator;
 
 use function file_get_contents;
@@ -40,15 +41,15 @@ class ContextGeneratorTest extends TestCase
         $testFiles = [getcwd() . '/tests/Tools/contexts/testContext.txt'];
         $readWords = ContextGenerator::readWords($testFiles);
         $this->assertEquals([
-            Token::TYPE_KEYWORD | Token::FLAG_KEYWORD_RESERVED => [
+            TokenType::Keyword->value | Token::FLAG_KEYWORD_RESERVED => [
                 8 => ['RESERVED'],
                 9 => ['RESERVED2','RESERVED3','RESERVED4','RESERVED5'],
             ],
-            Token::TYPE_KEYWORD | Token::FLAG_KEYWORD_FUNCTION => [8 => ['FUNCTION']],
-            Token::TYPE_KEYWORD | Token::FLAG_KEYWORD_DATA_TYPE => [8 => ['DATATYPE']],
-            Token::TYPE_KEYWORD | Token::FLAG_KEYWORD_KEY => [7 => ['KEYWORD']],
-            Token::TYPE_KEYWORD => [7 => ['NO_FLAG']],
-            Token::TYPE_KEYWORD | Token::FLAG_KEYWORD_RESERVED | 4 => [16 => ['COMPOSED KEYWORD']],
+            TokenType::Keyword->value | Token::FLAG_KEYWORD_FUNCTION => [8 => ['FUNCTION']],
+            TokenType::Keyword->value | Token::FLAG_KEYWORD_DATA_TYPE => [8 => ['DATATYPE']],
+            TokenType::Keyword->value | Token::FLAG_KEYWORD_KEY => [7 => ['KEYWORD']],
+            TokenType::Keyword->value => [7 => ['NO_FLAG']],
+            TokenType::Keyword->value | Token::FLAG_KEYWORD_RESERVED | 4 => [16 => ['COMPOSED KEYWORD']],
         ], $readWords);
     }
 

--- a/tests/data/bugs/fuzz1.out
+++ b/tests/data/bugs/fuzz1.out
@@ -7,13 +7,19 @@
         "last": 8,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 4,
+            "idx": 4,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 5
                 },
@@ -31,7 +41,11 @@
                     "token": ".2",
                     "value": 0.2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 2,
                     "position": 6
                 },
@@ -40,13 +54,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 4,
-            "idx": 4
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -85,7 +101,7 @@
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@4"
+                    "@type": "@6"
                 },
                 0
             ]

--- a/tests/data/bugs/fuzz2.out
+++ b/tests/data/bugs/fuzz2.out
@@ -7,13 +7,19 @@
         "last": 6,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 4,
+            "idx": 4,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "]",
                     "value": "]",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 5
                 },
@@ -40,13 +54,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 4,
-            "idx": 4
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -88,21 +104,21 @@
             [
                 "The name of the CTE was expected.",
                 {
-                    "@type": "@3"
+                    "@type": "@4"
                 },
                 0
             ],
             [
                 "Unexpected end of the WITH CTE.",
                 {
-                    "@type": "@3"
+                    "@type": "@4"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@3"
+                    "@type": "@4"
                 },
                 0
             ]

--- a/tests/data/bugs/fuzz3.out
+++ b/tests/data/bugs/fuzz3.out
@@ -7,13 +7,19 @@
         "last": 8,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 5,
+            "idx": 5,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "*/",
                     "value": "*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "A",
                     "value": "A",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -40,7 +54,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -49,13 +67,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 5,
-            "idx": 5
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -97,14 +117,14 @@
             [
                 "A closing bracket was expected.",
                 {
-                    "@type": "@6"
+                    "@type": "@10"
                 },
                 0
             ],
             [
                 "Unexpected end of the WITH CTE.",
                 {
-                    "@type": "@6"
+                    "@type": "@10"
                 },
                 0
             ]

--- a/tests/data/bugs/fuzz4.out
+++ b/tests/data/bugs/fuzz4.out
@@ -7,13 +7,19 @@
         "last": 9,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 4,
+            "idx": 4,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTeR",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 6
                 },
@@ -40,13 +52,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 4,
-            "idx": 4
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/bugs/fuzz5.out
+++ b/tests/data/bugs/fuzz5.out
@@ -7,13 +7,19 @@
         "last": 4,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 3,
+            "idx": 3,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "+0x",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 1,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "O",
                     "value": "O",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,13 +41,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 3,
-            "idx": 3
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -67,7 +79,7 @@
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@3"
+                    "@type": "@4"
                 },
                 0
             ]

--- a/tests/data/bugs/fuzz6.out
+++ b/tests/data/bugs/fuzz6.out
@@ -7,13 +7,19 @@
         "last": 5,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 3,
+            "idx": 3,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-+0x",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 9,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "!",
                     "value": "!",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 4
                 },
@@ -31,13 +41,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 3,
-            "idx": 3
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/bugs/gh14.out
+++ b/tests/data/bugs/gh14.out
@@ -7,13 +7,19 @@
         "last": 113,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 29,
+            "idx": 29,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`actor`",
                     "value": "actor",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 16
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +87,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 24
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -85,7 +109,9 @@
                     "token": "`actor_id`",
                     "value": "actor_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 31
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -103,7 +131,9 @@
                     "token": "SMALLINT",
                     "value": "SMALLINT",
                     "keyword": "SMALLINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 42
                 },
@@ -112,7 +142,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 50
                 },
@@ -121,7 +155,11 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 52
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -148,7 +190,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 54
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -166,7 +212,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 63
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -184,7 +234,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 72
                 },
@@ -193,7 +245,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 86
                 },
@@ -202,7 +256,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -211,7 +267,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 92
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -229,7 +289,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 107
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -247,7 +311,9 @@
                     "token": "201",
                     "value": 201,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -256,7 +322,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -265,13 +335,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 29,
-            "idx": 29
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -318,34 +388,34 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
-                            },
-                            {
-                                "@type": "@14"
-                            },
-                            {
                                 "@type": "@15"
                             },
                             {
                                 "@type": "@16"
                             },
                             {
-                                "@type": "@17"
-                            },
-                            {
                                 "@type": "@18"
-                            },
-                            {
-                                "@type": "@19"
                             },
                             {
                                 "@type": "@20"
                             },
                             {
                                 "@type": "@21"
+                            },
+                            {
+                                "@type": "@22"
+                            },
+                            {
+                                "@type": "@23"
+                            },
+                            {
+                                "@type": "@24"
+                            },
+                            {
+                                "@type": "@25"
+                            },
+                            {
+                                "@type": "@26"
                             }
                         ]
                     },

--- a/tests/data/bugs/gh16.out
+++ b/tests/data/bugs/gh16.out
@@ -7,13 +7,19 @@
         "last": 476,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 134,
+            "idx": 134,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`jos_core_acl_aro`",
                     "value": "jos_core_acl_aro",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -76,7 +100,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -85,7 +111,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 36
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -103,7 +133,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 41
                 },
@@ -112,7 +144,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 44
                 },
@@ -121,7 +155,11 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 47
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -148,7 +190,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 49
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 57
                 },
@@ -166,7 +212,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -175,7 +223,9 @@
                     "token": "`section_value`",
                     "value": "section_value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 61
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -193,7 +245,9 @@
                     "token": "varchar",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 77
                 },
@@ -202,7 +256,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 84
                 },
@@ -211,7 +267,9 @@
                     "token": "240",
                     "value": 240,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -220,7 +278,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 88
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -238,7 +300,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 90
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -256,7 +322,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 99
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -274,7 +344,11 @@
                     "token": "'0'",
                     "value": "0",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 107
                 },
@@ -283,7 +357,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 110
                 },
@@ -292,7 +368,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -301,7 +379,9 @@
                     "token": "`value`",
                     "value": "value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 114
                 },
@@ -310,7 +390,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -319,7 +401,9 @@
                     "token": "varchar",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 122
                 },
@@ -328,7 +412,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 129
                 },
@@ -337,7 +423,9 @@
                     "token": "240",
                     "value": 240,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -346,7 +434,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 133
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 134
                 },
@@ -364,7 +456,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 135
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -382,7 +478,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 144
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 151
                 },
@@ -400,7 +500,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 1,
                     "position": 152
                 },
@@ -409,7 +511,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 154
                 },
@@ -418,7 +522,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 155
                 },
@@ -427,7 +533,9 @@
                     "token": "`order_value`",
                     "value": "order_value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 158
                 },
@@ -436,7 +544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 171
                 },
@@ -445,7 +555,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 172
                 },
@@ -454,7 +566,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 175
                 },
@@ -463,7 +577,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -472,7 +588,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 178
                 },
@@ -481,7 +599,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 179
                 },
@@ -490,7 +610,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 180
                 },
@@ -499,7 +621,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 188
                 },
@@ -508,7 +632,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 189
                 },
@@ -517,7 +643,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 196
                 },
@@ -526,7 +654,9 @@
                     "token": "'0'",
                     "value": "0",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 1,
                     "position": 197
                 },
@@ -535,7 +665,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 200
                 },
@@ -544,7 +676,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 201
                 },
@@ -553,7 +687,9 @@
                     "token": "`name`",
                     "value": "name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 204
                 },
@@ -562,7 +698,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 210
                 },
@@ -571,7 +709,9 @@
                     "token": "varchar",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 211
                 },
@@ -580,7 +720,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 218
                 },
@@ -589,7 +731,9 @@
                     "token": "255",
                     "value": 255,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 219
                 },
@@ -598,7 +742,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 222
                 },
@@ -607,7 +753,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 223
                 },
@@ -616,7 +764,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 224
                 },
@@ -625,7 +775,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 232
                 },
@@ -634,7 +786,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 233
                 },
@@ -643,7 +797,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 240
                 },
@@ -652,7 +808,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 1,
                     "position": 241
                 },
@@ -661,7 +819,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 243
                 },
@@ -670,7 +830,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 244
                 },
@@ -679,7 +841,9 @@
                     "token": "`hidden`",
                     "value": "hidden",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 247
                 },
@@ -688,7 +852,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 255
                 },
@@ -697,7 +863,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 256
                 },
@@ -706,7 +874,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 259
                 },
@@ -715,7 +885,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 260
                 },
@@ -724,7 +896,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 262
                 },
@@ -733,7 +907,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 263
                 },
@@ -742,7 +918,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 264
                 },
@@ -751,7 +929,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 272
                 },
@@ -760,7 +940,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 273
                 },
@@ -769,7 +951,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 280
                 },
@@ -778,7 +962,9 @@
                     "token": "'0'",
                     "value": "0",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 1,
                     "position": 281
                 },
@@ -787,7 +973,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 284
                 },
@@ -796,7 +984,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 285
                 },
@@ -805,7 +995,9 @@
                     "token": "PRIMARY KEY",
                     "value": "PRIMARY KEY",
                     "keyword": "PRIMARY KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 288
                 },
@@ -814,7 +1006,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 299
                 },
@@ -823,7 +1017,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 300
                 },
@@ -832,7 +1028,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 301
                 },
@@ -841,7 +1039,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 305
                 },
@@ -850,7 +1050,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 306
                 },
@@ -859,7 +1061,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 307
                 },
@@ -868,7 +1072,9 @@
                     "token": "UNIQUE KEY",
                     "value": "UNIQUE KEY",
                     "keyword": "UNIQUE KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 310
                 },
@@ -877,7 +1083,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 320
                 },
@@ -886,7 +1094,9 @@
                     "token": "`jos_section_value_value_aro`",
                     "value": "jos_section_value_value_aro",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 321
                 },
@@ -895,7 +1105,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 350
                 },
@@ -904,7 +1116,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 351
                 },
@@ -913,7 +1127,9 @@
                     "token": "`section_value`",
                     "value": "section_value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 352
                 },
@@ -922,7 +1138,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 367
                 },
@@ -931,7 +1149,9 @@
                     "token": "100",
                     "value": 100,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 368
                 },
@@ -940,7 +1160,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 371
                 },
@@ -949,7 +1171,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 372
                 },
@@ -958,7 +1182,9 @@
                     "token": "`value`",
                     "value": "value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 373
                 },
@@ -967,7 +1193,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 380
                 },
@@ -976,7 +1204,9 @@
                     "token": "15",
                     "value": 15,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 381
                 },
@@ -985,7 +1215,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 383
                 },
@@ -994,7 +1226,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 384
                 },
@@ -1003,7 +1237,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 385
                 },
@@ -1012,7 +1248,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 386
                 },
@@ -1021,7 +1259,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 391
                 },
@@ -1030,7 +1270,9 @@
                     "token": "BTREE",
                     "value": "BTREE",
                     "keyword": "BTREE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 392
                 },
@@ -1039,7 +1281,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 397
                 },
@@ -1048,7 +1292,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 398
                 },
@@ -1057,7 +1303,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 401
                 },
@@ -1066,7 +1314,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 404
                 },
@@ -1075,7 +1325,9 @@
                     "token": "`jos_gacl_hidden_aro`",
                     "value": "jos_gacl_hidden_aro",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 405
                 },
@@ -1084,7 +1336,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 426
                 },
@@ -1093,7 +1347,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 427
                 },
@@ -1102,7 +1358,9 @@
                     "token": "`hidden`",
                     "value": "hidden",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 428
                 },
@@ -1111,7 +1369,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 436
                 },
@@ -1120,7 +1380,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 437
                 },
@@ -1129,7 +1391,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 438
                 },
@@ -1138,7 +1402,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 439
                 },
@@ -1147,7 +1413,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 440
                 },
@@ -1156,7 +1424,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 446
                 },
@@ -1165,7 +1435,11 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 447
                 },
@@ -1174,7 +1448,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 453
                 },
@@ -1183,7 +1459,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 454
                 },
@@ -1192,7 +1470,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 469
                 },
@@ -1201,7 +1481,9 @@
                     "token": "latin1",
                     "value": "latin1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@137"
+                    },
                     "flags": 0,
                     "position": 470
                 },
@@ -1210,13 +1492,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 134,
-            "idx": 134
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/bugs/gh234.out
+++ b/tests/data/bugs/gh234.out
@@ -7,13 +7,19 @@
         "last": 101,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 27,
+            "idx": 27,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`mail_template`",
                     "value": "mail_template",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -67,7 +87,9 @@
                     "token": "CHANGE",
                     "value": "CHANGE",
                     "keyword": "CHANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 28
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -85,7 +109,9 @@
                     "token": "COLUMN",
                     "value": "COLUMN",
                     "keyword": "COLUMN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 35
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -103,7 +131,9 @@
                     "token": "`mtpl_group`",
                     "value": "mtpl_group",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 42
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -121,7 +153,9 @@
                     "token": "`mtpl_group`",
                     "value": "mtpl_group",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 55
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -139,7 +175,9 @@
                     "token": "ENUM",
                     "value": "ENUM",
                     "keyword": "ENUM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 9,
                     "position": 68
                 },
@@ -148,7 +186,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 72
                 },
@@ -157,7 +199,11 @@
                     "token": "'ORDER'",
                     "value": "ORDER",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 73
                 },
@@ -166,7 +212,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -184,7 +234,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -202,7 +256,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 87
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -220,7 +278,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 95
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -238,7 +300,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -247,13 +313,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 27,
-            "idx": 27
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -301,15 +367,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@14"
-                            },
-                            {
-                                "@type": "@15"
-                            },
-                            {
-                                "@type": "@16"
-                            },
-                            {
                                 "@type": "@17"
                             },
                             {
@@ -322,13 +379,7 @@
                                 "@type": "@20"
                             },
                             {
-                                "@type": "@21"
-                            },
-                            {
                                 "@type": "@22"
-                            },
-                            {
-                                "@type": "@23"
                             },
                             {
                                 "@type": "@24"
@@ -338,6 +389,21 @@
                             },
                             {
                                 "@type": "@26"
+                            },
+                            {
+                                "@type": "@27"
+                            },
+                            {
+                                "@type": "@28"
+                            },
+                            {
+                                "@type": "@29"
+                            },
+                            {
+                                "@type": "@30"
+                            },
+                            {
+                                "@type": "@31"
                             }
                         ]
                     }

--- a/tests/data/bugs/gh317.out
+++ b/tests/data/bugs/gh317.out
@@ -7,13 +7,19 @@
         "last": 51,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`demo`",
                     "value": "demo",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "ADD",
                     "value": "ADD",
                     "keyword": "ADD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,7 +109,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 23
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +131,9 @@
                     "token": "`IDX_REPAIR`",
                     "value": "IDX_REPAIR",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -121,7 +153,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -130,7 +166,9 @@
                     "token": "`REPAIR`",
                     "value": "REPAIR",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 41
                 },
@@ -139,7 +177,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 49
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -157,13 +201,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -211,13 +255,13 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@14"
+                                "@type": "@17"
                             },
                             {
-                                "@type": "@15"
+                                "@type": "@19"
                             },
                             {
-                                "@type": "@16"
+                                "@type": "@20"
                             }
                         ]
                     }

--- a/tests/data/bugs/gh478.out
+++ b/tests/data/bugs/gh478.out
@@ -7,13 +7,19 @@
         "last": 150,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 49,
+            "idx": 49,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`MY_TABLE`",
                     "value": "MY_TABLE",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +87,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 23
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -85,7 +109,9 @@
                     "token": "`FOO`",
                     "value": "FOO",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 30
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -103,7 +131,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 36
                 },
@@ -112,7 +142,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 39
                 },
@@ -121,7 +155,11 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -148,7 +190,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 48
                 },
@@ -166,7 +212,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -175,7 +223,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -193,7 +245,9 @@
                     "token": "`MY_COLUMN`",
                     "value": "MY_COLUMN",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 57
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -211,7 +267,9 @@
                     "token": "ENUM",
                     "value": "ENUM",
                     "keyword": "ENUM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 9,
                     "position": 69
                 },
@@ -220,7 +278,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 73
                 },
@@ -229,7 +289,11 @@
                     "token": "'INSERT'",
                     "value": "INSERT",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 74
                 },
@@ -238,7 +302,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 82
                 },
@@ -247,7 +313,9 @@
                     "token": "'UPDATE'",
                     "value": "UPDATE",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@32"
+                    },
                     "flags": 1,
                     "position": 83
                 },
@@ -256,7 +324,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 91
                 },
@@ -265,7 +335,9 @@
                     "token": "'DELETE'",
                     "value": "DELETE",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@32"
+                    },
                     "flags": 1,
                     "position": 92
                 },
@@ -274,7 +346,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 100
                 },
@@ -283,7 +357,9 @@
                     "token": "'REPLACE'",
                     "value": "REPLACE",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@32"
+                    },
                     "flags": 1,
                     "position": 101
                 },
@@ -292,7 +368,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 110
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -310,7 +390,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 112
                 },
@@ -319,7 +401,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 116
                 },
@@ -328,7 +412,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -337,7 +423,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 118
                 },
@@ -346,7 +434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -355,7 +445,9 @@
                     "token": "`BAR`",
                     "value": "BAR",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 125
                 },
@@ -364,7 +456,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -373,7 +467,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 131
                 },
@@ -382,7 +478,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 138
                 },
@@ -391,7 +489,9 @@
                     "token": "255",
                     "value": 255,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -400,7 +500,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 142
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -418,7 +522,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 144
                 },
@@ -427,7 +533,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -436,7 +546,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -445,13 +557,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@55"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 49,
-            "idx": 49
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -498,22 +610,22 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
-                            },
-                            {
-                                "@type": "@14"
-                            },
-                            {
                                 "@type": "@15"
                             },
                             {
                                 "@type": "@16"
                             },
                             {
-                                "@type": "@17"
+                                "@type": "@18"
+                            },
+                            {
+                                "@type": "@20"
+                            },
+                            {
+                                "@type": "@21"
+                            },
+                            {
+                                "@type": "@22"
                             }
                         ]
                     },
@@ -538,21 +650,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@24"
-                            },
-                            {
-                                "@type": "@25"
-                            },
-                            {
-                                "@type": "@26"
-                            },
-                            {
-                                "@type": "@27"
-                            },
-                            {
-                                "@type": "@28"
-                            },
-                            {
                                 "@type": "@29"
                             },
                             {
@@ -562,9 +659,6 @@
                                 "@type": "@31"
                             },
                             {
-                                "@type": "@32"
-                            },
-                            {
                                 "@type": "@33"
                             },
                             {
@@ -572,6 +666,24 @@
                             },
                             {
                                 "@type": "@35"
+                            },
+                            {
+                                "@type": "@36"
+                            },
+                            {
+                                "@type": "@37"
+                            },
+                            {
+                                "@type": "@38"
+                            },
+                            {
+                                "@type": "@39"
+                            },
+                            {
+                                "@type": "@40"
+                            },
+                            {
+                                "@type": "@41"
                             }
                         ]
                     },
@@ -596,22 +708,22 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@42"
+                                "@type": "@48"
                             },
                             {
-                                "@type": "@43"
+                                "@type": "@49"
                             },
                             {
-                                "@type": "@44"
+                                "@type": "@50"
                             },
                             {
-                                "@type": "@45"
+                                "@type": "@51"
                             },
                             {
-                                "@type": "@46"
+                                "@type": "@52"
                             },
                             {
-                                "@type": "@47"
+                                "@type": "@53"
                             }
                         ]
                     }

--- a/tests/data/bugs/gh508.out
+++ b/tests/data/bugs/gh508.out
@@ -7,13 +7,19 @@
         "last": 4,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 2,
+            "idx": 2,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "0X0F",
                     "value": "0X0F",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,13 +28,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 2,
-            "idx": 2
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/bugs/gh511.out
+++ b/tests/data/bugs/gh511.out
@@ -7,13 +7,19 @@
         "last": 201,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 56,
+            "idx": 56,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "users_type",
                     "value": "users_type",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +87,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 23
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -85,7 +109,9 @@
                     "token": "limitations",
                     "value": "limitations",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -103,7 +131,9 @@
                     "token": "ENUM",
                     "value": "ENUM",
                     "keyword": "ENUM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 9,
                     "position": 42
                 },
@@ -112,7 +142,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 46
                 },
@@ -121,7 +155,11 @@
                     "token": "'tout'",
                     "value": "tout",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 47
                 },
@@ -130,7 +168,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 53
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -148,7 +190,9 @@
                     "token": "'rien'",
                     "value": "rien",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 1,
                     "position": 55
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 61
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -175,7 +223,9 @@
                     "token": "'bu'",
                     "value": "bu",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 1,
                     "position": 63
                 },
@@ -184,7 +234,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 67
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -202,7 +256,9 @@
                     "token": "'agence'",
                     "value": "agence",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 1,
                     "position": 69
                 },
@@ -211,7 +267,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -229,7 +289,9 @@
                     "token": "'agence_limite'",
                     "value": "agence_limite",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 1,
                     "position": 79
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 94
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -256,7 +322,9 @@
                     "token": "'n-1'",
                     "value": "n-1",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 1,
                     "position": 96
                 },
@@ -265,7 +333,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 101
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -283,7 +355,9 @@
                     "token": "'agence_inactif'",
                     "value": "agence_inactif",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 1,
                     "position": 103
                 },
@@ -292,7 +366,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 119
                 },
@@ -301,7 +377,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -310,7 +390,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -319,7 +401,9 @@
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 122
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 128
                 },
@@ -337,7 +423,9 @@
                     "token": "users_type",
                     "value": "users_type",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -346,7 +434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -355,7 +445,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 140
                 },
@@ -364,7 +456,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -373,7 +467,9 @@
                     "token": "limitations",
                     "value": "limitations",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 144
                 },
@@ -382,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 155
                 },
@@ -391,7 +489,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 156
                 },
@@ -400,7 +500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -409,7 +511,9 @@
                     "token": "'agence_inactif'",
                     "value": "agence_inactif",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 1,
                     "position": 158
                 },
@@ -418,7 +522,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 174
                 },
@@ -427,7 +533,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 175
                 },
@@ -436,7 +544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 180
                 },
@@ -445,7 +555,9 @@
                     "token": "id_users_type",
                     "value": "id_users_type",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 181
                 },
@@ -454,7 +566,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 194
                 },
@@ -463,7 +577,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 195
                 },
@@ -472,7 +588,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 196
                 },
@@ -481,7 +599,11 @@
                     "token": "19",
                     "value": 19,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 197
                 },
@@ -490,7 +612,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 199
                 },
@@ -499,7 +623,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 200
                 },
@@ -508,13 +634,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 56,
-            "idx": 56
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -561,28 +687,13 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
-                            },
-                            {
-                                "@type": "@14"
-                            },
-                            {
                                 "@type": "@15"
                             },
                             {
                                 "@type": "@16"
                             },
                             {
-                                "@type": "@17"
-                            },
-                            {
                                 "@type": "@18"
-                            },
-                            {
-                                "@type": "@19"
                             },
                             {
                                 "@type": "@20"
@@ -625,6 +736,21 @@
                             },
                             {
                                 "@type": "@33"
+                            },
+                            {
+                                "@type": "@34"
+                            },
+                            {
+                                "@type": "@35"
+                            },
+                            {
+                                "@type": "@36"
+                            },
+                            {
+                                "@type": "@37"
+                            },
+                            {
+                                "@type": "@38"
                             }
                         ]
                     }

--- a/tests/data/bugs/gh9.out
+++ b/tests/data/bugs/gh9.out
@@ -7,13 +7,19 @@
         "last": 213,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 75,
+            "idx": 75,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -85,7 +111,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -94,7 +122,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -103,7 +133,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -121,7 +155,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 31
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -139,7 +177,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -157,7 +199,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -175,7 +221,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -184,7 +232,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -193,7 +243,9 @@
                     "token": "START TRANSACTION",
                     "value": "START TRANSACTION",
                     "keyword": "START TRANSACTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 49
                 },
@@ -202,7 +254,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -211,7 +267,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -220,7 +278,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 69
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -238,7 +300,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 76
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,11 @@
                     "token": "`tb`",
                     "value": "tb",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 82
                 },
@@ -265,7 +335,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +346,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 87
                 },
@@ -283,7 +357,9 @@
                     "token": "`uid`",
                     "value": "uid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 2,
                     "position": 88
                 },
@@ -292,7 +368,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -301,7 +379,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 94
                 },
@@ -310,7 +390,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -319,7 +401,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 98
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -337,7 +423,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 107
                 },
@@ -346,7 +434,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -355,7 +445,9 @@
                     "token": "`position`",
                     "value": "position",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 2,
                     "position": 116
                 },
@@ -364,7 +456,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -373,7 +467,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 127
                 },
@@ -382,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -391,7 +489,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 131
                 },
@@ -400,7 +500,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 139
                 },
@@ -409,7 +511,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -418,7 +522,9 @@
                     "token": "PRIMARY KEY",
                     "value": "PRIMARY KEY",
                     "keyword": "PRIMARY KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 141
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -436,7 +544,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 153
                 },
@@ -445,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -454,7 +566,9 @@
                     "token": "`uid`",
                     "value": "uid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 2,
                     "position": 155
                 },
@@ -463,7 +577,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -472,7 +588,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 161
                 },
@@ -481,7 +599,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 162
                 },
@@ -490,7 +610,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 163
                 },
@@ -499,7 +621,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 164
                 },
@@ -508,7 +632,9 @@
                     "token": "INDEX",
                     "value": "INDEX",
                     "keyword": "INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 165
                 },
@@ -517,7 +643,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 170
                 },
@@ -526,7 +654,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 171
                 },
@@ -535,7 +665,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 172
                 },
@@ -544,7 +676,9 @@
                     "token": "`position`",
                     "value": "position",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 2,
                     "position": 173
                 },
@@ -553,7 +687,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 183
                 },
@@ -562,7 +698,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 184
                 },
@@ -571,7 +709,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 185
                 },
@@ -580,7 +720,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 186
                 },
@@ -589,7 +731,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 187
                 },
@@ -598,7 +742,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 188
                 },
@@ -607,7 +753,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 194
                 },
@@ -616,7 +764,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 195
                 },
@@ -625,7 +775,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 196
                 },
@@ -634,7 +786,9 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 197
                 },
@@ -643,7 +797,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 0,
                     "position": 203
                 },
@@ -652,7 +808,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 204
                 },
@@ -661,7 +819,9 @@
                     "token": "COMMIT",
                     "value": "COMMIT",
                     "keyword": "COMMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 206
                 },
@@ -670,7 +830,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 0,
                     "position": 212
                 },
@@ -679,13 +841,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 75,
-            "idx": 75
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -893,35 +1055,35 @@
             [
                 "This type of clause was previously parsed.",
                 {
-                    "@type": "@12"
+                    "@type": "@16"
                 },
                 0
             ],
             [
                 "A new statement was found, but no delimiter between it and the previous one.",
                 {
-                    "@type": "@22"
+                    "@type": "@26"
                 },
                 0
             ],
             [
                 "A comma or a closing bracket was expected.",
                 {
-                    "@type": "@40"
+                    "@type": "@46"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@51"
+                    "@type": "@57"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@57"
+                    "@type": "@63"
                 },
                 0
             ]

--- a/tests/data/bugs/pma11800.out
+++ b/tests/data/bugs/pma11800.out
@@ -7,13 +7,19 @@
         "last": 27,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 9,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "'a'",
                     "value": "a",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +65,9 @@
                     "token": "REGEXP",
                     "value": "REGEXP",
                     "keyword": "REGEXP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "'^[a-d]'",
                     "value": "^[a-d]",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 18
                 },
@@ -76,7 +98,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,13 +111,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 9,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/bugs/pma11836.out
+++ b/tests/data/bugs/pma11836.out
@@ -7,13 +7,19 @@
         "last": 94,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 45,
+            "idx": 45,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "alumnos",
                     "value": "alumnos",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +133,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -121,7 +155,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 31
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -139,7 +177,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 33
                 },
@@ -148,7 +188,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -157,7 +199,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -175,7 +221,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 39
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -193,7 +243,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -202,7 +256,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -220,7 +278,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -229,7 +289,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 46
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -247,7 +311,9 @@
                     "token": "nombre",
                     "value": "nombre",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -256,7 +322,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 54
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -274,7 +344,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 56
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -292,7 +366,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -310,7 +388,9 @@
                     "token": "not in",
                     "value": "NOT IN",
                     "keyword": "NOT IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 39,
                     "position": 63
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -328,7 +410,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 70
                 },
@@ -337,7 +421,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 71
                 },
@@ -346,7 +432,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -355,7 +443,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -364,7 +454,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -373,7 +465,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 81
                 },
@@ -382,7 +476,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -391,7 +487,9 @@
                     "token": "alumnos",
                     "value": "alumnos",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -400,7 +498,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 93
                 },
@@ -409,13 +509,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 45,
-            "idx": 45
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/bugs/pma11843.out
+++ b/tests/data/bugs/pma11843.out
@@ -7,13 +7,19 @@
         "last": 119,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 34,
+            "idx": 34,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`mytable`",
                     "value": "mytable",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 23
                 },
@@ -76,7 +100,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 29
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -103,7 +133,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 34
                 },
@@ -112,7 +144,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 37
                 },
@@ -121,7 +155,11 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +190,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 42
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 50
                 },
@@ -166,7 +212,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -175,7 +223,9 @@
                     "token": "`created_at`",
                     "value": "created_at",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 56
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -193,7 +245,9 @@
                     "token": "timestamp",
                     "value": "timestamp",
                     "keyword": "TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 69
                 },
@@ -202,7 +256,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 78
                 },
@@ -211,7 +267,9 @@
                     "token": "6",
                     "value": 6,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -220,7 +278,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -238,7 +300,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 82
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -256,7 +322,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 91
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -274,7 +344,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 99
                 },
@@ -283,7 +355,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -292,7 +366,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 117
                 },
@@ -301,7 +377,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -310,13 +390,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 34,
-            "idx": 34
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/bugs/pma11879.out
+++ b/tests/data/bugs/pma11879.out
@@ -7,13 +7,19 @@
         "last": 175,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 54,
+            "idx": 54,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "tbproject",
                     "value": "tbproject",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 23
                 },
@@ -67,7 +89,11 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 24
                 },
@@ -76,7 +102,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 28
                 },
@@ -85,7 +113,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -94,7 +124,9 @@
                     "token": "`name`",
                     "value": "name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 30
                 },
@@ -103,7 +135,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 36
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -121,7 +157,9 @@
                     "token": "`description`",
                     "value": "description",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 38
                 },
@@ -130,7 +168,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 51
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -148,7 +190,9 @@
                     "token": "`create_dt`",
                     "value": "create_dt",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 53
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 64
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -175,7 +223,9 @@
                     "token": "`dbtype`",
                     "value": "dbtype",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 66
                 },
@@ -184,7 +234,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 74
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -202,7 +256,9 @@
                     "token": "`useclause`",
                     "value": "useclause",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 76
                 },
@@ -211,7 +267,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 87
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -229,7 +289,9 @@
                     "token": "`sync_comments`",
                     "value": "sync_comments",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 89
                 },
@@ -238,7 +300,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 104
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -256,7 +322,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 106
                 },
@@ -265,7 +333,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -274,7 +344,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 115
                 },
@@ -283,7 +355,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 116
                 },
@@ -292,7 +366,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 120
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -310,7 +388,11 @@
                     "token": "'testdb'",
                     "value": "testdb",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 122
                 },
@@ -319,7 +401,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 130
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -337,7 +423,9 @@
                     "token": "'Descrizione test'",
                     "value": "Descrizione test",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@41"
+                    },
                     "flags": 1,
                     "position": 132
                 },
@@ -346,7 +434,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 150
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 151
                 },
@@ -364,7 +456,9 @@
                     "token": "NOW",
                     "value": "NOW",
                     "keyword": "NOW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 152
                 },
@@ -373,7 +467,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 155
                 },
@@ -382,7 +478,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 156
                 },
@@ -391,7 +489,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 157
                 },
@@ -400,7 +500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -409,7 +511,9 @@
                     "token": "'mySQL'",
                     "value": "mySQL",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@41"
+                    },
                     "flags": 1,
                     "position": 159
                 },
@@ -418,7 +522,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 166
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 167
                 },
@@ -436,7 +544,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@41"
+                    },
                     "flags": 1,
                     "position": 168
                 },
@@ -445,7 +555,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 170
                 },
@@ -454,7 +566,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 171
                 },
@@ -463,7 +577,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 172
                 },
@@ -472,7 +590,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 173
                 },
@@ -481,7 +601,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 174
                 },
@@ -490,13 +614,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 54,
-            "idx": 54
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lex.out
+++ b/tests/data/lexer/lex.out
@@ -7,13 +7,19 @@
         "last": 9,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 5,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "\\",
                     "value": "\\",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "\\",
                     "value": "\\",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,13 +65,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 5,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexBool.out
+++ b/tests/data/lexer/lexBool.out
@@ -7,13 +7,19 @@
         "last": 18,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 7,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "true",
                     "value": true,
                     "keyword": null,
-                    "type": 5,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Bool",
+                        "value": 5
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 11
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +78,9 @@
                     "token": "FalSe",
                     "value": false,
                     "keyword": null,
-                    "type": 5,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -67,13 +89,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 7,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexComment.out
+++ b/tests/data/lexer/lexComment.out
@@ -7,13 +7,19 @@
         "last": 111,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 25,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "# comment",
                     "value": "# comment",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 1,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,11 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +65,9 @@
                     "token": "/*!50000",
                     "value": "/*!50000",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 10,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -67,7 +87,9 @@
                     "token": "STRAIGHT_JOIN",
                     "value": "STRAIGHT_JOIN",
                     "keyword": "STRAIGHT_JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 26
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -85,7 +109,9 @@
                     "token": "*/",
                     "value": "*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 2,
                     "position": 40
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -103,7 +131,11 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -121,7 +155,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 48
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -139,7 +177,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -148,7 +188,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 59
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -166,7 +212,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -184,7 +234,9 @@
                     "token": "/* select query */",
                     "value": "/* select query */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -193,7 +245,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -202,7 +256,9 @@
                     "token": "-- comment",
                     "value": "-- comment",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 4,
                     "position": 87
                 },
@@ -211,7 +267,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -220,7 +278,9 @@
                     "token": "-- comment 2",
                     "value": "-- comment 2",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 4,
                     "position": 98
                 },
@@ -229,13 +289,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 25,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexCommentEnd.out
+++ b/tests/data/lexer/lexCommentEnd.out
@@ -7,13 +7,19 @@
         "last": 23,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,11 @@
                     "token": "-- comment",
                     "value": "-- comment",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": "--",
                     "value": "--",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 4,
                     "position": 20
                 },
@@ -76,13 +100,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexDelimiter.out
+++ b/tests/data/lexer/lexDelimiter.out
@@ -7,13 +7,19 @@
         "last": 53,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,11 @@
                     "token": "GO",
                     "value": "GO",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -40,7 +54,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +65,11 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -76,7 +100,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 21
                 },
@@ -85,7 +113,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +124,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -103,7 +135,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -121,7 +157,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -139,7 +179,9 @@
                     "token": "GO",
                     "value": "GO",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -148,7 +190,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -157,7 +201,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 36
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -175,7 +223,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -193,7 +245,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -211,7 +267,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -220,13 +278,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 0
+            ]
         },
         "delimiter": "GO",
         "delimiterLen": 2,

--- a/tests/data/lexer/lexDelimiter2.out
+++ b/tests/data/lexer/lexDelimiter2.out
@@ -7,13 +7,19 @@
         "last": 56,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 29,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMTER",
                     "value": "DELIMTER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -31,7 +41,11 @@
                     "token": "/",
                     "value": "/",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 1,
                     "position": 9
                 },
@@ -40,7 +54,9 @@
                     "token": "/",
                     "value": "/",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 10
                 },
@@ -49,7 +65,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -58,7 +76,11 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 12
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +100,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +111,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 20
                 },
@@ -94,7 +122,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -112,7 +144,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 23
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -130,7 +166,9 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -148,7 +188,9 @@
                     "token": "/",
                     "value": "/",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 33
                 },
@@ -157,7 +199,9 @@
                     "token": "/",
                     "value": "/",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 34
                 },
@@ -166,7 +210,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -175,7 +221,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 36
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -193,7 +243,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -211,7 +265,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -229,7 +287,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -247,7 +309,9 @@
                     "token": "/",
                     "value": "/",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 54
                 },
@@ -256,7 +320,9 @@
                     "token": "/",
                     "value": "/",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 55
                 },
@@ -265,13 +331,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 29,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexDelimiterErr1.out
+++ b/tests/data/lexer/lexDelimiterErr1.out
@@ -7,13 +7,19 @@
         "last": 9,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 2,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,13 +28,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 2,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexDelimiterErr2.out
+++ b/tests/data/lexer/lexDelimiterErr2.out
@@ -7,13 +7,19 @@
         "last": 11,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 3,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " \r",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,13 +41,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 3,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexDelimiterErr3.out
+++ b/tests/data/lexer/lexDelimiterErr3.out
@@ -7,13 +7,19 @@
         "last": 11,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 4,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -31,7 +41,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -40,13 +54,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 4,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexDelimiterLen.out
+++ b/tests/data/lexer/lexDelimiterLen.out
@@ -7,13 +7,19 @@
         "last": 73,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 13,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,11 @@
                     "token": "abcdefghijklmno",
                     "value": "abcdefghijklmno",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -40,7 +54,9 @@
                     "token": "pqrstuvwxyz",
                     "value": "pqrstuvwxyz",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -49,7 +65,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -58,7 +76,11 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 37
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -76,7 +100,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -85,7 +113,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -94,7 +124,9 @@
                     "token": "abcdefghijklmno",
                     "value": "abcdefghijklmno",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -103,7 +135,9 @@
                     "token": "pqrstuvwxyz",
                     "value": "pqrstuvwxyz",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -112,7 +146,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -121,13 +157,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 13,
-            "idx": 0
+            ]
         },
         "delimiter": "abcdefghijklmno",
         "delimiterLen": 15,

--- a/tests/data/lexer/lexKeyword.out
+++ b/tests/data/lexer/lexKeyword.out
@@ -7,13 +7,19 @@
         "last": 8,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 4,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,13 +54,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 4,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexKeyword2.out
+++ b/tests/data/lexer/lexKeyword2.out
@@ -7,13 +7,19 @@
         "last": 25,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "tbl",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 10
                 },
@@ -49,7 +67,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +89,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": "tbl",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,13 +122,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexLabel1.out
+++ b/tests/data/lexer/lexLabel1.out
@@ -7,13 +7,19 @@
         "last": 187,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 73,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "PROCEDURE",
                     "value": "PROCEDURE",
                     "keyword": "PROCEDURE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +63,11 @@
                     "token": "doiterate",
                     "value": "doiterate",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -58,7 +76,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 26
                 },
@@ -67,7 +89,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -85,7 +111,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 30
                 },
@@ -94,7 +122,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -103,7 +133,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -112,7 +144,9 @@
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -121,7 +155,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -130,7 +166,11 @@
                     "token": "label1 :",
                     "value": "label1 :",
                     "keyword": null,
-                    "type": 10,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Label",
+                        "value": 10
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -148,7 +190,9 @@
                     "token": "LOOP",
                     "value": "LOOP",
                     "keyword": "LOOP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 52
                 },
@@ -157,7 +201,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -166,7 +212,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 61
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -184,7 +234,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -202,7 +256,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -220,7 +278,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -238,7 +300,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 73
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -256,7 +322,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -265,7 +335,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -274,7 +348,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -283,7 +359,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 82
                 },
@@ -292,7 +370,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -301,7 +381,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -310,7 +392,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -319,7 +403,9 @@
                     "token": "<",
                     "value": "<",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 88
                 },
@@ -328,7 +414,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -337,7 +425,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -346,7 +436,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -355,7 +447,9 @@
                     "token": "THEN",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 93
                 },
@@ -364,7 +458,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -373,7 +469,9 @@
                     "token": "ITERATE",
                     "value": "ITERATE",
                     "keyword": "ITERATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 104
                 },
@@ -382,7 +480,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -391,7 +491,9 @@
                     "token": "label1",
                     "value": "label1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -400,7 +502,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -409,7 +513,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -418,7 +524,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 124
                 },
@@ -427,7 +535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -436,7 +546,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 128
                 },
@@ -445,7 +557,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -454,7 +568,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -463,7 +579,9 @@
                     "token": "LEAVE",
                     "value": "LEAVE",
                     "keyword": "LEAVE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 136
                 },
@@ -472,7 +590,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -481,7 +601,9 @@
                     "token": "label1",
                     "value": "label1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -490,7 +612,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -499,7 +623,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -508,7 +634,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 152
                 },
@@ -517,7 +645,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 155
                 },
@@ -526,7 +656,9 @@
                     "token": "LOOP",
                     "value": "LOOP",
                     "keyword": "LOOP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 156
                 },
@@ -535,7 +667,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -544,7 +678,9 @@
                     "token": "label1",
                     "value": "label1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 161
                 },
@@ -553,7 +689,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 167
                 },
@@ -562,7 +700,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 168
                 },
@@ -571,7 +711,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 171
                 },
@@ -580,7 +722,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 174
                 },
@@ -589,7 +733,11 @@
                     "token": "@x",
                     "value": "x",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 175
                 },
@@ -598,7 +746,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 177
                 },
@@ -607,7 +757,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 178
                 },
@@ -616,7 +768,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 179
                 },
@@ -625,7 +779,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 180
                 },
@@ -634,7 +790,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 182
                 },
@@ -643,7 +801,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 183
                 },
@@ -652,7 +812,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 184
                 },
@@ -661,13 +823,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 73,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexLabel2.out
+++ b/tests/data/lexer/lexLabel2.out
@@ -7,13 +7,19 @@
         "last": 186,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 73,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "PROCEDURE",
                     "value": "PROCEDURE",
                     "keyword": "PROCEDURE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +63,11 @@
                     "token": "doiterate",
                     "value": "doiterate",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -58,7 +76,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 26
                 },
@@ -67,7 +89,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -85,7 +111,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 30
                 },
@@ -94,7 +122,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -103,7 +133,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -112,7 +144,9 @@
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -121,7 +155,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -130,7 +166,11 @@
                     "token": "label1:",
                     "value": "label1:",
                     "keyword": null,
-                    "type": 10,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Label",
+                        "value": 10
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +190,9 @@
                     "token": "LOOP",
                     "value": "LOOP",
                     "keyword": "LOOP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 51
                 },
@@ -157,7 +201,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -166,7 +212,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 60
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -184,7 +234,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -202,7 +256,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 67
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -220,7 +278,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -238,7 +300,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 72
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -256,7 +322,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -265,7 +335,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -274,7 +348,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -283,7 +359,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 81
                 },
@@ -292,7 +370,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -301,7 +381,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -310,7 +392,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -319,7 +403,9 @@
                     "token": "<",
                     "value": "<",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 87
                 },
@@ -328,7 +414,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -337,7 +425,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -346,7 +436,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -355,7 +447,9 @@
                     "token": "THEN",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 92
                 },
@@ -364,7 +458,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -373,7 +469,9 @@
                     "token": "ITERATE",
                     "value": "ITERATE",
                     "keyword": "ITERATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 103
                 },
@@ -382,7 +480,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -391,7 +491,9 @@
                     "token": "label1",
                     "value": "label1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -400,7 +502,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -409,7 +513,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -418,7 +524,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 123
                 },
@@ -427,7 +535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -436,7 +546,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 127
                 },
@@ -445,7 +557,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -454,7 +568,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -463,7 +579,9 @@
                     "token": "LEAVE",
                     "value": "LEAVE",
                     "keyword": "LEAVE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 135
                 },
@@ -472,7 +590,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -481,7 +601,9 @@
                     "token": "label1",
                     "value": "label1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -490,7 +612,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -499,7 +623,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -508,7 +634,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 151
                 },
@@ -517,7 +645,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -526,7 +656,9 @@
                     "token": "LOOP",
                     "value": "LOOP",
                     "keyword": "LOOP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 155
                 },
@@ -535,7 +667,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 159
                 },
@@ -544,7 +678,9 @@
                     "token": "label1",
                     "value": "label1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -553,7 +689,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 166
                 },
@@ -562,7 +700,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 167
                 },
@@ -571,7 +711,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 170
                 },
@@ -580,7 +722,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 173
                 },
@@ -589,7 +733,11 @@
                     "token": "@x",
                     "value": "x",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 174
                 },
@@ -598,7 +746,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -607,7 +757,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 177
                 },
@@ -616,7 +768,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 178
                 },
@@ -625,7 +779,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 179
                 },
@@ -634,7 +790,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 181
                 },
@@ -643,7 +801,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 182
                 },
@@ -652,7 +812,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 183
                 },
@@ -661,13 +823,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 73,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexNoLabel.out
+++ b/tests/data/lexer/lexNoLabel.out
@@ -7,13 +7,19 @@
         "last": 63,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "wins",
                     "value": "wins",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,9 @@
                     "token": "players",
                     "value": "players",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 25
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +131,9 @@
                     "token": "auth",
                     "value": "auth",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -121,7 +153,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 36
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -139,7 +177,11 @@
                     "token": "'[U1:123456789]'",
                     "value": "[U1:123456789]",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 38
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -157,7 +201,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 55
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -175,7 +223,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -184,7 +236,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -193,13 +247,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexNumber.out
+++ b/tests/data/lexer/lexNumber.out
@@ -7,13 +7,19 @@
         "last": 176,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 75,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "12",
                     "value": 12,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 9
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -58,7 +78,9 @@
                     "token": "34",
                     "value": 34,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -67,7 +89,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 13
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -85,7 +111,9 @@
                     "token": "5.67",
                     "value": 5.67,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 15
                 },
@@ -94,7 +122,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -112,7 +144,9 @@
                     "token": "0x89",
                     "value": 137,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 21
                 },
@@ -121,7 +155,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 25
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -139,7 +177,9 @@
                     "token": "-10",
                     "value": -10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 8,
                     "position": 27
                 },
@@ -148,7 +188,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -166,7 +210,9 @@
                     "token": "--11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 8,
                     "position": 32
                 },
@@ -175,7 +221,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 36
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -193,7 +243,9 @@
                     "token": "+12",
                     "value": 12,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -202,7 +254,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -220,7 +276,9 @@
                     "token": ".15",
                     "value": 0.15,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 43
                 },
@@ -229,7 +287,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 46
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -247,7 +309,9 @@
                     "token": "0xFFa",
                     "value": 4090,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 48
                 },
@@ -256,7 +320,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 53
                 },
@@ -265,7 +331,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -274,7 +342,9 @@
                     "token": "0xfFA",
                     "value": 4090,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 55
                 },
@@ -283,7 +353,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 60
                 },
@@ -292,7 +364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -301,7 +375,9 @@
                     "token": "+0xfFA",
                     "value": 4090,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 62
                 },
@@ -310,7 +386,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 68
                 },
@@ -319,7 +397,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -328,7 +408,9 @@
                     "token": "-0xFFa",
                     "value": -4090,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 70
                 },
@@ -337,7 +419,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 76
                 },
@@ -346,7 +430,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -355,7 +441,9 @@
                     "token": "-0xfFA",
                     "value": -4090,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 78
                 },
@@ -364,7 +452,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 84
                 },
@@ -373,7 +463,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -382,7 +474,9 @@
                     "token": "1e-10",
                     "value": 1.0e-10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 4,
                     "position": 86
                 },
@@ -391,7 +485,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 91
                 },
@@ -400,7 +496,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -409,7 +507,9 @@
                     "token": "1e10",
                     "value": 10000000000.0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 4,
                     "position": 93
                 },
@@ -418,7 +518,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 97
                 },
@@ -427,7 +529,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -436,7 +540,9 @@
                     "token": ".5e10",
                     "value": 5000000000.0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 6,
                     "position": 99
                 },
@@ -445,7 +551,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 104
                 },
@@ -454,7 +562,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -463,7 +573,9 @@
                     "token": "b'10'",
                     "value": "b'10'",
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 106
                 },
@@ -472,7 +584,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -481,7 +597,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -490,7 +608,11 @@
                     "token": "-- invalid numbers",
                     "value": "-- invalid numbers",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 113
                 },
@@ -499,7 +621,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -508,7 +632,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 132
                 },
@@ -517,7 +643,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -526,7 +654,11 @@
                     "token": "12ex10",
                     "value": "12ex10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -535,7 +667,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 145
                 },
@@ -544,7 +678,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 146
                 },
@@ -553,7 +689,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@66"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -562,7 +700,11 @@
                     "token": "'15'",
                     "value": "15",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 148
                 },
@@ -571,7 +713,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 152
                 },
@@ -580,7 +724,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 153
                 },
@@ -589,7 +735,9 @@
                     "token": "0XFfA",
                     "value": "0XFfA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@66"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -598,7 +746,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 159
                 },
@@ -607,7 +757,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -616,7 +768,9 @@
                     "token": "-",
                     "value": "-",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 161
                 },
@@ -625,7 +779,9 @@
                     "token": "0XFfA",
                     "value": "0XFfA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@66"
+                    },
                     "flags": 0,
                     "position": 162
                 },
@@ -634,7 +790,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 167
                 },
@@ -643,7 +801,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 168
                 },
@@ -652,7 +812,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 169
                 },
@@ -661,7 +823,9 @@
                     "token": "0XFfA",
                     "value": "0XFfA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@66"
+                    },
                     "flags": 0,
                     "position": 170
                 },
@@ -670,7 +834,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 0,
                     "position": 175
                 },
@@ -679,13 +845,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 75,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexOperator.out
+++ b/tests/data/lexer/lexOperator.out
@@ -7,13 +7,19 @@
         "last": 12,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,11 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 1,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -67,7 +89,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -76,13 +100,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexOperatorStarIsArithmetic.out
+++ b/tests/data/lexer/lexOperatorStarIsArithmetic.out
@@ -7,13 +7,19 @@
         "last": 2429,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 672,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 1,
                     "position": 8
                 },
@@ -49,7 +67,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -67,7 +89,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 11
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -85,7 +111,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -103,7 +133,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 20
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -121,7 +155,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -130,7 +166,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -139,7 +177,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -157,7 +199,9 @@
                     "token": "field",
                     "value": "field",
                     "keyword": "FIELD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 31
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -175,7 +221,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 37
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -193,7 +243,9 @@
                     "token": "8",
                     "value": 8,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -202,7 +254,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -211,7 +265,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 41
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -229,7 +287,9 @@
                     "token": "8",
                     "value": 8,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -247,7 +309,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -265,7 +331,9 @@
                     "token": "field",
                     "value": "field",
                     "keyword": "FIELD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 52
                 },
@@ -274,7 +342,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -283,7 +353,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 58
                 },
@@ -292,7 +364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -301,7 +375,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -319,7 +399,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 69
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -337,7 +421,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -346,7 +432,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -355,7 +443,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 75
                 },
@@ -364,7 +454,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -373,7 +465,11 @@
                     "token": "`escaped_field`",
                     "value": "escaped_field",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 82
                 },
@@ -382,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -391,7 +489,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 98
                 },
@@ -400,7 +500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -409,7 +511,9 @@
                     "token": "16",
                     "value": 16,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -418,7 +522,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -427,7 +533,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 103
                 },
@@ -436,7 +544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -445,7 +555,9 @@
                     "token": "16",
                     "value": 16,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -454,7 +566,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -463,7 +577,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 113
                 },
@@ -472,7 +588,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -481,7 +599,9 @@
                     "token": "`escaped_field`",
                     "value": "escaped_field",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 115
                 },
@@ -490,7 +610,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -499,7 +621,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 131
                 },
@@ -508,7 +632,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 137
                 },
@@ -517,7 +643,9 @@
                     "token": "`foo`",
                     "value": "foo",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 138
                 },
@@ -526,7 +654,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -535,7 +665,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 144
                 },
@@ -544,7 +676,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 145
                 },
@@ -553,7 +687,9 @@
                     "token": "`bar`",
                     "value": "bar",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 146
                 },
@@ -562,7 +698,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 151
                 },
@@ -571,7 +709,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 152
                 },
@@ -580,7 +720,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -589,7 +731,9 @@
                     "token": "`foo`",
                     "value": "foo",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 159
                 },
@@ -598,7 +742,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 164
                 },
@@ -607,7 +753,9 @@
                     "token": "`bar`",
                     "value": "bar",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 165
                 },
@@ -616,7 +764,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 170
                 },
@@ -625,7 +775,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 171
                 },
@@ -634,7 +786,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 177
                 },
@@ -643,7 +797,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 178
                 },
@@ -652,7 +808,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 179
                 },
@@ -661,7 +819,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 180
                 },
@@ -670,7 +830,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 181
                 },
@@ -679,7 +841,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 182
                 },
@@ -688,7 +852,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 183
                 },
@@ -697,7 +863,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 189
                 },
@@ -706,7 +874,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 190
                 },
@@ -715,7 +885,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 195
                 },
@@ -724,7 +896,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 196
                 },
@@ -733,7 +907,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 197
                 },
@@ -742,7 +918,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 198
                 },
@@ -751,7 +929,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 199
                 },
@@ -760,7 +940,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 203
                 },
@@ -769,7 +951,9 @@
                     "token": "nb_rows",
                     "value": "nb_rows",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": 204
                 },
@@ -778,7 +962,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 211
                 },
@@ -787,7 +973,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 212
                 },
@@ -796,7 +984,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 213
                 },
@@ -805,7 +995,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 219
                 },
@@ -814,7 +1006,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 220
                 },
@@ -823,7 +1017,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 221
                 },
@@ -832,7 +1028,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 227
                 },
@@ -841,7 +1039,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 228
                 },
@@ -850,7 +1050,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 233
                 },
@@ -859,7 +1061,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 234
                 },
@@ -868,7 +1072,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 235
                 },
@@ -877,7 +1083,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 236
                 },
@@ -886,7 +1094,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 237
                 },
@@ -895,7 +1105,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 241
                 },
@@ -904,7 +1116,9 @@
                     "token": "nb_rows",
                     "value": "nb_rows",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": 242
                 },
@@ -913,7 +1127,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 249
                 },
@@ -922,7 +1138,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 250
                 },
@@ -931,7 +1149,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 251
                 },
@@ -940,7 +1160,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 252
                 },
@@ -949,7 +1171,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 253
                 },
@@ -958,7 +1182,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 254
                 },
@@ -967,7 +1193,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 255
                 },
@@ -976,7 +1204,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 261
                 },
@@ -985,7 +1215,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 262
                 },
@@ -994,7 +1226,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 263
                 },
@@ -1003,7 +1237,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 269
                 },
@@ -1012,7 +1248,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 270
                 },
@@ -1021,7 +1259,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 275
                 },
@@ -1030,7 +1270,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 276
                 },
@@ -1039,7 +1281,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 277
                 },
@@ -1048,7 +1292,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 278
                 },
@@ -1057,7 +1303,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 279
                 },
@@ -1066,7 +1314,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 283
                 },
@@ -1075,7 +1325,9 @@
                     "token": "nb_rows",
                     "value": "nb_rows",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": 284
                 },
@@ -1084,7 +1336,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 291
                 },
@@ -1093,7 +1347,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 292
                 },
@@ -1102,7 +1358,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 293
                 },
@@ -1111,7 +1369,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 294
                 },
@@ -1120,7 +1380,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 295
                 },
@@ -1129,7 +1391,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 296
                 },
@@ -1138,7 +1402,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 302
                 },
@@ -1147,7 +1413,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 303
                 },
@@ -1156,7 +1424,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 308
                 },
@@ -1165,7 +1435,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 309
                 },
@@ -1174,7 +1446,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 310
                 },
@@ -1183,7 +1457,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 311
                 },
@@ -1192,7 +1468,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 312
                 },
@@ -1201,7 +1479,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 316
                 },
@@ -1210,7 +1490,9 @@
                     "token": "nb_rows",
                     "value": "nb_rows",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": 317
                 },
@@ -1219,7 +1501,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 324
                 },
@@ -1228,7 +1512,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 325
                 },
@@ -1237,7 +1523,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 326
                 },
@@ -1246,7 +1534,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 332
                 },
@@ -1255,7 +1545,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 333
                 },
@@ -1264,7 +1556,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 334
                 },
@@ -1273,7 +1567,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 335
                 },
@@ -1282,7 +1578,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 336
                 },
@@ -1291,7 +1589,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 337
                 },
@@ -1300,7 +1600,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 338
                 },
@@ -1309,7 +1611,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 339
                 },
@@ -1318,7 +1622,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 340
                 },
@@ -1327,7 +1633,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 341
                 },
@@ -1336,7 +1644,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 342
                 },
@@ -1345,7 +1655,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 343
                 },
@@ -1354,7 +1666,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 344
                 },
@@ -1363,7 +1677,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 345
                 },
@@ -1372,7 +1688,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 346
                 },
@@ -1381,7 +1699,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 347
                 },
@@ -1390,7 +1710,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 348
                 },
@@ -1399,7 +1721,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 349
                 },
@@ -1408,7 +1732,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 350
                 },
@@ -1417,7 +1743,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 351
                 },
@@ -1426,7 +1754,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 357
                 },
@@ -1435,7 +1765,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 358
                 },
@@ -1444,7 +1776,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 359
                 },
@@ -1453,7 +1787,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 360
                 },
@@ -1462,7 +1798,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 361
                 },
@@ -1471,7 +1809,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 362
                 },
@@ -1480,7 +1820,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 363
                 },
@@ -1489,7 +1831,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 364
                 },
@@ -1498,7 +1842,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 365
                 },
@@ -1507,7 +1853,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 366
                 },
@@ -1516,7 +1864,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 367
                 },
@@ -1525,7 +1875,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 368
                 },
@@ -1534,7 +1886,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 369
                 },
@@ -1543,7 +1897,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 370
                 },
@@ -1552,7 +1908,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 371
                 },
@@ -1561,7 +1919,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 372
                 },
@@ -1570,7 +1930,9 @@
                     "token": "4",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 373
                 },
@@ -1579,7 +1941,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 374
                 },
@@ -1588,7 +1952,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 375
                 },
@@ -1597,7 +1963,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 376
                 },
@@ -1606,7 +1974,9 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 377
                 },
@@ -1615,7 +1985,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 378
                 },
@@ -1624,7 +1996,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 379
                 },
@@ -1633,7 +2007,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 380
                 },
@@ -1642,7 +2018,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 381
                 },
@@ -1651,7 +2029,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 382
                 },
@@ -1660,7 +2040,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 388
                 },
@@ -1669,7 +2051,9 @@
                     "token": "2.71",
                     "value": 2.71,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 389
                 },
@@ -1678,7 +2062,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 393
                 },
@@ -1687,7 +2073,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 394
                 },
@@ -1696,7 +2084,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 395
                 },
@@ -1705,7 +2095,9 @@
                     "token": "3.14",
                     "value": 3.14,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 396
                 },
@@ -1714,7 +2106,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 400
                 },
@@ -1723,7 +2117,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 401
                 },
@@ -1732,7 +2128,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 407
                 },
@@ -1741,7 +2139,9 @@
                     "token": "2.71",
                     "value": 2.71,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 408
                 },
@@ -1750,7 +2150,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 412
                 },
@@ -1759,7 +2161,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 413
                 },
@@ -1768,7 +2172,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 414
                 },
@@ -1777,7 +2183,9 @@
                     "token": "-3.14",
                     "value": -3.14,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 10,
                     "position": 415
                 },
@@ -1786,7 +2194,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 420
                 },
@@ -1795,7 +2205,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 421
                 },
@@ -1804,7 +2216,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 427
                 },
@@ -1813,7 +2227,9 @@
                     "token": "-2.71",
                     "value": -2.71,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 10,
                     "position": 428
                 },
@@ -1822,7 +2238,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 433
                 },
@@ -1831,7 +2249,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 434
                 },
@@ -1840,7 +2260,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 435
                 },
@@ -1849,7 +2271,9 @@
                     "token": "3.14",
                     "value": 3.14,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 436
                 },
@@ -1858,7 +2282,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 440
                 },
@@ -1867,7 +2293,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 441
                 },
@@ -1876,7 +2304,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 447
                 },
@@ -1885,7 +2315,9 @@
                     "token": "-2.71",
                     "value": -2.71,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 10,
                     "position": 448
                 },
@@ -1894,7 +2326,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 453
                 },
@@ -1903,7 +2337,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 454
                 },
@@ -1912,7 +2348,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 455
                 },
@@ -1921,7 +2359,9 @@
                     "token": "-3.14",
                     "value": -3.14,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 10,
                     "position": 456
                 },
@@ -1930,7 +2370,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 461
                 },
@@ -1939,7 +2381,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 462
                 },
@@ -1948,7 +2392,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 468
                 },
@@ -1957,7 +2403,9 @@
                     "token": "0xABC",
                     "value": 2748,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 469
                 },
@@ -1966,7 +2414,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 474
                 },
@@ -1975,7 +2425,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 475
                 },
@@ -1984,7 +2436,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 476
                 },
@@ -1993,7 +2447,9 @@
                     "token": "0xCBA",
                     "value": 3258,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 477
                 },
@@ -2002,7 +2458,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 482
                 },
@@ -2011,7 +2469,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 483
                 },
@@ -2020,7 +2480,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 489
                 },
@@ -2029,7 +2491,9 @@
                     "token": "0xABC",
                     "value": 2748,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 490
                 },
@@ -2038,7 +2502,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 495
                 },
@@ -2047,7 +2513,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 496
                 },
@@ -2056,7 +2524,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 497
                 },
@@ -2065,7 +2535,9 @@
                     "token": "-0xCBA",
                     "value": -3258,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 498
                 },
@@ -2074,7 +2546,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 504
                 },
@@ -2083,7 +2557,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 505
                 },
@@ -2092,7 +2568,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 511
                 },
@@ -2101,7 +2579,9 @@
                     "token": "-0xABC",
                     "value": -2748,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 512
                 },
@@ -2110,7 +2590,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 518
                 },
@@ -2119,7 +2601,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 519
                 },
@@ -2128,7 +2612,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 520
                 },
@@ -2137,7 +2623,9 @@
                     "token": "0xCBA",
                     "value": 3258,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 521
                 },
@@ -2146,7 +2634,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 526
                 },
@@ -2155,7 +2645,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 527
                 },
@@ -2164,7 +2656,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 533
                 },
@@ -2173,7 +2667,9 @@
                     "token": "-0xABC",
                     "value": -2748,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 534
                 },
@@ -2182,7 +2678,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 540
                 },
@@ -2191,7 +2689,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 541
                 },
@@ -2200,7 +2700,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 542
                 },
@@ -2209,7 +2711,9 @@
                     "token": "-0xCBA",
                     "value": -3258,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 543
                 },
@@ -2218,7 +2722,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 549
                 },
@@ -2227,7 +2733,11 @@
                     "token": "-- Now same but with comments inside (C style comments could conflicts with operator if lexer is failing)",
                     "value": "-- Now same but with comments inside (C style comments could conflicts with operator if lexer is failing)",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 551
                 },
@@ -2236,7 +2746,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 656
                 },
@@ -2245,7 +2757,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 657
                 },
@@ -2254,7 +2768,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 663
                 },
@@ -2263,7 +2779,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 664
                 },
@@ -2272,7 +2790,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 665
                 },
@@ -2281,7 +2801,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 666
                 },
@@ -2290,7 +2812,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 667
                 },
@@ -2299,7 +2823,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 668
                 },
@@ -2308,7 +2834,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 681
                 },
@@ -2317,7 +2845,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 682
                 },
@@ -2326,7 +2856,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 683
                 },
@@ -2335,7 +2867,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 689
                 },
@@ -2344,7 +2878,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 690
                 },
@@ -2353,7 +2889,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 691
                 },
@@ -2362,7 +2900,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 704
                 },
@@ -2371,7 +2911,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 705
                 },
@@ -2380,7 +2922,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 706
                 },
@@ -2389,7 +2933,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 707
                 },
@@ -2398,7 +2944,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 708
                 },
@@ -2407,7 +2955,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 709
                 },
@@ -2416,7 +2966,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 715
                 },
@@ -2425,7 +2977,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 716
                 },
@@ -2434,7 +2988,9 @@
                     "token": "/* comment with * inside */",
                     "value": "/* comment with * inside */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 717
                 },
@@ -2443,7 +2999,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 744
                 },
@@ -2452,7 +3010,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 745
                 },
@@ -2461,7 +3021,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 746
                 },
@@ -2470,7 +3032,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 747
                 },
@@ -2479,7 +3043,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 748
                 },
@@ -2488,7 +3054,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 749
                 },
@@ -2497,7 +3065,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 755
                 },
@@ -2506,7 +3076,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 756
                 },
@@ -2515,7 +3087,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 769
                 },
@@ -2524,7 +3098,9 @@
                     "token": "field",
                     "value": "field",
                     "keyword": "FIELD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 770
                 },
@@ -2533,7 +3109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 775
                 },
@@ -2542,7 +3120,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 776
                 },
@@ -2551,7 +3131,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 789
                 },
@@ -2560,7 +3142,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 790
                 },
@@ -2569,7 +3153,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 791
                 },
@@ -2578,7 +3164,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 792
                 },
@@ -2587,7 +3175,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 805
                 },
@@ -2596,7 +3186,9 @@
                     "token": "8",
                     "value": 8,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 806
                 },
@@ -2605,7 +3197,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 807
                 },
@@ -2614,7 +3208,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 808
                 },
@@ -2623,7 +3219,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 821
                 },
@@ -2632,7 +3230,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 822
                 },
@@ -2641,7 +3241,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 828
                 },
@@ -2650,7 +3252,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 829
                 },
@@ -2659,7 +3263,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 842
                 },
@@ -2668,7 +3274,9 @@
                     "token": "8",
                     "value": 8,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 843
                 },
@@ -2677,7 +3285,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 844
                 },
@@ -2686,7 +3296,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 845
                 },
@@ -2695,7 +3307,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 858
                 },
@@ -2704,7 +3318,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 859
                 },
@@ -2713,7 +3329,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 860
                 },
@@ -2722,7 +3340,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 861
                 },
@@ -2731,7 +3351,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 874
                 },
@@ -2740,7 +3362,9 @@
                     "token": "field",
                     "value": "field",
                     "keyword": "FIELD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 875
                 },
@@ -2749,7 +3373,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 880
                 },
@@ -2758,7 +3384,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 881
                 },
@@ -2767,7 +3395,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 894
                 },
@@ -2776,7 +3406,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 895
                 },
@@ -2785,7 +3417,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 901
                 },
@@ -2794,7 +3428,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 902
                 },
@@ -2803,7 +3439,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 915
                 },
@@ -2812,7 +3450,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": 916
                 },
@@ -2821,7 +3461,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 919
                 },
@@ -2830,7 +3472,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 920
                 },
@@ -2839,7 +3483,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 933
                 },
@@ -2848,7 +3494,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 934
                 },
@@ -2857,7 +3505,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 935
                 },
@@ -2866,7 +3516,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 936
                 },
@@ -2875,7 +3527,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 949
                 },
@@ -2884,7 +3538,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": 950
                 },
@@ -2893,7 +3549,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 953
                 },
@@ -2902,7 +3560,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 954
                 },
@@ -2911,7 +3571,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 967
                 },
@@ -2920,7 +3582,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 968
                 },
@@ -2929,7 +3593,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 974
                 },
@@ -2938,7 +3604,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 975
                 },
@@ -2947,7 +3615,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 988
                 },
@@ -2956,7 +3626,9 @@
                     "token": "`escaped_field`",
                     "value": "escaped_field",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 989
                 },
@@ -2965,7 +3637,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1004
                 },
@@ -2974,7 +3648,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1005
                 },
@@ -2983,7 +3659,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1018
                 },
@@ -2992,7 +3670,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1019
                 },
@@ -3001,7 +3681,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1020
                 },
@@ -3010,7 +3692,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1021
                 },
@@ -3019,7 +3703,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1034
                 },
@@ -3028,7 +3714,9 @@
                     "token": "16",
                     "value": 16,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1035
                 },
@@ -3037,7 +3725,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1037
                 },
@@ -3046,7 +3736,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1038
                 },
@@ -3055,7 +3747,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1051
                 },
@@ -3064,7 +3758,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1052
                 },
@@ -3073,7 +3769,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1058
                 },
@@ -3082,7 +3780,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1059
                 },
@@ -3091,7 +3791,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1072
                 },
@@ -3100,7 +3802,9 @@
                     "token": "16",
                     "value": 16,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1073
                 },
@@ -3109,7 +3813,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1075
                 },
@@ -3118,7 +3824,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1076
                 },
@@ -3127,7 +3835,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1089
                 },
@@ -3136,7 +3846,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1090
                 },
@@ -3145,7 +3857,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1091
                 },
@@ -3154,7 +3868,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1092
                 },
@@ -3163,7 +3879,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1105
                 },
@@ -3172,7 +3890,9 @@
                     "token": "`escaped_field`",
                     "value": "escaped_field",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 1106
                 },
@@ -3181,7 +3901,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1121
                 },
@@ -3190,7 +3912,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1122
                 },
@@ -3199,7 +3923,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1135
                 },
@@ -3208,7 +3934,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1136
                 },
@@ -3217,7 +3945,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1142
                 },
@@ -3226,7 +3956,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1143
                 },
@@ -3235,7 +3967,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1156
                 },
@@ -3244,7 +3978,9 @@
                     "token": "`foo`",
                     "value": "foo",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 1157
                 },
@@ -3253,7 +3989,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1162
                 },
@@ -3262,7 +4000,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1163
                 },
@@ -3271,7 +4011,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1176
                 },
@@ -3280,7 +4022,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1177
                 },
@@ -3289,7 +4033,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1178
                 },
@@ -3298,7 +4044,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1179
                 },
@@ -3307,7 +4055,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1192
                 },
@@ -3316,7 +4066,9 @@
                     "token": "`bar`",
                     "value": "bar",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 1193
                 },
@@ -3325,7 +4077,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1198
                 },
@@ -3334,7 +4088,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1199
                 },
@@ -3343,7 +4099,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1212
                 },
@@ -3352,7 +4110,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1213
                 },
@@ -3361,7 +4121,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1219
                 },
@@ -3370,7 +4132,9 @@
                     "token": "/* `comment` */",
                     "value": "/* `comment` */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1220
                 },
@@ -3379,7 +4143,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1235
                 },
@@ -3388,7 +4154,9 @@
                     "token": "`foo`",
                     "value": "foo",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 1236
                 },
@@ -3397,7 +4165,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1241
                 },
@@ -3406,7 +4176,9 @@
                     "token": "/* `comment` */",
                     "value": "/* `comment` */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1242
                 },
@@ -3415,7 +4187,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1257
                 },
@@ -3424,7 +4198,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1258
                 },
@@ -3433,7 +4209,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1259
                 },
@@ -3442,7 +4220,9 @@
                     "token": "/* `comment` */",
                     "value": "/* `comment` */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1260
                 },
@@ -3451,7 +4231,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1275
                 },
@@ -3460,7 +4242,9 @@
                     "token": "`bar`",
                     "value": "bar",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 1276
                 },
@@ -3469,7 +4253,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1281
                 },
@@ -3478,7 +4264,9 @@
                     "token": "/* `comment` */",
                     "value": "/* `comment` */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1282
                 },
@@ -3487,7 +4275,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1297
                 },
@@ -3496,7 +4286,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1298
                 },
@@ -3505,7 +4297,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1304
                 },
@@ -3514,7 +4308,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1305
                 },
@@ -3523,7 +4319,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1318
                 },
@@ -3532,7 +4330,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1319
                 },
@@ -3541,7 +4341,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1320
                 },
@@ -3550,7 +4352,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1321
                 },
@@ -3559,7 +4363,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1334
                 },
@@ -3568,7 +4374,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1335
                 },
@@ -3577,7 +4385,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1336
                 },
@@ -3586,7 +4396,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1337
                 },
@@ -3595,7 +4407,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1350
                 },
@@ -3604,7 +4418,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1351
                 },
@@ -3613,7 +4429,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1352
                 },
@@ -3622,7 +4440,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1358
                 },
@@ -3631,7 +4451,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 1359
                 },
@@ -3640,7 +4462,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1364
                 },
@@ -3649,7 +4473,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1365
                 },
@@ -3658,7 +4484,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1378
                 },
@@ -3667,7 +4495,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1379
                 },
@@ -3676,7 +4506,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1392
                 },
@@ -3685,7 +4517,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1393
                 },
@@ -3694,7 +4528,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1394
                 },
@@ -3703,7 +4539,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1407
                 },
@@ -3712,7 +4550,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1408
                 },
@@ -3721,7 +4561,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1412
                 },
@@ -3730,7 +4572,9 @@
                     "token": "nb_rows",
                     "value": "nb_rows",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": 1413
                 },
@@ -3739,7 +4583,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1420
                 },
@@ -3748,7 +4594,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1421
                 },
@@ -3757,7 +4605,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1422
                 },
@@ -3766,7 +4616,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1428
                 },
@@ -3775,7 +4627,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1429
                 },
@@ -3784,7 +4638,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1442
                 },
@@ -3793,7 +4649,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1443
                 },
@@ -3802,7 +4660,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1444
                 },
@@ -3811,7 +4671,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1450
                 },
@@ -3820,7 +4682,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 1451
                 },
@@ -3829,7 +4693,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1456
                 },
@@ -3838,7 +4704,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1457
                 },
@@ -3847,7 +4715,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1458
                 },
@@ -3856,7 +4726,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1459
                 },
@@ -3865,7 +4737,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1460
                 },
@@ -3874,7 +4748,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1473
                 },
@@ -3883,7 +4759,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1477
                 },
@@ -3892,7 +4770,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1490
                 },
@@ -3901,7 +4781,9 @@
                     "token": "nb_rows",
                     "value": "nb_rows",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": 1491
                 },
@@ -3910,7 +4792,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1498
                 },
@@ -3919,7 +4803,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1499
                 },
@@ -3928,7 +4814,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1500
                 },
@@ -3937,7 +4825,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1513
                 },
@@ -3946,7 +4836,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1514
                 },
@@ -3955,7 +4847,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1515
                 },
@@ -3964,7 +4858,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1516
                 },
@@ -3973,7 +4869,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1529
                 },
@@ -3982,7 +4880,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1530
                 },
@@ -3991,7 +4891,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1531
                 },
@@ -4000,7 +4902,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1532
                 },
@@ -4009,7 +4913,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1538
                 },
@@ -4018,7 +4924,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1539
                 },
@@ -4027,7 +4935,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1540
                 },
@@ -4036,7 +4946,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1546
                 },
@@ -4045,7 +4957,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1547
                 },
@@ -4054,7 +4968,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1560
                 },
@@ -4063,7 +4979,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 1561
                 },
@@ -4072,7 +4990,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1566
                 },
@@ -4081,7 +5001,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1567
                 },
@@ -4090,7 +5012,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1568
                 },
@@ -4099,7 +5023,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1569
                 },
@@ -4108,7 +5034,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1570
                 },
@@ -4117,7 +5045,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1583
                 },
@@ -4126,7 +5056,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1584
                 },
@@ -4135,7 +5067,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1588
                 },
@@ -4144,7 +5078,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1589
                 },
@@ -4153,7 +5089,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1602
                 },
@@ -4162,7 +5100,9 @@
                     "token": "nb_rows",
                     "value": "nb_rows",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": 1603
                 },
@@ -4171,7 +5111,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1610
                 },
@@ -4180,7 +5122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1611
                 },
@@ -4189,7 +5133,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1612
                 },
@@ -4198,7 +5144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1625
                 },
@@ -4207,7 +5155,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1626
                 },
@@ -4216,7 +5166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1627
                 },
@@ -4225,7 +5177,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1628
                 },
@@ -4234,7 +5188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1641
                 },
@@ -4243,7 +5199,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1642
                 },
@@ -4252,7 +5210,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1643
                 },
@@ -4261,7 +5221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1649
                 },
@@ -4270,7 +5232,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 1650
                 },
@@ -4279,7 +5243,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1655
                 },
@@ -4288,7 +5254,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1656
                 },
@@ -4297,7 +5265,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1657
                 },
@@ -4306,7 +5276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1658
                 },
@@ -4315,7 +5287,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1659
                 },
@@ -4324,7 +5298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1663
                 },
@@ -4333,7 +5309,9 @@
                     "token": "nb_rows",
                     "value": "nb_rows",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": 1664
                 },
@@ -4342,7 +5320,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1671
                 },
@@ -4351,7 +5331,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1672
                 },
@@ -4360,7 +5342,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1673
                 },
@@ -4369,7 +5353,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1679
                 },
@@ -4378,7 +5364,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1680
                 },
@@ -4387,7 +5375,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1681
                 },
@@ -4396,7 +5386,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1682
                 },
@@ -4405,7 +5397,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1683
                 },
@@ -4414,7 +5408,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1684
                 },
@@ -4423,7 +5419,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1685
                 },
@@ -4432,7 +5430,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1686
                 },
@@ -4441,7 +5441,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1687
                 },
@@ -4450,7 +5452,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1688
                 },
@@ -4459,7 +5463,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1701
                 },
@@ -4468,7 +5474,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1702
                 },
@@ -4477,7 +5485,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1703
                 },
@@ -4486,7 +5496,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1704
                 },
@@ -4495,7 +5507,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1717
                 },
@@ -4504,7 +5518,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1718
                 },
@@ -4513,7 +5529,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1719
                 },
@@ -4522,7 +5540,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1720
                 },
@@ -4531,7 +5551,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1721
                 },
@@ -4540,7 +5562,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1722
                 },
@@ -4549,7 +5573,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1723
                 },
@@ -4558,7 +5584,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1724
                 },
@@ -4567,7 +5595,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1725
                 },
@@ -4576,7 +5606,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1726
                 },
@@ -4585,7 +5617,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1732
                 },
@@ -4594,7 +5628,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1733
                 },
@@ -4603,7 +5639,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1746
                 },
@@ -4612,7 +5650,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1747
                 },
@@ -4621,7 +5661,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1748
                 },
@@ -4630,7 +5672,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1749
                 },
@@ -4639,7 +5683,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1762
                 },
@@ -4648,7 +5694,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1763
                 },
@@ -4657,7 +5705,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1764
                 },
@@ -4666,7 +5716,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1765
                 },
@@ -4675,7 +5727,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1778
                 },
@@ -4684,7 +5738,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1779
                 },
@@ -4693,7 +5749,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1780
                 },
@@ -4702,7 +5760,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1781
                 },
@@ -4711,7 +5771,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1782
                 },
@@ -4720,7 +5782,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1795
                 },
@@ -4729,7 +5793,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1796
                 },
@@ -4738,7 +5804,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1797
                 },
@@ -4747,7 +5815,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1798
                 },
@@ -4756,7 +5826,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1811
                 },
@@ -4765,7 +5837,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1812
                 },
@@ -4774,7 +5848,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1813
                 },
@@ -4783,7 +5859,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1814
                 },
@@ -4792,7 +5870,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1815
                 },
@@ -4801,7 +5881,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1828
                 },
@@ -4810,7 +5892,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1829
                 },
@@ -4819,7 +5903,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1830
                 },
@@ -4828,7 +5914,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1831
                 },
@@ -4837,7 +5925,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1844
                 },
@@ -4846,7 +5936,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1845
                 },
@@ -4855,7 +5947,9 @@
                     "token": "4",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1846
                 },
@@ -4864,7 +5958,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1847
                 },
@@ -4873,7 +5969,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1848
                 },
@@ -4882,7 +5980,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1861
                 },
@@ -4891,7 +5991,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1862
                 },
@@ -4900,7 +6002,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1863
                 },
@@ -4909,7 +6013,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1864
                 },
@@ -4918,7 +6024,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1877
                 },
@@ -4927,7 +6035,9 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1878
                 },
@@ -4936,7 +6046,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1879
                 },
@@ -4945,7 +6057,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1880
                 },
@@ -4954,7 +6068,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1881
                 },
@@ -4963,7 +6079,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1882
                 },
@@ -4972,7 +6090,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1883
                 },
@@ -4981,7 +6101,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1896
                 },
@@ -4990,7 +6112,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1897
                 },
@@ -4999,7 +6123,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1903
                 },
@@ -5008,7 +6134,9 @@
                     "token": "2.71",
                     "value": 2.71,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 1904
                 },
@@ -5017,7 +6145,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1908
                 },
@@ -5026,7 +6156,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1909
                 },
@@ -5035,7 +6167,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1922
                 },
@@ -5044,7 +6178,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1923
                 },
@@ -5053,7 +6189,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1924
                 },
@@ -5062,7 +6200,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1925
                 },
@@ -5071,7 +6211,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1938
                 },
@@ -5080,7 +6222,9 @@
                     "token": "3.14",
                     "value": 3.14,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 1939
                 },
@@ -5089,7 +6233,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1943
                 },
@@ -5098,7 +6244,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1944
                 },
@@ -5107,7 +6255,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1950
                 },
@@ -5116,7 +6266,9 @@
                     "token": "2.71",
                     "value": 2.71,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 1951
                 },
@@ -5125,7 +6277,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1955
                 },
@@ -5134,7 +6288,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1956
                 },
@@ -5143,7 +6299,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1969
                 },
@@ -5152,7 +6310,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 1970
                 },
@@ -5161,7 +6321,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1971
                 },
@@ -5170,7 +6332,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 1972
                 },
@@ -5179,7 +6343,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1985
                 },
@@ -5188,7 +6354,9 @@
                     "token": "-3.14",
                     "value": -3.14,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 10,
                     "position": 1986
                 },
@@ -5197,7 +6365,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1991
                 },
@@ -5206,7 +6376,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1992
                 },
@@ -5215,7 +6387,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1998
                 },
@@ -5224,7 +6398,9 @@
                     "token": "-2.71",
                     "value": -2.71,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 10,
                     "position": 1999
                 },
@@ -5233,7 +6409,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2004
                 },
@@ -5242,7 +6420,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2005
                 },
@@ -5251,7 +6431,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2018
                 },
@@ -5260,7 +6442,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 2019
                 },
@@ -5269,7 +6453,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2020
                 },
@@ -5278,7 +6464,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2021
                 },
@@ -5287,7 +6475,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2034
                 },
@@ -5296,7 +6486,9 @@
                     "token": "3.14",
                     "value": 3.14,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 2035
                 },
@@ -5305,7 +6497,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2039
                 },
@@ -5314,7 +6508,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2040
                 },
@@ -5323,7 +6519,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2046
                 },
@@ -5332,7 +6530,9 @@
                     "token": "-2.71",
                     "value": -2.71,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 10,
                     "position": 2047
                 },
@@ -5341,7 +6541,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2052
                 },
@@ -5350,7 +6552,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2053
                 },
@@ -5359,7 +6563,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2066
                 },
@@ -5368,7 +6574,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 2067
                 },
@@ -5377,7 +6585,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2068
                 },
@@ -5386,7 +6596,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2069
                 },
@@ -5395,7 +6607,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2082
                 },
@@ -5404,7 +6618,9 @@
                     "token": "-3.14",
                     "value": -3.14,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 10,
                     "position": 2083
                 },
@@ -5413,7 +6629,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2088
                 },
@@ -5422,7 +6640,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2089
                 },
@@ -5431,7 +6651,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2095
                 },
@@ -5440,7 +6662,9 @@
                     "token": "0xABC",
                     "value": 2748,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 2096
                 },
@@ -5449,7 +6673,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2101
                 },
@@ -5458,7 +6684,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2102
                 },
@@ -5467,7 +6695,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2115
                 },
@@ -5476,7 +6706,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 2116
                 },
@@ -5485,7 +6717,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2117
                 },
@@ -5494,7 +6728,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2118
                 },
@@ -5503,7 +6739,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2131
                 },
@@ -5512,7 +6750,9 @@
                     "token": "0xCBA",
                     "value": 3258,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 2132
                 },
@@ -5521,7 +6761,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2137
                 },
@@ -5530,7 +6772,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2138
                 },
@@ -5539,7 +6783,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2144
                 },
@@ -5548,7 +6794,9 @@
                     "token": "0xABC",
                     "value": 2748,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 2145
                 },
@@ -5557,7 +6805,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2150
                 },
@@ -5566,7 +6816,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2151
                 },
@@ -5575,7 +6827,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2164
                 },
@@ -5584,7 +6838,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 2165
                 },
@@ -5593,7 +6849,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2166
                 },
@@ -5602,7 +6860,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2167
                 },
@@ -5611,7 +6871,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2180
                 },
@@ -5620,7 +6882,9 @@
                     "token": "-0xCBA",
                     "value": -3258,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 2181
                 },
@@ -5629,7 +6893,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2187
                 },
@@ -5638,7 +6904,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2188
                 },
@@ -5647,7 +6915,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2194
                 },
@@ -5656,7 +6926,9 @@
                     "token": "-0xABC",
                     "value": -2748,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 2195
                 },
@@ -5665,7 +6937,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2201
                 },
@@ -5674,7 +6948,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2202
                 },
@@ -5683,7 +6959,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2215
                 },
@@ -5692,7 +6970,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 2216
                 },
@@ -5701,7 +6981,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2217
                 },
@@ -5710,7 +6992,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2218
                 },
@@ -5719,7 +7003,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2231
                 },
@@ -5728,7 +7014,9 @@
                     "token": "0xCBA",
                     "value": 3258,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 2232
                 },
@@ -5737,7 +7025,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2237
                 },
@@ -5746,7 +7036,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2238
                 },
@@ -5755,7 +7047,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2244
                 },
@@ -5764,7 +7058,9 @@
                     "token": "-0xABC",
                     "value": -2748,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 2245
                 },
@@ -5773,7 +7069,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2251
                 },
@@ -5782,7 +7080,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2252
                 },
@@ -5791,7 +7091,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2265
                 },
@@ -5800,7 +7102,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 2266
                 },
@@ -5809,7 +7113,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2267
                 },
@@ -5818,7 +7124,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2268
                 },
@@ -5827,7 +7135,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2281
                 },
@@ -5836,7 +7146,9 @@
                     "token": "-0xCBA",
                     "value": -3258,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 2282
                 },
@@ -5845,7 +7157,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2288
                 },
@@ -5854,7 +7168,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2289
                 },
@@ -5863,7 +7179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2295
                 },
@@ -5872,7 +7190,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2296
                 },
@@ -5881,7 +7201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2297
                 },
@@ -5890,7 +7212,9 @@
                     "token": "/* comment with FROM keyword */",
                     "value": "/* comment with FROM keyword */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2298
                 },
@@ -5899,7 +7223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2329
                 },
@@ -5908,7 +7234,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 2330
                 },
@@ -5917,7 +7245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2331
                 },
@@ -5926,7 +7256,9 @@
                     "token": "/* comment with USING keyword */",
                     "value": "/* comment with USING keyword */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2332
                 },
@@ -5935,7 +7267,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2364
                 },
@@ -5944,7 +7278,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2365
                 },
@@ -5953,7 +7289,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2366
                 },
@@ -5962,7 +7300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2372
                 },
@@ -5971,7 +7311,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2373
                 },
@@ -5980,7 +7322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2374
                 },
@@ -5989,7 +7333,9 @@
                     "token": "/* comment with ) */",
                     "value": "/* comment with ) */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2375
                 },
@@ -5998,7 +7344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2395
                 },
@@ -6007,7 +7355,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 2396
                 },
@@ -6016,7 +7366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2397
                 },
@@ -6025,7 +7377,9 @@
                     "token": "/* comment with , keyword */",
                     "value": "/* comment with , keyword */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@255"
+                    },
                     "flags": 2,
                     "position": 2398
                 },
@@ -6034,7 +7388,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2426
                 },
@@ -6043,7 +7399,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2427
                 },
@@ -6052,13 +7410,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 672,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexOperatorStarIsWildcard.out
+++ b/tests/data/lexer/lexOperatorStarIsWildcard.out
@@ -7,13 +7,19 @@
         "last": 1348,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 382,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 14
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 21
                 },
@@ -94,7 +120,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -103,7 +131,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -112,7 +142,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -121,7 +153,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -130,7 +164,11 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -139,7 +177,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -148,7 +188,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 36
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -166,7 +210,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 38
                 },
@@ -175,7 +221,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -184,7 +232,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 43
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -202,7 +254,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -211,7 +265,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 51
                 },
@@ -220,7 +276,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 52
                 },
@@ -229,7 +287,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 53
                 },
@@ -238,7 +298,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -247,7 +309,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 55
                 },
@@ -256,7 +320,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 56
                 },
@@ -265,7 +331,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -274,7 +342,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 58
                 },
@@ -283,7 +353,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -292,7 +364,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 63
                 },
@@ -301,7 +375,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -310,7 +386,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -319,7 +397,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -328,7 +408,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 72
                 },
@@ -337,7 +419,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 73
                 },
@@ -346,7 +430,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -355,7 +441,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -364,7 +452,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 76
                 },
@@ -373,7 +463,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -382,7 +474,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -391,7 +485,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 79
                 },
@@ -400,7 +496,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -409,7 +507,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 84
                 },
@@ -418,7 +518,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -427,7 +529,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -436,7 +540,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 92
                 },
@@ -445,7 +551,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 93
                 },
@@ -454,7 +562,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 94
                 },
@@ -463,7 +573,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -472,7 +584,11 @@
                     "token": "/* with a comment */",
                     "value": "/* with a comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 96
                 },
@@ -481,7 +597,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -490,7 +608,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -499,7 +619,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 118
                 },
@@ -508,7 +630,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 119
                 },
@@ -517,7 +641,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -526,7 +652,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 121
                 },
@@ -535,7 +663,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -544,7 +674,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 126
                 },
@@ -553,7 +685,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -562,7 +696,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -571,7 +707,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 134
                 },
@@ -580,7 +718,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 135
                 },
@@ -589,7 +729,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 136
                 },
@@ -598,7 +740,9 @@
                     "token": "/* with a comment */",
                     "value": "/* with a comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 137
                 },
@@ -607,7 +751,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -616,7 +762,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 158
                 },
@@ -625,7 +773,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 159
                 },
@@ -634,7 +784,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -643,7 +795,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 161
                 },
@@ -652,7 +806,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 165
                 },
@@ -661,7 +817,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 166
                 },
@@ -670,7 +828,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 172
                 },
@@ -679,7 +839,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 173
                 },
@@ -688,7 +850,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 174
                 },
@@ -697,7 +861,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 175
                 },
@@ -706,7 +872,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -715,7 +883,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 177
                 },
@@ -724,7 +894,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 190
                 },
@@ -733,7 +905,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 191
                 },
@@ -742,7 +916,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 195
                 },
@@ -751,7 +927,9 @@
                     "token": "-- SELECT a.*/* comment */ FROM (This one is not working yet because of https://github.com/phpmyadmin/sql-parser/issues/285. Please uncomment when this issue is fixed.)",
                     "value": "-- SELECT a.*/* comment */ FROM (This one is not working yet because of https://github.com/phpmyadmin/sql-parser/issues/285. Please uncomment when this issue is fixed.)",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 4,
                     "position": 196
                 },
@@ -760,7 +938,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 364
                 },
@@ -769,7 +949,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 365
                 },
@@ -778,7 +960,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 371
                 },
@@ -787,7 +971,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 372
                 },
@@ -796,7 +982,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 380
                 },
@@ -805,7 +993,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 381
                 },
@@ -814,7 +1004,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 382
                 },
@@ -823,7 +1015,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 383
                 },
@@ -832,7 +1026,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 387
                 },
@@ -841,7 +1037,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 388
                 },
@@ -850,7 +1048,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 394
                 },
@@ -859,7 +1059,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 395
                 },
@@ -868,7 +1070,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 403
                 },
@@ -877,7 +1081,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 404
                 },
@@ -886,7 +1092,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 405
                 },
@@ -895,7 +1103,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 409
                 },
@@ -904,7 +1114,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 410
                 },
@@ -913,7 +1125,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 416
                 },
@@ -922,7 +1136,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 417
                 },
@@ -931,7 +1147,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 425
                 },
@@ -940,7 +1158,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 426
                 },
@@ -949,7 +1169,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 427
                 },
@@ -958,7 +1180,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 428
                 },
@@ -967,7 +1191,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 429
                 },
@@ -976,7 +1202,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 430
                 },
@@ -985,7 +1213,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 434
                 },
@@ -994,7 +1224,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 435
                 },
@@ -1003,7 +1235,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 441
                 },
@@ -1012,7 +1246,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 442
                 },
@@ -1021,7 +1257,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 450
                 },
@@ -1030,7 +1268,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 451
                 },
@@ -1039,7 +1279,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 452
                 },
@@ -1048,7 +1290,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 453
                 },
@@ -1057,7 +1301,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 454
                 },
@@ -1066,7 +1312,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 455
                 },
@@ -1075,7 +1323,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 456
                 },
@@ -1084,7 +1334,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 457
                 },
@@ -1093,7 +1345,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 458
                 },
@@ -1102,7 +1356,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 459
                 },
@@ -1111,7 +1367,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 463
                 },
@@ -1120,7 +1378,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 464
                 },
@@ -1129,7 +1389,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 470
                 },
@@ -1138,7 +1400,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 471
                 },
@@ -1147,7 +1411,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 479
                 },
@@ -1156,7 +1422,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 480
                 },
@@ -1165,7 +1433,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 481
                 },
@@ -1174,7 +1444,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 482
                 },
@@ -1183,7 +1455,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 483
                 },
@@ -1192,7 +1466,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 484
                 },
@@ -1201,7 +1477,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 485
                 },
@@ -1210,7 +1488,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 486
                 },
@@ -1219,7 +1499,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 487
                 },
@@ -1228,7 +1510,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 488
                 },
@@ -1237,7 +1521,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 489
                 },
@@ -1246,7 +1532,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 493
                 },
@@ -1255,7 +1543,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 494
                 },
@@ -1264,7 +1554,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 500
                 },
@@ -1273,7 +1565,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 501
                 },
@@ -1282,7 +1576,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 509
                 },
@@ -1291,7 +1587,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 510
                 },
@@ -1300,7 +1598,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 511
                 },
@@ -1309,7 +1609,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 512
                 },
@@ -1318,7 +1620,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 513
                 },
@@ -1327,7 +1631,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 514
                 },
@@ -1336,7 +1642,9 @@
                     "token": "/* with a comment */",
                     "value": "/* with a comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 515
                 },
@@ -1345,7 +1653,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 535
                 },
@@ -1354,7 +1664,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 536
                 },
@@ -1363,7 +1675,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 537
                 },
@@ -1372,7 +1686,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 538
                 },
@@ -1381,7 +1697,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 539
                 },
@@ -1390,7 +1708,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 540
                 },
@@ -1399,7 +1719,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 544
                 },
@@ -1408,7 +1730,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 545
                 },
@@ -1417,7 +1741,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 551
                 },
@@ -1426,7 +1752,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 552
                 },
@@ -1435,7 +1763,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 560
                 },
@@ -1444,7 +1774,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 561
                 },
@@ -1453,7 +1785,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 562
                 },
@@ -1462,7 +1796,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 563
                 },
@@ -1471,7 +1807,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 564
                 },
@@ -1480,7 +1818,9 @@
                     "token": "/* with a comment */",
                     "value": "/* with a comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 565
                 },
@@ -1489,7 +1829,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 585
                 },
@@ -1498,7 +1840,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 586
                 },
@@ -1507,7 +1851,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 587
                 },
@@ -1516,7 +1862,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 588
                 },
@@ -1525,7 +1873,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 589
                 },
@@ -1534,7 +1884,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 593
                 },
@@ -1543,7 +1895,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 594
                 },
@@ -1552,7 +1906,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 600
                 },
@@ -1561,7 +1917,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 601
                 },
@@ -1570,7 +1928,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 609
                 },
@@ -1579,7 +1939,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 610
                 },
@@ -1588,7 +1950,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 611
                 },
@@ -1597,7 +1961,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 612
                 },
@@ -1606,7 +1972,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 613
                 },
@@ -1615,7 +1983,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 614
                 },
@@ -1624,7 +1994,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 627
                 },
@@ -1633,7 +2005,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 628
                 },
@@ -1642,7 +2016,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 632
                 },
@@ -1651,7 +2027,9 @@
                     "token": "-- SELECT DISTINCT a.*/* comment */ FROM (This one is not working yet because of https://github.com/phpmyadmin/sql-parser/issues/285. Please uncomment when this issue is fixed.)",
                     "value": "-- SELECT DISTINCT a.*/* comment */ FROM (This one is not working yet because of https://github.com/phpmyadmin/sql-parser/issues/285. Please uncomment when this issue is fixed.)",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 4,
                     "position": 633
                 },
@@ -1660,7 +2038,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 810
                 },
@@ -1669,7 +2049,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 811
                 },
@@ -1678,7 +2060,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 817
                 },
@@ -1687,7 +2071,11 @@
                     "token": "`*`",
                     "value": "*",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 818
                 },
@@ -1696,7 +2084,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 821
                 },
@@ -1705,7 +2095,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 822
                 },
@@ -1714,7 +2106,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 826
                 },
@@ -1723,7 +2117,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 827
                 },
@@ -1732,7 +2128,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 837
                 },
@@ -1741,7 +2139,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 838
                 },
@@ -1750,7 +2150,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 844
                 },
@@ -1759,7 +2161,9 @@
                     "token": "`*`",
                     "value": "*",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@194"
+                    },
                     "flags": 2,
                     "position": 845
                 },
@@ -1768,7 +2172,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 848
                 },
@@ -1777,7 +2183,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 849
                 },
@@ -1786,7 +2194,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 850
                 },
@@ -1795,7 +2205,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 851
                 },
@@ -1804,7 +2216,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 855
                 },
@@ -1813,7 +2227,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 856
                 },
@@ -1822,7 +2238,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 866
                 },
@@ -1831,7 +2249,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 867
                 },
@@ -1840,7 +2260,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 869
                 },
@@ -1849,7 +2271,9 @@
                     "token": "`*`",
                     "value": "*",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@194"
+                    },
                     "flags": 2,
                     "position": 870
                 },
@@ -1858,7 +2282,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 873
                 },
@@ -1867,7 +2293,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 874
                 },
@@ -1876,7 +2304,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 880
                 },
@@ -1885,7 +2315,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 881
                 },
@@ -1894,7 +2326,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 886
                 },
@@ -1903,7 +2337,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 887
                 },
@@ -1912,7 +2348,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 888
                 },
@@ -1921,7 +2359,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 889
                 },
@@ -1930,7 +2370,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 890
                 },
@@ -1939,7 +2381,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 894
                 },
@@ -1948,7 +2392,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 895
                 },
@@ -1957,7 +2403,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 905
                 },
@@ -1966,7 +2414,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 906
                 },
@@ -1975,7 +2425,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 912
                 },
@@ -1984,7 +2436,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 913
                 },
@@ -1993,7 +2447,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 918
                 },
@@ -2002,7 +2458,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 919
                 },
@@ -2011,7 +2469,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 920
                 },
@@ -2020,7 +2480,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 921
                 },
@@ -2029,7 +2491,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 922
                 },
@@ -2038,7 +2502,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 923
                 },
@@ -2047,7 +2513,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 924
                 },
@@ -2056,7 +2524,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 928
                 },
@@ -2065,7 +2535,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 929
                 },
@@ -2074,7 +2546,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 939
                 },
@@ -2083,7 +2557,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 940
                 },
@@ -2092,7 +2568,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 946
                 },
@@ -2101,7 +2579,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 947
                 },
@@ -2110,7 +2590,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 952
                 },
@@ -2119,7 +2601,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 953
                 },
@@ -2128,7 +2612,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 954
                 },
@@ -2137,7 +2623,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 955
                 },
@@ -2146,7 +2634,9 @@
                     "token": "/* comment with *,USING,FROM */",
                     "value": "/* comment with *,USING,FROM */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 956
                 },
@@ -2155,7 +2645,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 987
                 },
@@ -2164,7 +2656,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 988
                 },
@@ -2173,7 +2667,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 989
                 },
@@ -2182,7 +2678,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 993
                 },
@@ -2191,7 +2689,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 994
                 },
@@ -2200,7 +2700,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1004
                 },
@@ -2209,7 +2711,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1005
                 },
@@ -2218,7 +2722,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1011
                 },
@@ -2227,7 +2733,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 1012
                 },
@@ -2236,7 +2744,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1017
                 },
@@ -2245,7 +2755,9 @@
                     "token": "`*`",
                     "value": "*",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@194"
+                    },
                     "flags": 2,
                     "position": 1018
                 },
@@ -2254,7 +2766,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1021
                 },
@@ -2263,7 +2777,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1022
                 },
@@ -2272,7 +2788,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1023
                 },
@@ -2281,7 +2799,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1027
                 },
@@ -2290,7 +2810,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1028
                 },
@@ -2299,7 +2821,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1038
                 },
@@ -2308,7 +2832,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1039
                 },
@@ -2317,7 +2843,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1045
                 },
@@ -2326,7 +2854,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 1046
                 },
@@ -2335,7 +2867,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1047
                 },
@@ -2344,7 +2878,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1048
                 },
@@ -2353,7 +2889,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1052
                 },
@@ -2362,7 +2900,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1053
                 },
@@ -2371,7 +2911,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1063
                 },
@@ -2380,7 +2922,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1064
                 },
@@ -2389,7 +2933,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1069
                 },
@@ -2398,7 +2944,9 @@
                     "token": "LABEL",
                     "value": "LABEL",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1070
                 },
@@ -2407,7 +2955,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1075
                 },
@@ -2416,7 +2966,9 @@
                     "token": "LIKE",
                     "value": "LIKE",
                     "keyword": "LIKE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1076
                 },
@@ -2425,7 +2977,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1080
                 },
@@ -2434,7 +2988,11 @@
                     "token": "'%*%'",
                     "value": "%*%",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 1081
                 },
@@ -2443,7 +3001,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1086
                 },
@@ -2452,7 +3012,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1087
                 },
@@ -2461,7 +3023,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1093
                 },
@@ -2470,7 +3034,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1094
                 },
@@ -2479,7 +3045,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1095
                 },
@@ -2488,7 +3056,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1096
                 },
@@ -2497,7 +3067,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1097
                 },
@@ -2506,7 +3078,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1098
                 },
@@ -2515,7 +3089,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1103
                 },
@@ -2524,7 +3100,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1104
                 },
@@ -2533,7 +3111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1110
                 },
@@ -2542,7 +3122,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1111
                 },
@@ -2551,7 +3133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1112
                 },
@@ -2560,7 +3144,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1113
                 },
@@ -2569,7 +3155,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1114
                 },
@@ -2578,7 +3166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1115
                 },
@@ -2587,7 +3177,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1116
                 },
@@ -2596,7 +3188,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1117
                 },
@@ -2605,7 +3199,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1118
                 },
@@ -2614,7 +3210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1119
                 },
@@ -2623,7 +3221,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1120
                 },
@@ -2632,7 +3232,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1125
                 },
@@ -2641,7 +3243,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1126
                 },
@@ -2650,7 +3254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1132
                 },
@@ -2659,7 +3265,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1133
                 },
@@ -2668,7 +3276,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1134
                 },
@@ -2677,7 +3287,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1135
                 },
@@ -2686,7 +3298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1136
                 },
@@ -2695,7 +3309,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1137
                 },
@@ -2704,7 +3320,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1138
                 },
@@ -2713,7 +3331,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1139
                 },
@@ -2722,7 +3342,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1140
                 },
@@ -2731,7 +3353,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1141
                 },
@@ -2740,7 +3364,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1142
                 },
@@ -2749,7 +3375,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1147
                 },
@@ -2758,7 +3386,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1148
                 },
@@ -2767,7 +3397,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1154
                 },
@@ -2776,7 +3408,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1155
                 },
@@ -2785,7 +3419,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1156
                 },
@@ -2794,7 +3430,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1157
                 },
@@ -2803,7 +3441,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1158
                 },
@@ -2812,7 +3452,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1159
                 },
@@ -2821,7 +3463,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1160
                 },
@@ -2830,7 +3474,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1161
                 },
@@ -2839,7 +3485,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1162
                 },
@@ -2848,7 +3496,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1163
                 },
@@ -2857,7 +3507,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1164
                 },
@@ -2866,7 +3518,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1165
                 },
@@ -2875,7 +3529,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1170
                 },
@@ -2884,7 +3540,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1171
                 },
@@ -2893,7 +3551,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1177
                 },
@@ -2902,7 +3562,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1178
                 },
@@ -2911,7 +3573,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1179
                 },
@@ -2920,7 +3584,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1180
                 },
@@ -2929,7 +3595,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1181
                 },
@@ -2938,7 +3606,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 1182
                 },
@@ -2947,7 +3617,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1195
                 },
@@ -2956,7 +3628,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1196
                 },
@@ -2965,7 +3639,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1201
                 },
@@ -2974,7 +3650,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1202
                 },
@@ -2983,7 +3661,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1208
                 },
@@ -2992,7 +3672,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1209
                 },
@@ -3001,7 +3683,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1210
                 },
@@ -3010,7 +3694,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1211
                 },
@@ -3019,7 +3705,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1212
                 },
@@ -3028,7 +3716,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 1213
                 },
@@ -3037,7 +3727,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1226
                 },
@@ -3046,7 +3738,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1227
                 },
@@ -3055,7 +3749,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1228
                 },
@@ -3064,7 +3760,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1229
                 },
@@ -3073,7 +3771,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1230
                 },
@@ -3082,7 +3782,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1231
                 },
@@ -3091,7 +3793,9 @@
                     "token": "/*comment*/",
                     "value": "/*comment*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 1232
                 },
@@ -3100,7 +3804,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1243
                 },
@@ -3109,7 +3815,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1244
                 },
@@ -3118,7 +3826,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1249
                 },
@@ -3127,7 +3837,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1250
                 },
@@ -3136,7 +3848,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1256
                 },
@@ -3145,7 +3859,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1257
                 },
@@ -3154,7 +3870,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1258
                 },
@@ -3163,7 +3881,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1259
                 },
@@ -3172,7 +3892,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1260
                 },
@@ -3181,7 +3903,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 1261
                 },
@@ -3190,7 +3914,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1274
                 },
@@ -3199,7 +3925,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1275
                 },
@@ -3208,7 +3936,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1276
                 },
@@ -3217,7 +3947,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1277
                 },
@@ -3226,7 +3958,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1278
                 },
@@ -3235,7 +3969,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1279
                 },
@@ -3244,7 +3980,9 @@
                     "token": "/*comment*/",
                     "value": "/*comment*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 1280
                 },
@@ -3253,7 +3991,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1291
                 },
@@ -3262,7 +4002,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1292
                 },
@@ -3271,7 +4013,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1297
                 },
@@ -3280,7 +4024,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1298
                 },
@@ -3289,7 +4035,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1304
                 },
@@ -3298,7 +4046,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1305
                 },
@@ -3307,7 +4057,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1306
                 },
@@ -3316,7 +4068,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1307
                 },
@@ -3325,7 +4079,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1308
                 },
@@ -3334,7 +4090,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 1309
                 },
@@ -3343,7 +4101,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1322
                 },
@@ -3352,7 +4112,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1323
                 },
@@ -3361,7 +4123,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1324
                 },
@@ -3370,7 +4134,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1325
                 },
@@ -3379,7 +4145,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1326
                 },
@@ -3388,7 +4156,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 1327
                 },
@@ -3397,7 +4167,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1328
                 },
@@ -3406,7 +4178,9 @@
                     "token": "/*comment*/",
                     "value": "/*comment*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 2,
                     "position": 1329
                 },
@@ -3415,7 +4189,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1340
                 },
@@ -3424,7 +4200,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1341
                 },
@@ -3433,7 +4211,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1346
                 },
@@ -3442,13 +4222,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 382,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexString.out
+++ b/tests/data/lexer/lexString.out
@@ -7,13 +7,19 @@
         "last": 32,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "'foo'",
                     "value": "foo",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 12
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +78,9 @@
                     "token": "\"bar\"",
                     "value": "bar",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 14
                 },
@@ -67,7 +89,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +111,9 @@
                     "token": "\"foo\\\\ bar\"",
                     "value": "foo\\ bar",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 21
                 },
@@ -94,13 +122,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexStringErr1.out
+++ b/tests/data/lexer/lexStringErr1.out
@@ -7,13 +7,19 @@
         "last": 32,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "'foo'",
                     "value": "foo",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 12
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +78,9 @@
                     "token": "\"bar\"",
                     "value": "bar",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 14
                 },
@@ -67,7 +89,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +111,9 @@
                     "token": "\"foo\\\\ bar",
                     "value": "foo\\ ba",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 21
                 },
@@ -94,13 +122,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexSymbol.out
+++ b/tests/data/lexer/lexSymbol.out
@@ -7,13 +7,19 @@
         "last": 54,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 22,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,11 @@
                     "token": "@idx",
                     "value": "idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 4
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,11 @@
                     "token": ":=",
                     "value": ":=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 8,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -67,7 +89,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -76,7 +102,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -85,7 +115,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -94,7 +126,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 15
                 },
@@ -103,7 +137,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -112,7 +148,9 @@
                     "token": "@idx",
                     "value": "idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 22
                 },
@@ -121,7 +159,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 26
                 },
@@ -130,7 +170,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -139,7 +181,9 @@
                     "token": "@`idx`",
                     "value": "idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 28
                 },
@@ -148,7 +192,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 34
                 },
@@ -157,7 +203,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -166,7 +214,9 @@
                     "token": "@'idx'",
                     "value": "idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 36
                 },
@@ -175,7 +225,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -184,7 +236,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -193,7 +247,9 @@
                     "token": "@@hostname",
                     "value": "hostname",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 44
                 },
@@ -202,13 +258,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 22,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexSymbolErr1.out
+++ b/tests/data/lexer/lexSymbolErr1.out
@@ -7,13 +7,19 @@
         "last": 42,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 19,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,11 @@
                     "token": "@idx",
                     "value": "idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 4
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,11 @@
                     "token": ":=",
                     "value": ":=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 8,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -67,7 +89,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -76,7 +102,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -85,7 +115,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -94,7 +126,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 15
                 },
@@ -103,7 +137,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -112,7 +148,9 @@
                     "token": "@idx",
                     "value": "idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 22
                 },
@@ -121,7 +159,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 26
                 },
@@ -130,7 +170,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -139,7 +181,9 @@
                     "token": "@`idx`",
                     "value": "idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 28
                 },
@@ -148,7 +192,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 34
                 },
@@ -157,7 +203,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -166,7 +214,9 @@
                     "token": "@'idx",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 36
                 },
@@ -175,13 +225,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 19,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexSymbolErr2.out
+++ b/tests/data/lexer/lexSymbolErr2.out
@@ -7,13 +7,19 @@
         "last": 38,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 19,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,11 @@
                     "token": "@idx",
                     "value": "idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 4
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,11 @@
                     "token": ":=",
                     "value": ":=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 8,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -67,7 +89,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -76,7 +102,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -85,7 +115,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -94,7 +126,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 15
                 },
@@ -103,7 +137,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -112,7 +148,9 @@
                     "token": "@idx",
                     "value": "idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 22
                 },
@@ -121,7 +159,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 26
                 },
@@ -130,7 +170,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -139,7 +181,9 @@
                     "token": "@`idx`",
                     "value": "idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 28
                 },
@@ -148,7 +192,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 34
                 },
@@ -157,7 +203,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -166,7 +214,9 @@
                     "token": "@",
                     "value": "",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 36
                 },
@@ -175,13 +225,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 19,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexSymbolErr3.out
+++ b/tests/data/lexer/lexSymbolErr3.out
@@ -7,13 +7,19 @@
         "last": 12,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 4,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "`idx",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 7
                 },
@@ -40,13 +54,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 4,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexSymbolUser1.out
+++ b/tests/data/lexer/lexSymbolUser1.out
@@ -7,13 +7,19 @@
         "last": 55,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 13,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "'user'@'hostname'",
                     "value": "user@hostname",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -67,7 +87,9 @@
                     "token": "IDENTIFIED",
                     "value": "IDENTIFIED",
                     "keyword": "IDENTIFIED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 30
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -85,7 +109,9 @@
                     "token": "BY",
                     "value": "BY",
                     "keyword": "BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 41
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -103,7 +131,11 @@
                     "token": "'password'",
                     "value": "password",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 44
                 },
@@ -112,7 +144,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -121,13 +157,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 13,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexSymbolUser2.out
+++ b/tests/data/lexer/lexSymbolUser2.out
@@ -7,13 +7,19 @@
         "last": 81,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'user'@'hostname'",
                     "value": "user@hostname",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -67,7 +87,9 @@
                     "token": "IDENTIFIED WITH",
                     "value": "IDENTIFIED WITH",
                     "keyword": "IDENTIFIED WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 29
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -85,7 +109,11 @@
                     "token": "mysql_native_password",
                     "value": "mysql_native_password",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -103,7 +133,9 @@
                     "token": "BY",
                     "value": "BY",
                     "keyword": "BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 67
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -121,7 +155,11 @@
                     "token": "'password'",
                     "value": "password",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 70
                 },
@@ -130,7 +168,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -139,13 +181,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexSymbolUser3.out
+++ b/tests/data/lexer/lexSymbolUser3.out
@@ -7,13 +7,19 @@
         "last": 84,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'user'@'hostname'",
                     "value": "user@hostname",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -67,7 +87,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -85,7 +109,9 @@
                     "token": "MAX_QUERIES_PER_HOUR",
                     "value": "MAX_QUERIES_PER_HOUR",
                     "keyword": "MAX_QUERIES_PER_HOUR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 34
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -103,7 +131,11 @@
                     "token": "500",
                     "value": 500,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -121,7 +155,9 @@
                     "token": "MAX_UPDATES_PER_HOUR",
                     "value": "MAX_UPDATES_PER_HOUR",
                     "keyword": "MAX_UPDATES_PER_HOUR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 59
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -139,7 +177,9 @@
                     "token": "100",
                     "value": 100,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -157,13 +201,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexSymbolUser4_mariadb_100400.out
+++ b/tests/data/lexer/lexSymbolUser4_mariadb_100400.out
@@ -7,13 +7,19 @@
         "last": 80,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'user'@'hostname'",
                     "value": "user@hostname",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -67,7 +87,9 @@
                     "token": "IDENTIFIED VIA",
                     "value": "IDENTIFIED VIA",
                     "keyword": "IDENTIFIED VIA",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 29
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -85,7 +109,11 @@
                     "token": "mysql_native_password",
                     "value": "mysql_native_password",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -103,7 +133,9 @@
                     "token": "BY",
                     "value": "BY",
                     "keyword": "BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 66
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -121,7 +155,11 @@
                     "token": "'password'",
                     "value": "password",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 69
                 },
@@ -130,7 +168,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -139,13 +181,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexSymbolUser5_mariadb_100400.out
+++ b/tests/data/lexer/lexSymbolUser5_mariadb_100400.out
@@ -7,13 +7,19 @@
         "last": 81,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "'user'@'hostname'",
                     "value": "user@hostname",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -67,7 +87,9 @@
                     "token": "IDENTIFIED VIA",
                     "value": "IDENTIFIED VIA",
                     "keyword": "IDENTIFIED VIA",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 30
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -85,7 +109,11 @@
                     "token": "mysql_native_password",
                     "value": "mysql_native_password",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -103,7 +133,9 @@
                     "token": "BY",
                     "value": "BY",
                     "keyword": "BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 67
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -121,7 +155,11 @@
                     "token": "'password'",
                     "value": "password",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 70
                 },
@@ -130,7 +168,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -139,13 +181,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexUtf8.out
+++ b/tests/data/lexer/lexUtf8.out
@@ -14,13 +14,19 @@
         "last": 19,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -29,7 +35,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -38,7 +48,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -47,7 +61,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -56,7 +72,9 @@
                     "token": "from",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -65,7 +83,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -74,7 +94,11 @@
                     "token": "école",
                     "value": "école",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -83,13 +107,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexWhitespace.out
+++ b/tests/data/lexer/lexWhitespace.out
@@ -7,13 +7,19 @@
         "last": 79,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 6,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "\n\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 3
                 },
@@ -31,7 +41,9 @@
                     "token": "      \n\t\t",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -40,7 +52,11 @@
                     "token": "'w h i t e\t\ts p a c e'",
                     "value": "w h i t e\t\ts p a c e",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 18
                 },
@@ -49,7 +65,9 @@
                     "token": "\n\n\t\t\n\t\t\t\n                \n             ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -58,13 +76,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 6,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/lexer/lexWildcardThenComment.out
+++ b/tests/data/lexer/lexWildcardThenComment.out
@@ -7,13 +7,19 @@
         "last": 495,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 109,
+            "idx": 0,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 8
                 },
@@ -49,7 +67,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -58,7 +78,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 23
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -76,7 +100,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 30
                 },
@@ -85,7 +111,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 43
                 },
@@ -94,7 +122,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -103,7 +133,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 46
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -121,7 +155,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -130,7 +168,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 54
                 },
@@ -139,7 +179,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 55
                 },
@@ -148,7 +190,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -157,7 +201,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -166,7 +212,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 71
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -184,7 +234,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -193,7 +245,9 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 79
                 },
@@ -202,7 +256,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 92
                 },
@@ -211,7 +267,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -220,7 +278,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -229,7 +289,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -247,7 +311,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 103
                 },
@@ -256,7 +322,9 @@
                     "token": "/*\ncomment\non\nmultiple\nlines\n*/",
                     "value": "/*\ncomment\non\nmultiple\nlines\n*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 104
                 },
@@ -265,7 +333,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 135
                 },
@@ -274,7 +344,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -283,7 +355,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 141
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -301,7 +377,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -310,7 +390,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 151
                 },
@@ -319,7 +401,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 152
                 },
@@ -328,7 +412,9 @@
                     "token": "/* foo */",
                     "value": "/* foo */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 153
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 162
                 },
@@ -346,7 +434,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 163
                 },
@@ -355,7 +445,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 168
                 },
@@ -364,7 +456,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 170
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -382,7 +478,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 177
                 },
@@ -391,7 +489,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 180
                 },
@@ -400,7 +500,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 181
                 },
@@ -409,7 +511,9 @@
                     "token": "/* foo */",
                     "value": "/* foo */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 182
                 },
@@ -418,7 +522,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 191
                 },
@@ -427,7 +533,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 192
                 },
@@ -436,7 +544,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 195
                 },
@@ -445,7 +555,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 196
                 },
@@ -454,7 +566,9 @@
                     "token": "/*bar*/",
                     "value": "/*bar*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 197
                 },
@@ -463,7 +577,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 204
                 },
@@ -472,7 +588,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 205
                 },
@@ -481,7 +599,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 210
                 },
@@ -490,7 +610,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 212
                 },
@@ -499,7 +621,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 218
                 },
@@ -508,7 +632,11 @@
                     "token": "`*`",
                     "value": "*",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 219
                 },
@@ -517,7 +645,9 @@
                     "token": "/*with comment*/",
                     "value": "/*with comment*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 222
                 },
@@ -526,7 +656,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 238
                 },
@@ -535,7 +667,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 239
                 },
@@ -544,7 +678,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 241
                 },
@@ -553,7 +689,9 @@
                     "token": "star_field",
                     "value": "star_field",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 242
                 },
@@ -562,7 +700,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 252
                 },
@@ -571,7 +711,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 254
                 },
@@ -580,7 +722,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 260
                 },
@@ -589,7 +733,9 @@
                     "token": "`*`",
                     "value": "*",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@64"
+                    },
                     "flags": 2,
                     "position": 261
                 },
@@ -598,7 +744,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 264
                 },
@@ -607,7 +755,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 265
                 },
@@ -616,7 +766,9 @@
                     "token": "/*with comment*/",
                     "value": "/*with comment*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 266
                 },
@@ -625,7 +777,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 282
                 },
@@ -634,7 +788,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 284
                 },
@@ -643,7 +799,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 290
                 },
@@ -652,7 +810,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 291
                 },
@@ -661,7 +821,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 292
                 },
@@ -670,7 +832,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 293
                 },
@@ -679,7 +843,9 @@
                     "token": "/*multi\nline /* with C open tag\ncomment inside */",
                     "value": "/*multi\nline /* with C open tag\ncomment inside */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 294
                 },
@@ -688,7 +854,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 343
                 },
@@ -697,7 +865,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 344
                 },
@@ -706,7 +876,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 349
                 },
@@ -715,7 +887,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 351
                 },
@@ -724,7 +898,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 357
                 },
@@ -733,7 +909,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 358
                 },
@@ -742,7 +920,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 359
                 },
@@ -751,7 +931,9 @@
                     "token": "/* operator */",
                     "value": "/* operator */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 360
                 },
@@ -760,7 +942,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 374
                 },
@@ -769,7 +953,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 375
                 },
@@ -778,7 +964,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 376
                 },
@@ -787,7 +975,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 377
                 },
@@ -796,7 +986,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 378
                 },
@@ -805,7 +997,9 @@
                     "token": "/* operator */",
                     "value": "/* operator */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 379
                 },
@@ -814,7 +1008,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 393
                 },
@@ -823,7 +1019,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 394
                 },
@@ -832,7 +1030,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 395
                 },
@@ -841,7 +1041,9 @@
                     "token": "/* start wildcard */",
                     "value": "/* start wildcard */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 396
                 },
@@ -850,7 +1052,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 416
                 },
@@ -859,7 +1063,9 @@
                     "token": "/* end wildcard */",
                     "value": "/* end wildcard */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 417
                 },
@@ -868,7 +1074,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 435
                 },
@@ -877,7 +1085,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 437
                 },
@@ -886,7 +1096,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 443
                 },
@@ -895,7 +1107,9 @@
                     "token": "`*`",
                     "value": "*",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@64"
+                    },
                     "flags": 2,
                     "position": 444
                 },
@@ -904,7 +1118,9 @@
                     "token": "/*a*/",
                     "value": "/*a*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 447
                 },
@@ -913,7 +1129,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 452
                 },
@@ -922,7 +1140,9 @@
                     "token": "/*b*/",
                     "value": "/*b*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 453
                 },
@@ -931,7 +1151,9 @@
                     "token": "`*`",
                     "value": "*",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@64"
+                    },
                     "flags": 2,
                     "position": 458
                 },
@@ -940,7 +1162,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 461
                 },
@@ -949,7 +1173,9 @@
                     "token": "-- invalid queries",
                     "value": "-- invalid queries",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 4,
                     "position": 463
                 },
@@ -958,7 +1184,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 481
                 },
@@ -967,7 +1195,9 @@
                     "token": "/* SELECT */",
                     "value": "/* SELECT */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 482
                 },
@@ -976,7 +1206,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 494
                 },
@@ -985,13 +1217,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 109,
-            "idx": 0
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/misc/parseParameter.out
+++ b/tests/data/misc/parseParameter.out
@@ -7,13 +7,19 @@
         "last": 95,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 29,
+            "idx": 29,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`person`",
                     "value": "person",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 21
                 },
@@ -76,7 +100,9 @@
                     "token": "`firstname`",
                     "value": "firstname",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 22
                 },
@@ -85,7 +111,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -103,7 +133,9 @@
                     "token": "`lastname`",
                     "value": "lastname",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 35
                 },
@@ -112,7 +144,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 45
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -130,7 +166,9 @@
                     "token": "`email`",
                     "value": "email",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 47
                 },
@@ -139,7 +177,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 54
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -157,7 +199,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 56
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -175,7 +221,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 63
                 },
@@ -184,7 +232,9 @@
                     "token": ":firstname",
                     "value": "firstname",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 64
                 },
@@ -193,7 +243,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 74
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -211,7 +265,9 @@
                     "token": ":lastname",
                     "value": "lastname",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 76
                 },
@@ -220,7 +276,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 85
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -238,7 +298,9 @@
                     "token": ":email",
                     "value": "email",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 87
                 },
@@ -247,7 +309,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 93
                 },
@@ -256,7 +320,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -265,13 +333,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@34"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 29,
-            "idx": 29
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parse.out
+++ b/tests/data/parser/parse.out
@@ -7,13 +7,19 @@
         "last": 9,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 5,
+            "idx": 5,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,13 +67,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 5,
-            "idx": 5
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parse2.out
+++ b/tests/data/parser/parse2.out
@@ -7,13 +7,19 @@
         "last": 24,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 15,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 1
                 },
@@ -31,7 +41,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +67,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 9
                 },
@@ -58,7 +78,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -67,7 +91,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 11
                 },
@@ -76,7 +102,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 12
                 },
@@ -85,7 +113,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -94,7 +124,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -103,7 +135,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -112,7 +146,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 21
                 },
@@ -121,7 +157,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 22
                 },
@@ -130,7 +168,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -139,13 +179,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 15
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlter.out
+++ b/tests/data/parser/parseAlter.out
@@ -7,13 +7,19 @@
         "last": 102,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 26,
+            "idx": 26,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`actor`",
                     "value": "actor",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +87,9 @@
                     "token": "ADD",
                     "value": "ADD",
                     "keyword": "ADD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -85,7 +109,9 @@
                     "token": "PRIMARY KEY",
                     "value": "PRIMARY KEY",
                     "keyword": "PRIMARY KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 28
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -103,7 +131,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -112,7 +144,9 @@
                     "token": "`actor_id`",
                     "value": "actor_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 41
                 },
@@ -121,7 +155,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 51
                 },
@@ -130,7 +166,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 52
                 },
@@ -139,7 +177,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -148,7 +188,9 @@
                     "token": "ADD",
                     "value": "ADD",
                     "keyword": "ADD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 58
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -166,7 +210,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 62
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -184,7 +232,9 @@
                     "token": "`idx_actor_last_name`",
                     "value": "idx_actor_last_name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 66
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -202,7 +254,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 88
                 },
@@ -211,7 +265,9 @@
                     "token": "`last_name`",
                     "value": "last_name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 89
                 },
@@ -220,7 +276,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 100
                 },
@@ -229,7 +287,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -238,13 +300,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 26,
-            "idx": 26
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -283,13 +345,13 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
+                                "@type": "@15"
                             },
                             {
-                                "@type": "@13"
+                                "@type": "@17"
                             },
                             {
-                                "@type": "@14"
+                                "@type": "@18"
                             }
                         ]
                     },
@@ -315,13 +377,13 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@23"
+                                "@type": "@27"
                             },
                             {
-                                "@type": "@24"
+                                "@type": "@28"
                             },
                             {
-                                "@type": "@25"
+                                "@type": "@29"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlter10.out
+++ b/tests/data/parser/parseAlter10.out
@@ -7,13 +7,19 @@
         "last": 81,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 22,
+            "idx": 22,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`database`",
                     "value": "database",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 22
                 },
@@ -67,7 +89,9 @@
                     "token": "`table`",
                     "value": "table",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 23
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -85,7 +111,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 31
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -103,7 +133,9 @@
                     "token": "`field`",
                     "value": "field",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 38
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -121,7 +155,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 46
                 },
@@ -130,7 +166,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 49
                 },
@@ -139,7 +177,11 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +190,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 52
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -166,7 +212,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 54
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -184,7 +234,9 @@
                     "token": "PRIMARY KEY",
                     "value": "PRIMARY KEY",
                     "keyword": "PRIMARY KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 69
                 },
@@ -193,7 +245,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -202,13 +258,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 22,
-            "idx": 22
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -255,18 +311,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@14"
-                            },
-                            {
-                                "@type": "@15"
-                            },
-                            {
-                                "@type": "@16"
-                            },
-                            {
-                                "@type": "@17"
-                            },
-                            {
                                 "@type": "@18"
                             },
                             {
@@ -276,7 +320,19 @@
                                 "@type": "@20"
                             },
                             {
-                                "@type": "@21"
+                                "@type": "@22"
+                            },
+                            {
+                                "@type": "@23"
+                            },
+                            {
+                                "@type": "@24"
+                            },
+                            {
+                                "@type": "@25"
+                            },
+                            {
+                                "@type": "@26"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlter11.out
+++ b/tests/data/parser/parseAlter11.out
@@ -7,13 +7,19 @@
         "last": 98,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 26,
+            "idx": 26,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`actor`",
                     "value": "actor",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +87,9 @@
                     "token": "ADD",
                     "value": "ADD",
                     "keyword": "ADD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +109,9 @@
                     "token": "`last_update2`",
                     "value": "last_update2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 24
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -103,7 +131,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 39
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -121,7 +153,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -130,7 +166,11 @@
                     "token": "'value1'",
                     "value": "value1",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 44
                 },
@@ -139,7 +179,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 52
                 },
@@ -148,7 +190,9 @@
                     "token": "'value2'",
                     "value": "value2",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 1,
                     "position": 53
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 61
                 },
@@ -166,7 +212,9 @@
                     "token": "'value3'",
                     "value": "value3",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 1,
                     "position": 62
                 },
@@ -175,7 +223,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 70
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -193,7 +245,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 72
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -211,7 +267,9 @@
                     "token": "AFTER",
                     "value": "AFTER",
                     "keyword": "AFTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 81
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -229,7 +289,11 @@
                     "token": "last_update",
                     "value": "last_update",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -238,13 +302,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 26,
-            "idx": 26
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -291,22 +357,22 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
+                                "@type": "@15"
                             },
                             {
-                                "@type": "@22"
+                                "@type": "@27"
                             },
                             {
-                                "@type": "@23"
+                                "@type": "@28"
                             },
                             {
-                                "@type": "@24"
+                                "@type": "@29"
                             },
                             {
-                                "@type": "@25"
+                                "@type": "@30"
                             },
                             {
-                                "@type": "@26"
+                                "@type": "@31"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlter12.out
+++ b/tests/data/parser/parseAlter12.out
@@ -7,13 +7,19 @@
         "last": 58,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "actor",
                     "value": "actor",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +109,9 @@
                     "token": "last_update2",
                     "value": "last_update2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -103,7 +131,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 37
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -121,7 +153,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 41
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -139,7 +175,11 @@
                     "token": "'value1'",
                     "value": "value1",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 49
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -157,13 +201,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -210,7 +254,7 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
+                                "@type": "@15"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlter13.out
+++ b/tests/data/parser/parseAlter13.out
@@ -7,13 +7,19 @@
         "last": 71,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 20,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`actor`",
                     "value": "actor",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +87,9 @@
                     "token": "ADD",
                     "value": "ADD",
                     "keyword": "ADD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +109,9 @@
                     "token": "`last_update2`",
                     "value": "last_update2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 24
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -103,7 +131,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 39
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -121,7 +153,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -130,7 +166,11 @@
                     "token": "'value1'",
                     "value": "value1",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 44
                 },
@@ -139,7 +179,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 52
                 },
@@ -148,7 +190,9 @@
                     "token": "'value2'",
                     "value": "value2",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 1,
                     "position": 53
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 61
                 },
@@ -166,7 +212,9 @@
                     "token": "'value3'",
                     "value": "value3",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 1,
                     "position": 62
                 },
@@ -175,7 +223,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 70
                 },
@@ -184,13 +234,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 20,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -237,7 +289,7 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
+                                "@type": "@15"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlter14.out
+++ b/tests/data/parser/parseAlter14.out
@@ -7,13 +7,19 @@
         "last": 97,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 30,
+            "idx": 30,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`table`",
                     "value": "table",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +87,9 @@
                     "token": "ADD",
                     "value": "ADD",
                     "keyword": "ADD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +109,9 @@
                     "token": "UNIQUE KEY",
                     "value": "UNIQUE KEY",
                     "keyword": "UNIQUE KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 24
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -103,7 +131,9 @@
                     "token": "`functional_index`",
                     "value": "functional_index",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 35
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -121,7 +153,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 54
                 },
@@ -130,7 +166,9 @@
                     "token": "`field1`",
                     "value": "field1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 55
                 },
@@ -139,7 +177,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 63
                 },
@@ -148,7 +188,9 @@
                     "token": "`field2`",
                     "value": "field2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 64
                 },
@@ -157,7 +199,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 72
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -175,7 +221,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 74
                 },
@@ -184,7 +232,9 @@
                     "token": "IFNULL",
                     "value": "IFNULL",
                     "keyword": "IFNULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 75
                 },
@@ -193,7 +243,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 81
                 },
@@ -202,7 +254,9 @@
                     "token": "`field3`",
                     "value": "field3",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 82
                 },
@@ -211,7 +265,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 90
                 },
@@ -220,7 +276,11 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -229,7 +289,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 92
                 },
@@ -238,7 +300,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 93
                 },
@@ -247,7 +311,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 94
                 },
@@ -256,7 +322,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -265,7 +335,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -274,13 +346,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 30,
-            "idx": 30
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -318,15 +390,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@10"
-                            },
-                            {
-                                "@type": "@11"
-                            },
-                            {
-                                "@type": "@12"
-                            },
-                            {
                                 "@type": "@13"
                             },
                             {
@@ -340,9 +403,6 @@
                             },
                             {
                                 "@type": "@17"
-                            },
-                            {
-                                "@type": "@18"
                             },
                             {
                                 "@type": "@19"
@@ -373,6 +433,18 @@
                             },
                             {
                                 "@type": "@28"
+                            },
+                            {
+                                "@type": "@29"
+                            },
+                            {
+                                "@type": "@31"
+                            },
+                            {
+                                "@type": "@32"
+                            },
+                            {
+                                "@type": "@33"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlter2.out
+++ b/tests/data/parser/parseAlter2.out
@@ -7,13 +7,19 @@
         "last": 84,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 29,
+            "idx": 29,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,11 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 6
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +65,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +109,9 @@
                     "token": "table",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -94,7 +120,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -103,7 +131,9 @@
                     "token": "CONVERT",
                     "value": "CONVERT",
                     "keyword": "CONVERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 30
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -121,7 +153,9 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 38
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -139,7 +175,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -148,7 +186,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -157,7 +197,9 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 47
                 },
@@ -166,7 +208,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -175,7 +219,9 @@
                     "token": "CHARACTER",
                     "value": "CHARACTER",
                     "keyword": "CHARACTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 53
                 },
@@ -184,7 +230,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -193,7 +241,9 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 63
                 },
@@ -202,7 +252,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -211,7 +263,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 69
                 },
@@ -220,7 +274,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -229,7 +285,9 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 73
                 },
@@ -238,7 +296,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -247,7 +307,11 @@
                     "token": "utf8",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -256,7 +320,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -265,13 +333,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@34"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 29,
-            "idx": 29
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -327,14 +395,14 @@
             [
                 "This option conflicts with \"TABLE\".",
                 {
-                    "@type": "@10"
+                    "@type": "@13"
                 },
                 0
             ],
             [
                 "A new statement was found, but no delimiter between it and the previous one.",
                 {
-                    "@type": "@24"
+                    "@type": "@27"
                 },
                 0
             ]

--- a/tests/data/parser/parseAlter3.out
+++ b/tests/data/parser/parseAlter3.out
@@ -7,13 +7,19 @@
         "last": 153,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 48,
+            "idx": 48,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`tbl`",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "CHANGE",
                     "value": "CHANGE",
                     "keyword": "CHANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "`uid`",
                     "value": "uid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 25
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +131,9 @@
                     "token": "`uid`",
                     "value": "uid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 31
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -121,7 +153,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 37
                 },
@@ -130,7 +164,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +188,11 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +212,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 45
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -184,7 +234,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 47
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -202,7 +256,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 56
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -220,7 +278,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 65
                 },
@@ -229,7 +289,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -238,7 +300,9 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 81
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -256,7 +322,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 87
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -274,7 +344,9 @@
                     "token": "`tbl`",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 93
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -292,7 +366,9 @@
                     "token": "CHANGE",
                     "value": "CHANGE",
                     "keyword": "CHANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 99
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -310,7 +388,9 @@
                     "token": "`field_1`",
                     "value": "field_1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 106
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -328,7 +410,9 @@
                     "token": "`field_2`",
                     "value": "field_2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 116
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -346,7 +432,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 126
                 },
@@ -355,7 +443,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 129
                 },
@@ -364,7 +454,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -373,7 +465,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -382,7 +476,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -391,7 +487,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 134
                 },
@@ -400,7 +498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -409,7 +509,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 136
                 },
@@ -418,7 +520,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 144
                 },
@@ -427,7 +531,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 145
                 },
@@ -436,13 +542,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 48,
-            "idx": 48
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -489,15 +597,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
-                            },
-                            {
-                                "@type": "@14"
-                            },
-                            {
                                 "@type": "@15"
                             },
                             {
@@ -510,16 +609,10 @@
                                 "@type": "@18"
                             },
                             {
-                                "@type": "@19"
-                            },
-                            {
                                 "@type": "@20"
                             },
                             {
                                 "@type": "@21"
-                            },
-                            {
-                                "@type": "@22"
                             },
                             {
                                 "@type": "@23"
@@ -532,6 +625,21 @@
                             },
                             {
                                 "@type": "@26"
+                            },
+                            {
+                                "@type": "@27"
+                            },
+                            {
+                                "@type": "@28"
+                            },
+                            {
+                                "@type": "@29"
+                            },
+                            {
+                                "@type": "@30"
+                            },
+                            {
+                                "@type": "@31"
                             }
                         ]
                     }
@@ -556,7 +664,7 @@
             [
                 "A new statement was found, but no delimiter between it and the previous one.",
                 {
-                    "@type": "@27"
+                    "@type": "@32"
                 },
                 0
             ]

--- a/tests/data/parser/parseAlter4.out
+++ b/tests/data/parser/parseAlter4.out
@@ -7,13 +7,19 @@
         "last": 48,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_table",
                     "value": "my_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 21
                 },
@@ -76,7 +98,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 28
                 },
@@ -85,7 +111,11 @@
                     "token": "'Comment of table'",
                     "value": "Comment of table",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 29
                 },
@@ -94,7 +124,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -103,13 +137,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlter5.out
+++ b/tests/data/parser/parseAlter5.out
@@ -7,13 +7,19 @@
         "last": 43,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 12,
+            "idx": 12,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "DATABASE",
                     "value": "DATABASE",
                     "keyword": "DATABASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -49,7 +63,11 @@
                     "token": "`abc`",
                     "value": "abc",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 15
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "CHARACTER SET",
                     "value": "CHARACTER SET",
                     "keyword": "CHARACTER SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -85,7 +109,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 35
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -103,7 +133,11 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 37
                 },
@@ -112,13 +146,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 12,
-            "idx": 12
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlter6.out
+++ b/tests/data/parser/parseAlter6.out
@@ -7,13 +7,19 @@
         "last": 39,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 16,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "`abc`",
                     "value": "abc",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +109,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +131,9 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -121,7 +153,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 31
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -139,7 +175,9 @@
                     "token": "`b`",
                     "value": "b",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 36
                 },
@@ -148,13 +186,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 16
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -192,15 +232,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@9"
-                            },
-                            {
-                                "@type": "@10"
-                            },
-                            {
-                                "@type": "@11"
-                            },
-                            {
                                 "@type": "@12"
                             },
                             {
@@ -214,6 +245,15 @@
                             },
                             {
                                 "@type": "@16"
+                            },
+                            {
+                                "@type": "@17"
+                            },
+                            {
+                                "@type": "@18"
+                            },
+                            {
+                                "@type": "@19"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlter7.out
+++ b/tests/data/parser/parseAlter7.out
@@ -7,13 +7,19 @@
         "last": 135,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 43,
+            "idx": 43,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`tbl`",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "CHANGE",
                     "value": "CHANGE",
                     "keyword": "CHANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "`uid`",
                     "value": "uid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 25
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +131,9 @@
                     "token": "`uid`",
                     "value": "uid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 31
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -121,7 +153,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 37
                 },
@@ -130,7 +164,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +188,11 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +212,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 45
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -184,7 +234,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 47
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -202,7 +256,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 56
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -220,7 +278,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 65
                 },
@@ -229,7 +289,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 79
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "CHANGE",
                     "value": "CHANGE",
                     "keyword": "CHANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -265,7 +333,9 @@
                     "token": "`field_1`",
                     "value": "field_1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 88
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -283,7 +355,9 @@
                     "token": "`field_2`",
                     "value": "field_2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 98
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -301,7 +377,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 108
                 },
@@ -310,7 +388,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 111
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -328,7 +410,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -346,7 +432,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 116
                 },
@@ -355,7 +443,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -364,7 +454,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 118
                 },
@@ -373,7 +465,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -382,7 +476,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 127
                 },
@@ -391,13 +487,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 43,
-            "idx": 43
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -444,15 +542,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
-                            },
-                            {
-                                "@type": "@14"
-                            },
-                            {
                                 "@type": "@15"
                             },
                             {
@@ -465,16 +554,10 @@
                                 "@type": "@18"
                             },
                             {
-                                "@type": "@19"
-                            },
-                            {
                                 "@type": "@20"
                             },
                             {
                                 "@type": "@21"
-                            },
-                            {
-                                "@type": "@22"
                             },
                             {
                                 "@type": "@23"
@@ -484,6 +567,21 @@
                             },
                             {
                                 "@type": "@25"
+                            },
+                            {
+                                "@type": "@26"
+                            },
+                            {
+                                "@type": "@27"
+                            },
+                            {
+                                "@type": "@28"
+                            },
+                            {
+                                "@type": "@29"
+                            },
+                            {
+                                "@type": "@30"
                             }
                         ]
                     },
@@ -508,21 +606,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@32"
-                            },
-                            {
-                                "@type": "@33"
-                            },
-                            {
-                                "@type": "@34"
-                            },
-                            {
-                                "@type": "@35"
-                            },
-                            {
-                                "@type": "@36"
-                            },
-                            {
                                 "@type": "@37"
                             },
                             {
@@ -542,6 +625,21 @@
                             },
                             {
                                 "@type": "@43"
+                            },
+                            {
+                                "@type": "@44"
+                            },
+                            {
+                                "@type": "@45"
+                            },
+                            {
+                                "@type": "@46"
+                            },
+                            {
+                                "@type": "@47"
+                            },
+                            {
+                                "@type": "@48"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlter8.out
+++ b/tests/data/parser/parseAlter8.out
@@ -7,13 +7,19 @@
         "last": 82,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 24,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`api_tab_user`",
                     "value": "api_tab_user",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -67,7 +87,9 @@
                     "token": "CHANGE",
                     "value": "CHANGE",
                     "keyword": "CHANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -85,7 +109,9 @@
                     "token": "`rank_id`",
                     "value": "rank_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 34
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -103,7 +131,9 @@
                     "token": "`rank_id`",
                     "value": "rank_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 44
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -121,7 +153,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 54
                 },
@@ -130,7 +164,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 57
                 },
@@ -139,7 +177,11 @@
                     "token": "4",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -148,7 +190,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 59
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -166,7 +212,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 61
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +234,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -202,7 +256,11 @@
                     "token": "'4'",
                     "value": "4",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 78
                 },
@@ -211,7 +269,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -220,13 +282,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 24
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -273,15 +335,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
-                            },
-                            {
-                                "@type": "@14"
-                            },
-                            {
                                 "@type": "@15"
                             },
                             {
@@ -294,19 +347,28 @@
                                 "@type": "@18"
                             },
                             {
-                                "@type": "@19"
-                            },
-                            {
                                 "@type": "@20"
-                            },
-                            {
-                                "@type": "@21"
                             },
                             {
                                 "@type": "@22"
                             },
                             {
                                 "@type": "@23"
+                            },
+                            {
+                                "@type": "@24"
+                            },
+                            {
+                                "@type": "@25"
+                            },
+                            {
+                                "@type": "@26"
+                            },
+                            {
+                                "@type": "@27"
+                            },
+                            {
+                                "@type": "@28"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlter9.out
+++ b/tests/data/parser/parseAlter9.out
@@ -7,13 +7,19 @@
         "last": 142,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 30,
+            "idx": 30,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "place",
                     "value": "place",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "CHANGE",
                     "value": "CHANGE",
                     "keyword": "CHANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "COLUMN",
                     "value": "COLUMN",
                     "keyword": "COLUMN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 25
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +131,9 @@
                     "token": "plc_location_type",
                     "value": "plc_location_type",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -121,7 +153,9 @@
                     "token": "gplc_location_type",
                     "value": "gplc_location_type",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -139,7 +175,9 @@
                     "token": "ENUM",
                     "value": "ENUM",
                     "keyword": "ENUM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 9,
                     "position": 69
                 },
@@ -148,7 +186,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 73
                 },
@@ -157,7 +199,11 @@
                     "token": "'LOCATION'",
                     "value": "LOCATION",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 74
                 },
@@ -166,7 +212,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 84
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -184,7 +234,9 @@
                     "token": "CHARACTER SET",
                     "value": "CHARACTER SET",
                     "keyword": "CHARACTER SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 86
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -202,7 +256,9 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 1,
                     "position": 100
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -220,7 +278,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 107
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -238,7 +300,9 @@
                     "token": "'utf8_unicode_ci'",
                     "value": "utf8_unicode_ci",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 1,
                     "position": 115
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -256,7 +322,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 133
                 },
@@ -265,7 +333,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -274,13 +346,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@36"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 30,
-            "idx": 30
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -328,15 +400,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@14"
-                            },
-                            {
-                                "@type": "@15"
-                            },
-                            {
-                                "@type": "@16"
-                            },
-                            {
                                 "@type": "@17"
                             },
                             {
@@ -349,13 +412,7 @@
                                 "@type": "@20"
                             },
                             {
-                                "@type": "@21"
-                            },
-                            {
                                 "@type": "@22"
-                            },
-                            {
-                                "@type": "@23"
                             },
                             {
                                 "@type": "@24"
@@ -374,6 +431,21 @@
                             },
                             {
                                 "@type": "@29"
+                            },
+                            {
+                                "@type": "@30"
+                            },
+                            {
+                                "@type": "@31"
+                            },
+                            {
+                                "@type": "@32"
+                            },
+                            {
+                                "@type": "@33"
+                            },
+                            {
+                                "@type": "@34"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterErr.out
+++ b/tests/data/parser/parseAlterErr.out
@@ -7,13 +7,19 @@
         "last": 176,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 44,
+            "idx": 44,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- missing comma between alter operations",
                     "value": "-- missing comma between alter operations",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -31,7 +41,11 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -49,7 +65,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 48
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -67,7 +87,11 @@
                     "token": "`tbl`",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 54
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -85,7 +111,9 @@
                     "token": "CHANGE",
                     "value": "CHANGE",
                     "keyword": "CHANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 60
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -103,7 +133,9 @@
                     "token": "`uid`",
                     "value": "uid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 67
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -121,7 +155,9 @@
                     "token": "`uid`",
                     "value": "uid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 73
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -139,7 +177,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 11,
                     "position": 79
                 },
@@ -148,7 +188,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 82
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -166,7 +212,11 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -175,7 +225,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -184,7 +236,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 16,
                     "position": 87
                 },
@@ -193,7 +247,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -202,7 +258,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 89
                 },
@@ -211,7 +269,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -220,7 +280,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 7,
                     "position": 98
                 },
@@ -229,7 +291,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -238,7 +302,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 107
                 },
@@ -247,7 +313,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -256,7 +324,9 @@
                     "token": "CHANGE",
                     "value": "CHANGE",
                     "keyword": "CHANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 122
                 },
@@ -265,7 +335,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 128
                 },
@@ -274,7 +346,9 @@
                     "token": "`field_1`",
                     "value": "field_1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 129
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -292,7 +368,9 @@
                     "token": "`field_2`",
                     "value": "field_2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 139
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -310,7 +390,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 11,
                     "position": 149
                 },
@@ -319,7 +401,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 16,
                     "position": 152
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 153
                 },
@@ -337,7 +423,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -346,7 +434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 156
                 },
@@ -355,7 +445,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 16,
                     "position": 157
                 },
@@ -364,7 +456,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -373,7 +467,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 159
                 },
@@ -382,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 167
                 },
@@ -391,7 +489,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 7,
                     "position": 168
                 },
@@ -400,13 +500,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 44,
-            "idx": 44
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -453,18 +555,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@14"
-                            },
-                            {
-                                "@type": "@15"
-                            },
-                            {
-                                "@type": "@16"
-                            },
-                            {
-                                "@type": "@17"
-                            },
-                            {
                                 "@type": "@18"
                             },
                             {
@@ -477,16 +567,10 @@
                                 "@type": "@21"
                             },
                             {
-                                "@type": "@22"
-                            },
-                            {
                                 "@type": "@23"
                             },
                             {
                                 "@type": "@24"
-                            },
-                            {
-                                "@type": "@25"
                             },
                             {
                                 "@type": "@26"
@@ -496,6 +580,24 @@
                             },
                             {
                                 "@type": "@28"
+                            },
+                            {
+                                "@type": "@29"
+                            },
+                            {
+                                "@type": "@30"
+                            },
+                            {
+                                "@type": "@31"
+                            },
+                            {
+                                "@type": "@32"
+                            },
+                            {
+                                "@type": "@33"
+                            },
+                            {
+                                "@type": "@34"
                             }
                         ]
                     }
@@ -520,7 +622,7 @@
             [
                 "Missing comma before start of a new alter operation.",
                 {
-                    "@type": "@29"
+                    "@type": "@35"
                 },
                 0
             ]

--- a/tests/data/parser/parseAlterErr2.out
+++ b/tests/data/parser/parseAlterErr2.out
@@ -7,13 +7,19 @@
         "last": 148,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 38,
+            "idx": 38,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- missing comma between alter operations",
                     "value": "-- missing comma between alter operations",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -31,7 +41,11 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -49,7 +65,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 48
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -67,7 +87,11 @@
                     "token": "tb_foo",
                     "value": "tb_foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -85,7 +111,9 @@
                     "token": "CHANGE",
                     "value": "CHANGE",
                     "keyword": "CHANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 61
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -103,7 +133,9 @@
                     "token": "inmsg",
                     "value": "inmsg",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -121,7 +155,9 @@
                     "token": "inmsg",
                     "value": "inmsg",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -139,7 +177,9 @@
                     "token": "date",
                     "value": "date",
                     "keyword": "DATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 41,
                     "position": 80
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -157,7 +199,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 85
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -175,7 +221,9 @@
                     "token": "AFTER",
                     "value": "AFTER",
                     "keyword": "AFTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 90
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -193,7 +243,9 @@
                     "token": "outmsg2",
                     "value": "outmsg2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -211,7 +265,9 @@
                     "token": "CHANGE",
                     "value": "CHANGE",
                     "keyword": "CHANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 104
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -229,7 +287,9 @@
                     "token": "inmsg2",
                     "value": "inmsg2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -247,7 +309,9 @@
                     "token": "inmsg2",
                     "value": "inmsg2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -265,7 +331,9 @@
                     "token": "time",
                     "value": "time",
                     "keyword": "TIME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 41,
                     "position": 125
                 },
@@ -274,7 +342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -283,7 +353,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 130
                 },
@@ -292,7 +364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 134
                 },
@@ -301,7 +375,9 @@
                     "token": "AFTER",
                     "value": "AFTER",
                     "keyword": "AFTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 135
                 },
@@ -310,7 +386,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -319,7 +397,9 @@
                     "token": "inmsg",
                     "value": "inmsg",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -328,7 +408,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 146
                 },
@@ -337,7 +421,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -346,13 +432,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@42"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 38,
-            "idx": 38
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -399,18 +485,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@14"
-                            },
-                            {
-                                "@type": "@15"
-                            },
-                            {
-                                "@type": "@16"
-                            },
-                            {
-                                "@type": "@17"
-                            },
-                            {
                                 "@type": "@18"
                             },
                             {
@@ -427,6 +501,18 @@
                             },
                             {
                                 "@type": "@23"
+                            },
+                            {
+                                "@type": "@24"
+                            },
+                            {
+                                "@type": "@25"
+                            },
+                            {
+                                "@type": "@26"
+                            },
+                            {
+                                "@type": "@27"
                             }
                         ]
                     }
@@ -451,7 +537,7 @@
             [
                 "Missing comma before start of a new alter operation.",
                 {
-                    "@type": "@24"
+                    "@type": "@28"
                 },
                 0
             ]

--- a/tests/data/parser/parseAlterErr3.out
+++ b/tests/data/parser/parseAlterErr3.out
@@ -7,13 +7,19 @@
         "last": 124,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 25,
+            "idx": 25,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- missing comma between alter operations",
                     "value": "-- missing comma between alter operations",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -31,7 +41,11 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -49,7 +65,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 48
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -67,7 +87,11 @@
                     "token": "`database`",
                     "value": "database",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 54
                 },
@@ -76,7 +100,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 64
                 },
@@ -85,7 +113,9 @@
                     "token": "`table`",
                     "value": "table",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 65
                 },
@@ -94,7 +124,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -103,7 +135,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 73
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -121,7 +157,9 @@
                     "token": "`field`",
                     "value": "field",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 80
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -139,7 +179,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 11,
                     "position": 88
                 },
@@ -148,7 +190,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 91
                 },
@@ -157,7 +201,11 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -166,7 +214,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 94
                 },
@@ -175,7 +225,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -184,7 +236,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 96
                 },
@@ -193,7 +247,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -202,7 +258,9 @@
                     "token": "PRIMARY KEY",
                     "value": "PRIMARY KEY",
                     "keyword": "PRIMARY KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 23,
                     "position": 111
                 },
@@ -211,7 +269,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -220,7 +282,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -229,13 +293,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 25,
-            "idx": 25
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -282,21 +346,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@16"
-                            },
-                            {
-                                "@type": "@17"
-                            },
-                            {
-                                "@type": "@18"
-                            },
-                            {
-                                "@type": "@19"
-                            },
-                            {
-                                "@type": "@20"
-                            },
-                            {
                                 "@type": "@21"
                             },
                             {
@@ -304,6 +353,21 @@
                             },
                             {
                                 "@type": "@23"
+                            },
+                            {
+                                "@type": "@25"
+                            },
+                            {
+                                "@type": "@26"
+                            },
+                            {
+                                "@type": "@27"
+                            },
+                            {
+                                "@type": "@28"
+                            },
+                            {
+                                "@type": "@29"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterErr4.out
+++ b/tests/data/parser/parseAlterErr4.out
@@ -7,13 +7,19 @@
         "last": 58,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "actor",
                     "value": "actor",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +109,9 @@
                     "token": "last_update2",
                     "value": "last_update2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -103,7 +131,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 37
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -121,7 +153,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 41
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -139,7 +175,9 @@
                     "token": "value1",
                     "value": "value1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -148,7 +186,11 @@
                     "token": "';",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 55
                 },
@@ -157,13 +199,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -210,10 +254,10 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
+                                "@type": "@15"
                             },
                             {
-                                "@type": "@17"
+                                "@type": "@20"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterEvent.out
+++ b/tests/data/parser/parseAlterEvent.out
@@ -7,13 +7,19 @@
         "last": 29,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "ENABLE",
                     "value": "ENABLE",
                     "keyword": "ENABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 21
                 },
@@ -76,7 +98,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -85,7 +111,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -94,13 +122,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEvent2.out
+++ b/tests/data/parser/parseAlterEvent2.out
@@ -7,13 +7,19 @@
         "last": 30,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "DISABLE",
                     "value": "DISABLE",
                     "keyword": "DISABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 21
                 },
@@ -76,7 +98,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +111,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -94,13 +122,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEvent3.out
+++ b/tests/data/parser/parseAlterEvent3.out
@@ -7,13 +7,19 @@
         "last": 39,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "DISABLE ON SLAVE",
                     "value": "DISABLE ON SLAVE",
                     "keyword": "DISABLE ON SLAVE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -76,7 +98,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -85,7 +111,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -94,13 +122,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEvent4.out
+++ b/tests/data/parser/parseAlterEvent4.out
@@ -7,13 +7,19 @@
         "last": 45,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "ON COMPLETION PRESERVE",
                     "value": "ON COMPLETION PRESERVE",
                     "keyword": "ON COMPLETION PRESERVE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -76,7 +98,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -85,7 +111,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -94,13 +122,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEvent5.out
+++ b/tests/data/parser/parseAlterEvent5.out
@@ -7,13 +7,19 @@
         "last": 49,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "ON COMPLETION NOT PRESERVE",
                     "value": "ON COMPLETION NOT PRESERVE",
                     "keyword": "ON COMPLETION NOT PRESERVE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -76,7 +98,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -85,7 +111,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -94,13 +122,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEvent6.out
+++ b/tests/data/parser/parseAlterEvent6.out
@@ -7,13 +7,19 @@
         "last": 45,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 14,
+            "idx": 14,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -85,7 +109,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 28
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +131,9 @@
                     "token": "my_new_event",
                     "value": "my_new_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -112,7 +142,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -121,7 +155,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,13 +166,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 14,
-            "idx": 14
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEvent7.out
+++ b/tests/data/parser/parseAlterEvent7.out
@@ -7,13 +7,19 @@
         "last": 49,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 12,
+            "idx": 12,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +109,11 @@
                     "token": "'This is an event'",
                     "value": "This is an event",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 29
                 },
@@ -94,7 +122,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -103,7 +135,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -112,13 +146,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 12,
-            "idx": 12
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEvent8.out
+++ b/tests/data/parser/parseAlterEvent8.out
@@ -7,13 +7,19 @@
         "last": 50,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 18,
+            "idx": 18,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "DO",
                     "value": "DO",
                     "keyword": "DO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +109,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 26
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +131,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -121,7 +155,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 35
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +177,9 @@
                     "token": "my_table",
                     "value": "my_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -157,7 +201,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -166,13 +212,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 18,
-            "idx": 18
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -210,15 +256,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@9"
-                            },
-                            {
-                                "@type": "@10"
-                            },
-                            {
-                                "@type": "@11"
-                            },
-                            {
                                 "@type": "@12"
                             },
                             {
@@ -231,7 +268,16 @@
                                 "@type": "@15"
                             },
                             {
-                                "@type": "@16"
+                                "@type": "@17"
+                            },
+                            {
+                                "@type": "@18"
+                            },
+                            {
+                                "@type": "@19"
+                            },
+                            {
+                                "@type": "@20"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterEvent9.out
+++ b/tests/data/parser/parseAlterEvent9.out
@@ -7,13 +7,19 @@
         "last": 122,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 35,
+            "idx": 35,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "old_db",
                     "value": "old_db",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 18
                 },
@@ -67,7 +89,9 @@
                     "token": "old_event",
                     "value": "old_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +111,9 @@
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -103,7 +133,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 36
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -121,7 +155,9 @@
                     "token": "new_db",
                     "value": "new_db",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -130,7 +166,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": "new_event",
                     "value": "new_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -157,7 +201,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -166,7 +212,9 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 57
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -184,7 +234,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 63
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -202,7 +256,11 @@
                     "token": "`old_db`",
                     "value": "old_db",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 69
                 },
@@ -211,7 +269,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -220,7 +280,9 @@
                     "token": "`old_event`",
                     "value": "old_event",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 2,
                     "position": 78
                 },
@@ -229,7 +291,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -238,7 +302,9 @@
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 90
                 },
@@ -247,7 +313,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -256,7 +324,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 97
                 },
@@ -265,7 +335,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -274,7 +346,9 @@
                     "token": "`new_db`",
                     "value": "new_db",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 2,
                     "position": 100
                 },
@@ -283,7 +357,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 108
                 },
@@ -292,7 +368,9 @@
                     "token": "`new_event`",
                     "value": "new_event",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 2,
                     "position": 109
                 },
@@ -301,7 +379,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -310,7 +390,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -319,13 +401,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 35,
-            "idx": 35
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEventComplete.out
+++ b/tests/data/parser/parseAlterEventComplete.out
@@ -7,13 +7,19 @@
         "last": 303,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 64,
+            "idx": 64,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "ON SCHEDULE",
                     "value": "ON SCHEDULE",
                     "keyword": "ON SCHEDULE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 25
                 },
@@ -76,7 +98,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -85,7 +109,9 @@
                     "token": "EVERY",
                     "value": "EVERY",
                     "keyword": "EVERY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 43
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -103,7 +131,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -121,7 +155,9 @@
                     "token": "WEEK",
                     "value": "WEEK",
                     "keyword": "WEEK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 51
                 },
@@ -130,7 +166,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -139,7 +177,9 @@
                     "token": "STARTS",
                     "value": "STARTS",
                     "keyword": "STARTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 62
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -157,7 +199,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 69
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -175,7 +221,11 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 1,
                     "position": 87
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -193,7 +245,9 @@
                     "token": "INTERVAL",
                     "value": "INTERVAL",
                     "keyword": "INTERVAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 89
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -211,7 +267,9 @@
                     "token": "4",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -229,7 +289,9 @@
                     "token": "WEEK",
                     "value": "WEEK",
                     "keyword": "WEEK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 100
                 },
@@ -238,7 +300,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -247,7 +311,9 @@
                     "token": "ENDS",
                     "value": "ENDS",
                     "keyword": "ENDS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 111
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -265,7 +333,11 @@
                     "token": "'2099-12-30 23:12:01'",
                     "value": "2099-12-30 23:12:01",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 116
                 },
@@ -274,7 +346,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 137
                 },
@@ -283,7 +357,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 1,
                     "position": 138
                 },
@@ -292,7 +368,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -301,7 +379,9 @@
                     "token": "INTERVAL",
                     "value": "INTERVAL",
                     "keyword": "INTERVAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 140
                 },
@@ -310,7 +390,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -319,7 +401,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 150
                 },
@@ -337,7 +423,9 @@
                     "token": "DAY",
                     "value": "DAY",
                     "keyword": "DAY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 151
                 },
@@ -346,7 +434,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -355,7 +445,9 @@
                     "token": "ON COMPLETION NOT PRESERVE",
                     "value": "ON COMPLETION NOT PRESERVE",
                     "keyword": "ON COMPLETION NOT PRESERVE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 159
                 },
@@ -364,7 +456,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 185
                 },
@@ -373,7 +467,9 @@
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 190
                 },
@@ -382,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 196
                 },
@@ -391,7 +489,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 197
                 },
@@ -400,7 +500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 199
                 },
@@ -409,7 +511,9 @@
                     "token": "my_complete_event",
                     "value": "my_complete_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 200
                 },
@@ -418,7 +522,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 217
                 },
@@ -427,7 +533,9 @@
                     "token": "DISABLE",
                     "value": "DISABLE",
                     "keyword": "DISABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 222
                 },
@@ -436,7 +544,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 229
                 },
@@ -445,7 +555,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 234
                 },
@@ -454,7 +566,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 241
                 },
@@ -463,7 +577,9 @@
                     "token": "'String as a comment'",
                     "value": "String as a comment",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@36"
+                    },
                     "flags": 1,
                     "position": 242
                 },
@@ -472,7 +588,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 263
                 },
@@ -481,7 +599,9 @@
                     "token": "DO",
                     "value": "DO",
                     "keyword": "DO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 268
                 },
@@ -490,7 +610,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 270
                 },
@@ -499,7 +621,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 279
                 },
@@ -508,7 +632,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 285
                 },
@@ -517,7 +643,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 16,
                     "position": 286
                 },
@@ -526,7 +654,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 287
                 },
@@ -535,7 +665,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 288
                 },
@@ -544,7 +676,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 292
                 },
@@ -553,7 +687,9 @@
                     "token": "my_table",
                     "value": "my_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 293
                 },
@@ -562,7 +698,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 301
                 },
@@ -571,7 +711,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 302
                 },
@@ -580,13 +722,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@70"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 64,
-            "idx": 64
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -694,28 +836,28 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@55"
-                            },
-                            {
-                                "@type": "@56"
-                            },
-                            {
-                                "@type": "@57"
-                            },
-                            {
-                                "@type": "@58"
-                            },
-                            {
-                                "@type": "@59"
-                            },
-                            {
-                                "@type": "@60"
-                            },
-                            {
                                 "@type": "@61"
                             },
                             {
                                 "@type": "@62"
+                            },
+                            {
+                                "@type": "@63"
+                            },
+                            {
+                                "@type": "@64"
+                            },
+                            {
+                                "@type": "@65"
+                            },
+                            {
+                                "@type": "@66"
+                            },
+                            {
+                                "@type": "@67"
+                            },
+                            {
+                                "@type": "@68"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterEventErr.out
+++ b/tests/data/parser/parseAlterEventErr.out
@@ -7,13 +7,19 @@
         "last": 51,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- No option in ALTER EVENT.",
                     "value": "-- No option in ALTER EVENT.",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -31,7 +41,11 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -49,7 +65,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -67,7 +87,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -76,7 +100,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -85,7 +113,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -94,13 +124,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEventOnScheduleAt.out
+++ b/tests/data/parser/parseAlterEventOnScheduleAt.out
@@ -7,13 +7,19 @@
         "last": 61,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 14,
+            "idx": 14,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "ON SCHEDULE",
                     "value": "ON SCHEDULE",
                     "keyword": "ON SCHEDULE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +109,9 @@
                     "token": "AT",
                     "value": "AT",
                     "keyword": "AT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -103,7 +131,11 @@
                     "token": "'2023-01-01 01:23:45'",
                     "value": "2023-01-01 01:23:45",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 38
                 },
@@ -112,7 +144,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -121,7 +157,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -130,13 +168,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 14,
-            "idx": 14
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEventOnScheduleAt2.out
+++ b/tests/data/parser/parseAlterEventOnScheduleAt2.out
@@ -7,13 +7,19 @@
         "last": 78,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 22,
+            "idx": 22,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "ON SCHEDULE",
                     "value": "ON SCHEDULE",
                     "keyword": "ON SCHEDULE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +109,9 @@
                     "token": "AT",
                     "value": "AT",
                     "keyword": "AT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -103,7 +131,11 @@
                     "token": "'2023-01-01 01:23:45'",
                     "value": "2023-01-01 01:23:45",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 38
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -121,7 +155,11 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 1,
                     "position": 60
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -139,7 +179,9 @@
                     "token": "INTERVAL",
                     "value": "INTERVAL",
                     "keyword": "INTERVAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 62
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -157,7 +201,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -166,7 +214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -175,7 +225,9 @@
                     "token": "DAY",
                     "value": "DAY",
                     "keyword": "DAY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 73
                 },
@@ -184,7 +236,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -193,7 +249,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -202,13 +260,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 22,
-            "idx": 22
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEventOnScheduleEvery.out
+++ b/tests/data/parser/parseAlterEventOnScheduleEvery.out
@@ -7,13 +7,19 @@
         "last": 49,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 16,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "ON SCHEDULE",
                     "value": "ON SCHEDULE",
                     "keyword": "ON SCHEDULE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +109,9 @@
                     "token": "EVERY",
                     "value": "EVERY",
                     "keyword": "EVERY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -103,7 +131,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -121,7 +155,9 @@
                     "token": "WEEK",
                     "value": "WEEK",
                     "keyword": "WEEK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 43
                 },
@@ -130,7 +166,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -139,7 +179,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -148,13 +190,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 16
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEventOnScheduleEvery2.out
+++ b/tests/data/parser/parseAlterEventOnScheduleEvery2.out
@@ -7,13 +7,19 @@
         "last": 67,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 24,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "ON SCHEDULE",
                     "value": "ON SCHEDULE",
                     "keyword": "ON SCHEDULE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +109,9 @@
                     "token": "EVERY",
                     "value": "EVERY",
                     "keyword": "EVERY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -103,7 +131,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -121,7 +155,9 @@
                     "token": "WEEK",
                     "value": "WEEK",
                     "keyword": "WEEK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 43
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -139,7 +177,11 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 1,
                     "position": 48
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -157,7 +201,9 @@
                     "token": "INTERVAL",
                     "value": "INTERVAL",
                     "keyword": "INTERVAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 50
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -175,7 +223,9 @@
                     "token": "4",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -193,7 +245,9 @@
                     "token": "HOUR",
                     "value": "HOUR",
                     "keyword": "HOUR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 61
                 },
@@ -202,7 +256,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -211,7 +269,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -220,13 +280,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 24
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEventOnScheduleEvery3.out
+++ b/tests/data/parser/parseAlterEventOnScheduleEvery3.out
@@ -7,13 +7,19 @@
         "last": 76,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 20,
+            "idx": 20,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "ON SCHEDULE",
                     "value": "ON SCHEDULE",
                     "keyword": "ON SCHEDULE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +109,9 @@
                     "token": "EVERY",
                     "value": "EVERY",
                     "keyword": "EVERY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -103,7 +131,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -121,7 +155,9 @@
                     "token": "WEEK",
                     "value": "WEEK",
                     "keyword": "WEEK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 43
                 },
@@ -130,7 +166,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -139,7 +177,9 @@
                     "token": "STARTS",
                     "value": "STARTS",
                     "keyword": "STARTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -157,7 +199,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 57
                 },
@@ -166,7 +210,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -175,7 +223,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -184,13 +234,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@24"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 20,
-            "idx": 20
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEventOnScheduleEvery4.out
+++ b/tests/data/parser/parseAlterEventOnScheduleEvery4.out
@@ -7,13 +7,19 @@
         "last": 94,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 28,
+            "idx": 28,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "ON SCHEDULE",
                     "value": "ON SCHEDULE",
                     "keyword": "ON SCHEDULE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +109,9 @@
                     "token": "EVERY",
                     "value": "EVERY",
                     "keyword": "EVERY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -103,7 +131,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -121,7 +155,9 @@
                     "token": "WEEK",
                     "value": "WEEK",
                     "keyword": "WEEK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 43
                 },
@@ -130,7 +166,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -139,7 +177,9 @@
                     "token": "STARTS",
                     "value": "STARTS",
                     "keyword": "STARTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -157,7 +199,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 57
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -175,7 +221,11 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 1,
                     "position": 75
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -193,7 +245,9 @@
                     "token": "INTERVAL",
                     "value": "INTERVAL",
                     "keyword": "INTERVAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 77
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -211,7 +267,9 @@
                     "token": "4",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -229,7 +289,9 @@
                     "token": "HOUR",
                     "value": "HOUR",
                     "keyword": "HOUR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 88
                 },
@@ -238,7 +300,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -247,7 +313,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -256,13 +324,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 28,
-            "idx": 28
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEventOnScheduleEvery5.out
+++ b/tests/data/parser/parseAlterEventOnScheduleEvery5.out
@@ -7,13 +7,19 @@
         "last": 105,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 24,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "ON SCHEDULE",
                     "value": "ON SCHEDULE",
                     "keyword": "ON SCHEDULE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +109,9 @@
                     "token": "EVERY",
                     "value": "EVERY",
                     "keyword": "EVERY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -103,7 +131,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -121,7 +155,9 @@
                     "token": "WEEK",
                     "value": "WEEK",
                     "keyword": "WEEK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 43
                 },
@@ -130,7 +166,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -139,7 +177,9 @@
                     "token": "STARTS",
                     "value": "STARTS",
                     "keyword": "STARTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -157,7 +199,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 57
                 },
@@ -166,7 +210,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -175,7 +221,9 @@
                     "token": "ENDS",
                     "value": "ENDS",
                     "keyword": "ENDS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 77
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -193,7 +243,11 @@
                     "token": "'2099-12-30 23:12:01'",
                     "value": "2099-12-30 23:12:01",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 82
                 },
@@ -202,7 +256,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -211,7 +269,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -220,13 +280,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 24
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEventOnScheduleEvery6.out
+++ b/tests/data/parser/parseAlterEventOnScheduleEvery6.out
@@ -7,13 +7,19 @@
         "last": 122,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 32,
+            "idx": 32,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "ON SCHEDULE",
                     "value": "ON SCHEDULE",
                     "keyword": "ON SCHEDULE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +109,9 @@
                     "token": "EVERY",
                     "value": "EVERY",
                     "keyword": "EVERY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -103,7 +131,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -121,7 +155,9 @@
                     "token": "WEEK",
                     "value": "WEEK",
                     "keyword": "WEEK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 43
                 },
@@ -130,7 +166,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -139,7 +177,9 @@
                     "token": "STARTS",
                     "value": "STARTS",
                     "keyword": "STARTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -157,7 +199,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 57
                 },
@@ -166,7 +210,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -175,7 +221,9 @@
                     "token": "ENDS",
                     "value": "ENDS",
                     "keyword": "ENDS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 77
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -193,7 +243,11 @@
                     "token": "'2099-12-30 23:12:01'",
                     "value": "2099-12-30 23:12:01",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 82
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -211,7 +267,11 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 1,
                     "position": 104
                 },
@@ -220,7 +280,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -229,7 +291,9 @@
                     "token": "INTERVAL",
                     "value": "INTERVAL",
                     "keyword": "INTERVAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 106
                 },
@@ -238,7 +302,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -247,7 +313,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -256,7 +324,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -265,7 +335,9 @@
                     "token": "DAY",
                     "value": "DAY",
                     "keyword": "DAY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 117
                 },
@@ -274,7 +346,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -283,7 +359,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -292,13 +370,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@38"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 32,
-            "idx": 32
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEventWithDefiner.out
+++ b/tests/data/parser/parseAlterEventWithDefiner.out
@@ -7,13 +7,19 @@
         "last": 44,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 16,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 16
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 21
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +131,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -121,7 +155,9 @@
                     "token": "ENABLE",
                     "value": "ENABLE",
                     "keyword": "ENABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 36
                 },
@@ -130,7 +166,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -139,7 +179,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -148,13 +190,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 16
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterEventWithOtherDefiners.out
+++ b/tests/data/parser/parseAlterEventWithOtherDefiners.out
@@ -7,13 +7,19 @@
         "last": 247,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 77,
+            "idx": 77,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,11 @@
                     "token": "'user'",
                     "value": "user",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 16
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,7 +111,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 23
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -103,7 +133,11 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -121,7 +157,9 @@
                     "token": "ENABLE",
                     "value": "ENABLE",
                     "keyword": "ENABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 38
                 },
@@ -130,7 +168,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -139,7 +181,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -148,7 +192,9 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 46
                 },
@@ -157,7 +203,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -166,7 +214,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 52
                 },
@@ -175,7 +225,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -184,7 +236,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 60
                 },
@@ -193,7 +247,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -202,7 +258,11 @@
                     "token": "`user`",
                     "value": "user",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 62
                 },
@@ -211,7 +271,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -220,7 +282,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 69
                 },
@@ -229,7 +293,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -238,7 +304,9 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -247,7 +315,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -256,7 +326,9 @@
                     "token": "ENABLE",
                     "value": "ENABLE",
                     "keyword": "ENABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 84
                 },
@@ -265,7 +337,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -274,7 +348,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -283,7 +359,9 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 92
                 },
@@ -292,7 +370,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -301,7 +381,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 98
                 },
@@ -310,7 +392,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -319,7 +403,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 106
                 },
@@ -328,7 +414,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -337,7 +425,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 108
                 },
@@ -346,7 +436,9 @@
                     "token": "@host",
                     "value": "host",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@30"
+                    },
                     "flags": 1,
                     "position": 112
                 },
@@ -355,7 +447,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -364,7 +458,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 118
                 },
@@ -373,7 +469,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -382,7 +480,9 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -391,7 +491,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -400,7 +502,9 @@
                     "token": "ENABLE",
                     "value": "ENABLE",
                     "keyword": "ENABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 133
                 },
@@ -409,7 +513,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -418,7 +524,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -427,7 +535,9 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 141
                 },
@@ -436,7 +546,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 146
                 },
@@ -445,7 +557,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 147
                 },
@@ -454,7 +568,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -463,7 +579,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 155
                 },
@@ -472,7 +590,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 156
                 },
@@ -481,7 +601,9 @@
                     "token": "'user'@'host'",
                     "value": "user@host",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@30"
+                    },
                     "flags": 4,
                     "position": 157
                 },
@@ -490,7 +612,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 170
                 },
@@ -499,7 +623,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 171
                 },
@@ -508,7 +634,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -517,7 +645,9 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": 177
                 },
@@ -526,7 +656,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 185
                 },
@@ -535,7 +667,9 @@
                     "token": "ENABLE",
                     "value": "ENABLE",
                     "keyword": "ENABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 186
                 },
@@ -544,7 +678,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 192
                 },
@@ -553,7 +689,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 193
                 },
@@ -562,7 +700,9 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 194
                 },
@@ -571,7 +711,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 199
                 },
@@ -580,7 +722,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 200
                 },
@@ -589,7 +733,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 207
                 },
@@ -598,7 +744,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 208
                 },
@@ -607,7 +755,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 209
                 },
@@ -616,7 +766,9 @@
                     "token": "`user`@`host`",
                     "value": "user@host",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@30"
+                    },
                     "flags": 4,
                     "position": 210
                 },
@@ -625,7 +777,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 223
                 },
@@ -634,7 +788,9 @@
                     "token": "EVENT",
                     "value": "EVENT",
                     "keyword": "EVENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 224
                 },
@@ -643,7 +799,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 229
                 },
@@ -652,7 +810,9 @@
                     "token": "my_event",
                     "value": "my_event",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": 230
                 },
@@ -661,7 +821,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 238
                 },
@@ -670,7 +832,9 @@
                     "token": "ENABLE",
                     "value": "ENABLE",
                     "keyword": "ENABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 239
                 },
@@ -679,7 +843,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 245
                 },
@@ -688,7 +854,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 246
                 },
@@ -697,13 +865,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 77,
-            "idx": 77
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterRenameColumn.out
+++ b/tests/data/parser/parseAlterRenameColumn.out
@@ -7,13 +7,19 @@
         "last": 46,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 18,
+            "idx": 18,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "myTable",
                     "value": "myTable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +87,9 @@
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,7 +109,9 @@
                     "token": "COLUMN",
                     "value": "COLUMN",
                     "keyword": "COLUMN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -103,7 +131,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -121,7 +153,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 38
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -139,7 +175,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +186,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -157,7 +199,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -166,13 +210,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 18,
-            "idx": 18
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterRenameColumns.out
+++ b/tests/data/parser/parseAlterRenameColumns.out
@@ -7,13 +7,19 @@
         "last": 168,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 51,
+            "idx": 51,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "myTable",
                     "value": "myTable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +87,9 @@
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,7 +109,9 @@
                     "token": "COLUMN",
                     "value": "COLUMN",
                     "keyword": "COLUMN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -103,7 +131,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -121,7 +153,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 36
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -139,7 +175,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -148,7 +186,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -157,7 +199,9 @@
                     "token": "\n                    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -166,7 +210,9 @@
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 62
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -184,7 +232,9 @@
                     "token": "COLUMN",
                     "value": "COLUMN",
                     "keyword": "COLUMN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 69
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -202,7 +254,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -220,7 +276,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 78
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -238,7 +298,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -247,7 +309,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 82
                 },
@@ -256,7 +320,9 @@
                     "token": "\n                    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -265,7 +331,9 @@
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 104
                 },
@@ -274,7 +342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -283,7 +353,9 @@
                     "token": "COLUMN",
                     "value": "COLUMN",
                     "keyword": "COLUMN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 111
                 },
@@ -292,7 +364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -301,7 +375,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -310,7 +386,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -319,7 +397,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 120
                 },
@@ -328,7 +408,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -337,7 +419,9 @@
                     "token": "d",
                     "value": "d",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -346,7 +430,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 124
                 },
@@ -355,7 +441,9 @@
                     "token": "\n                    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -364,7 +452,9 @@
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 146
                 },
@@ -373,7 +463,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -382,7 +474,9 @@
                     "token": "COLUMN",
                     "value": "COLUMN",
                     "keyword": "COLUMN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 153
                 },
@@ -391,7 +485,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 159
                 },
@@ -400,7 +496,9 @@
                     "token": "d",
                     "value": "d",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -409,7 +507,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 161
                 },
@@ -418,7 +518,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 162
                 },
@@ -427,7 +529,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 164
                 },
@@ -436,7 +540,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 165
                 },
@@ -445,7 +551,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 166
                 },
@@ -454,7 +564,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 167
                 },
@@ -463,13 +575,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@55"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 51,
-            "idx": 51
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterTableAddSpatialIndex1.out
+++ b/tests/data/parser/parseAlterTableAddSpatialIndex1.out
@@ -7,13 +7,19 @@
         "last": 83,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 24,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "testtable",
                     "value": "testtable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -67,7 +87,9 @@
                     "token": "ADD",
                     "value": "ADD",
                     "keyword": "ADD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -85,7 +109,9 @@
                     "token": "SPATIAL INDEX",
                     "value": "SPATIAL INDEX",
                     "keyword": "SPATIAL INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 26
                 },
@@ -94,7 +120,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 39
                 },
@@ -103,7 +133,11 @@
                     "token": "`mypoint`",
                     "value": "mypoint",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 40
                 },
@@ -112,7 +146,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 49
                 },
@@ -121,7 +157,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 50
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -139,7 +179,9 @@
                     "token": "ALGORITHM",
                     "value": "ALGORITHM",
                     "keyword": "ALGORITHM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 52
                 },
@@ -148,7 +190,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 61
                 },
@@ -157,7 +201,9 @@
                     "token": "INPLACE",
                     "value": "INPLACE",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -166,7 +212,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 69
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -184,7 +234,9 @@
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 71
                 },
@@ -193,7 +245,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 75
                 },
@@ -202,7 +256,9 @@
                     "token": "SHARED",
                     "value": "SHARED",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -211,7 +267,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -220,13 +280,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@30"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 24
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -264,16 +324,16 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@10"
-                            },
-                            {
-                                "@type": "@11"
-                            },
-                            {
-                                "@type": "@12"
-                            },
-                            {
                                 "@type": "@13"
+                            },
+                            {
+                                "@type": "@14"
+                            },
+                            {
+                                "@type": "@16"
+                            },
+                            {
+                                "@type": "@18"
                             }
                         ]
                     },

--- a/tests/data/parser/parseAlterTableCharacterSet1.out
+++ b/tests/data/parser/parseAlterTableCharacterSet1.out
@@ -7,13 +7,19 @@
         "last": 60,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 16,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`d`",
                     "value": "d",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 16
                 },
@@ -76,7 +98,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 31
                 },
@@ -85,7 +111,11 @@
                     "token": "hp8",
                     "value": "hp8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -94,7 +124,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -103,7 +135,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 36
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -121,7 +157,9 @@
                     "token": "hp8_english_ci",
                     "value": "hp8_english_ci",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +168,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -139,7 +181,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -148,13 +192,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 16
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -192,22 +236,22 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@9"
-                            },
-                            {
-                                "@type": "@10"
-                            },
-                            {
-                                "@type": "@11"
-                            },
-                            {
                                 "@type": "@12"
                             },
                             {
-                                "@type": "@13"
+                                "@type": "@14"
                             },
                             {
-                                "@type": "@14"
+                                "@type": "@16"
+                            },
+                            {
+                                "@type": "@17"
+                            },
+                            {
+                                "@type": "@18"
+                            },
+                            {
+                                "@type": "@19"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterTableCharacterSet2.out
+++ b/tests/data/parser/parseAlterTableCharacterSet2.out
@@ -7,13 +7,19 @@
         "last": 29,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`d`",
                     "value": "d",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": "CHARSET",
                     "value": "CHARSET",
                     "keyword": "CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 16
                 },
@@ -76,7 +98,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 23
                 },
@@ -85,7 +111,11 @@
                     "token": "hp8",
                     "value": "hp8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +124,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,13 +135,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -147,13 +181,13 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@9"
+                                "@type": "@12"
                             },
                             {
-                                "@type": "@10"
+                                "@type": "@14"
                             },
                             {
-                                "@type": "@11"
+                                "@type": "@16"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterTableCharacterSet3.out
+++ b/tests/data/parser/parseAlterTableCharacterSet3.out
@@ -7,13 +7,19 @@
         "last": 29,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 12,
+            "idx": 12,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`d`",
                     "value": "d",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": "CHARSET",
                     "value": "CHARSET",
                     "keyword": "CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 16
                 },
@@ -76,7 +98,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 23
                 },
@@ -85,7 +111,11 @@
                     "token": "hp8",
                     "value": "hp8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +124,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +137,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -112,13 +148,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 12,
-            "idx": 12
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -156,10 +192,10 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@9"
+                                "@type": "@12"
                             },
                             {
-                                "@type": "@10"
+                                "@type": "@14"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterTableCharacterSet4.out
+++ b/tests/data/parser/parseAlterTableCharacterSet4.out
@@ -7,13 +7,19 @@
         "last": 61,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 16,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "tbl_name",
                     "value": "tbl_name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "CONVERT",
                     "value": "CONVERT",
                     "keyword": "CONVERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +109,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +131,9 @@
                     "token": "CHARACTER SET",
                     "value": "CHARACTER SET",
                     "keyword": "CHARACTER SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 32
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -121,7 +153,9 @@
                     "token": "charset_name",
                     "value": "charset_name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -130,7 +164,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -139,7 +177,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -148,13 +188,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 16
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterTableCharacterSet5.out
+++ b/tests/data/parser/parseAlterTableCharacterSet5.out
@@ -7,13 +7,19 @@
         "last": 37,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 12,
+            "idx": 12,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`d`",
                     "value": "d",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": "CHARACTER SET",
                     "value": "CHARACTER SET",
                     "keyword": "CHARACTER SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 16
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -85,7 +109,11 @@
                     "token": "utf8",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -94,7 +122,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -103,7 +135,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -112,13 +146,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 12,
-            "idx": 12
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterTableCharacterSet6.out
+++ b/tests/data/parser/parseAlterTableCharacterSet6.out
@@ -7,13 +7,19 @@
         "last": 61,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 16,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`d`",
                     "value": "d",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": "CHARACTER SET",
                     "value": "CHARACTER SET",
                     "keyword": "CHARACTER SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 16
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -85,7 +109,11 @@
                     "token": "utf8",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -103,7 +133,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 35
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -121,7 +155,9 @@
                     "token": "utf8_general_ci",
                     "value": "utf8_general_ci",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -130,7 +166,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -139,7 +179,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -148,13 +190,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 16
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -201,13 +243,13 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
+                                "@type": "@16"
                             },
                             {
-                                "@type": "@13"
+                                "@type": "@17"
                             },
                             {
-                                "@type": "@14"
+                                "@type": "@18"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterTableCharacterSet7.out
+++ b/tests/data/parser/parseAlterTableCharacterSet7.out
@@ -7,13 +7,19 @@
         "last": 75,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 16,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`d`",
                     "value": "d",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": "        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": "CHARACTER SET",
                     "value": "CHARACTER SET",
                     "keyword": "CHARACTER SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 23
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -85,7 +109,11 @@
                     "token": "utf8",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -103,7 +133,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 49
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -121,7 +155,9 @@
                     "token": "utf8_general_ci",
                     "value": "utf8_general_ci",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -130,7 +166,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -139,7 +179,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -148,13 +190,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 16
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -201,13 +243,13 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
+                                "@type": "@16"
                             },
                             {
-                                "@type": "@13"
+                                "@type": "@17"
                             },
                             {
-                                "@type": "@14"
+                                "@type": "@18"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterTableCoalescePartition.out
+++ b/tests/data/parser/parseAlterTableCoalescePartition.out
@@ -7,13 +7,19 @@
         "last": 44,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`MY_TABLE`",
                     "value": "MY_TABLE",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +87,9 @@
                     "token": "COALESCE PARTITION",
                     "value": "COALESCE PARTITION",
                     "keyword": "COALESCE PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 23
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -85,7 +109,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -94,7 +122,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -103,13 +135,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterTableDropAddIndex1.out
+++ b/tests/data/parser/parseAlterTableDropAddIndex1.out
@@ -7,13 +7,19 @@
         "last": 102,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 36,
+            "idx": 36,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "testtable",
                     "value": "testtable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -67,7 +87,9 @@
                     "token": "DROP",
                     "value": "DROP",
                     "keyword": "DROP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,7 +109,9 @@
                     "token": "INDEX",
                     "value": "INDEX",
                     "keyword": "INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 27
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +131,9 @@
                     "token": "my_index2",
                     "value": "my_index2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -112,7 +142,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -130,7 +166,9 @@
                     "token": "ADD",
                     "value": "ADD",
                     "keyword": "ADD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -148,7 +188,9 @@
                     "token": "INDEX",
                     "value": "INDEX",
                     "keyword": "INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 48
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -166,7 +210,9 @@
                     "token": "my_index3",
                     "value": "my_index3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -175,7 +221,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 63
                 },
@@ -184,7 +232,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -193,7 +243,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 66
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -211,7 +265,9 @@
                     "token": "id3",
                     "value": "id3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -220,7 +276,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -238,7 +298,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -247,7 +309,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -256,7 +320,9 @@
                     "token": "BTREE",
                     "value": "BTREE",
                     "keyword": "BTREE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 79
                 },
@@ -265,7 +331,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 84
                 },
@@ -274,7 +342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -283,7 +353,9 @@
                     "token": "ALGORITHM",
                     "value": "ALGORITHM",
                     "keyword": "ALGORITHM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 86
                 },
@@ -292,7 +364,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 95
                 },
@@ -301,7 +375,9 @@
                     "token": "COPY",
                     "value": "COPY",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -310,7 +386,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -319,7 +399,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -328,13 +410,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 36,
-            "idx": 36
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -396,18 +478,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@20"
-                            },
-                            {
-                                "@type": "@21"
-                            },
-                            {
-                                "@type": "@22"
-                            },
-                            {
-                                "@type": "@23"
-                            },
-                            {
                                 "@type": "@24"
                             },
                             {
@@ -424,6 +494,18 @@
                             },
                             {
                                 "@type": "@29"
+                            },
+                            {
+                                "@type": "@30"
+                            },
+                            {
+                                "@type": "@31"
+                            },
+                            {
+                                "@type": "@32"
+                            },
+                            {
+                                "@type": "@33"
                             }
                         ]
                     },

--- a/tests/data/parser/parseAlterTableDropColumn1.out
+++ b/tests/data/parser/parseAlterTableDropColumn1.out
@@ -7,13 +7,19 @@
         "last": 72,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 23,
+            "idx": 23,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`testtable`",
                     "value": "testtable",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +87,9 @@
                     "token": "DROP",
                     "value": "DROP",
                     "keyword": "DROP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +109,9 @@
                     "token": "COLUMN",
                     "value": "COLUMN",
                     "keyword": "COLUMN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -103,7 +131,9 @@
                     "token": "`id2`",
                     "value": "id2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 36
                 },
@@ -112,7 +142,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -130,7 +166,9 @@
                     "token": "ALGORITHM",
                     "value": "ALGORITHM",
                     "keyword": "ALGORITHM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 43
                 },
@@ -139,7 +177,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 52
                 },
@@ -148,7 +188,11 @@
                     "token": "INPLACE",
                     "value": "INPLACE",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 60
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -175,7 +223,9 @@
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 62
                 },
@@ -184,7 +234,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 66
                 },
@@ -193,7 +245,9 @@
                     "token": "NONE",
                     "value": "NONE",
                     "keyword": "NONE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 67
                 },
@@ -202,7 +256,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -211,13 +269,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 23,
-            "idx": 23
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterTableModifyColumn.out
+++ b/tests/data/parser/parseAlterTableModifyColumn.out
@@ -7,13 +7,19 @@
         "last": 85,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 30,
+            "idx": 30,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "testtable",
                     "value": "testtable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -67,7 +87,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 22
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +109,9 @@
                     "token": "COLUMN",
                     "value": "COLUMN",
                     "keyword": "COLUMN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -103,7 +131,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -121,7 +153,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 39
                 },
@@ -130,7 +164,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -139,7 +177,11 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -148,7 +190,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 45
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -166,7 +212,9 @@
                     "token": "FIRST",
                     "value": "FIRST",
                     "keyword": "FIRST",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 47
                 },
@@ -175,7 +223,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 52
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -193,7 +245,9 @@
                     "token": "ALGORITHM",
                     "value": "ALGORITHM",
                     "keyword": "ALGORITHM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 54
                 },
@@ -202,7 +256,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 2,
                     "position": 63
                 },
@@ -211,7 +267,9 @@
                     "token": "INPLACE",
                     "value": "INPLACE",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -220,7 +278,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -238,7 +300,9 @@
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -247,7 +311,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 2,
                     "position": 77
                 },
@@ -256,7 +322,9 @@
                     "token": "SHARED",
                     "value": "SHARED",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -265,7 +333,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -274,13 +346,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@36"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 30,
-            "idx": 30
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -328,22 +400,22 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@14"
-                            },
-                            {
-                                "@type": "@15"
-                            },
-                            {
-                                "@type": "@16"
-                            },
-                            {
                                 "@type": "@17"
                             },
                             {
                                 "@type": "@18"
                             },
                             {
-                                "@type": "@19"
+                                "@type": "@20"
+                            },
+                            {
+                                "@type": "@22"
+                            },
+                            {
+                                "@type": "@23"
+                            },
+                            {
+                                "@type": "@24"
                             }
                         ]
                     },

--- a/tests/data/parser/parseAlterTableModifyColumnEnum1.out
+++ b/tests/data/parser/parseAlterTableModifyColumnEnum1.out
@@ -7,13 +7,19 @@
         "last": 109,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- ENUM with a string that is a database option.",
                     "value": "-- ENUM with a string that is a database option.",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -31,7 +41,11 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 49
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -49,7 +65,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 55
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -67,7 +87,11 @@
                     "token": "`test_table`",
                     "value": "test_table",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 61
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -85,7 +111,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 74
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -103,7 +133,9 @@
                     "token": "`COL`",
                     "value": "COL",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 81
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -121,7 +155,9 @@
                     "token": "ENUM",
                     "value": "ENUM",
                     "keyword": "ENUM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 87
                 },
@@ -130,7 +166,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 91
                 },
@@ -139,7 +179,11 @@
                     "token": "\"COLLATE\"",
                     "value": "COLLATE",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 92
                 },
@@ -148,7 +192,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 16,
                     "position": 101
                 },
@@ -157,7 +203,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -166,7 +214,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 103
                 },
@@ -175,7 +225,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -184,7 +238,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -193,13 +249,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -246,22 +302,22 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@14"
-                            },
-                            {
-                                "@type": "@15"
-                            },
-                            {
-                                "@type": "@16"
-                            },
-                            {
-                                "@type": "@17"
-                            },
-                            {
                                 "@type": "@18"
                             },
                             {
                                 "@type": "@19"
+                            },
+                            {
+                                "@type": "@21"
+                            },
+                            {
+                                "@type": "@23"
+                            },
+                            {
+                                "@type": "@24"
+                            },
+                            {
+                                "@type": "@25"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterTableModifyColumnEnum2.out
+++ b/tests/data/parser/parseAlterTableModifyColumnEnum2.out
@@ -7,13 +7,19 @@
         "last": 103,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- ENUM with a string that is a table option.",
                     "value": "-- ENUM with a string that is a table option.",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -31,7 +41,11 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 46
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -49,7 +65,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 52
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -67,7 +87,11 @@
                     "token": "`test_table`",
                     "value": "test_table",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 58
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -85,7 +111,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 71
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -103,7 +133,9 @@
                     "token": "`COL`",
                     "value": "COL",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 78
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -121,7 +155,9 @@
                     "token": "ENUM",
                     "value": "ENUM",
                     "keyword": "ENUM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 84
                 },
@@ -130,7 +166,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 88
                 },
@@ -139,7 +179,11 @@
                     "token": "\"LOCK\"",
                     "value": "LOCK",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 89
                 },
@@ -148,7 +192,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 16,
                     "position": 95
                 },
@@ -157,7 +203,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -166,7 +214,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 97
                 },
@@ -175,7 +225,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -184,7 +238,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -193,13 +249,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -246,22 +302,22 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@14"
-                            },
-                            {
-                                "@type": "@15"
-                            },
-                            {
-                                "@type": "@16"
-                            },
-                            {
-                                "@type": "@17"
-                            },
-                            {
                                 "@type": "@18"
                             },
                             {
                                 "@type": "@19"
+                            },
+                            {
+                                "@type": "@21"
+                            },
+                            {
+                                "@type": "@23"
+                            },
+                            {
+                                "@type": "@24"
+                            },
+                            {
+                                "@type": "@25"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterTableModifyColumnEnum3.out
+++ b/tests/data/parser/parseAlterTableModifyColumnEnum3.out
@@ -7,13 +7,19 @@
         "last": 102,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- ENUM with a string that is a statement.",
                     "value": "-- ENUM with a string that is a statement.",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -31,7 +41,11 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 43
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -49,7 +65,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 49
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -67,7 +87,11 @@
                     "token": "`test_table`",
                     "value": "test_table",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 55
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -85,7 +111,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 68
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -103,7 +133,9 @@
                     "token": "`COL`",
                     "value": "COL",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 75
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -121,7 +155,9 @@
                     "token": "ENUM",
                     "value": "ENUM",
                     "keyword": "ENUM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 9,
                     "position": 81
                 },
@@ -130,7 +166,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 85
                 },
@@ -139,7 +179,11 @@
                     "token": "\"INSERT\"",
                     "value": "INSERT",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 86
                 },
@@ -148,7 +192,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 16,
                     "position": 94
                 },
@@ -157,7 +203,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -166,7 +214,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -175,7 +225,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -184,7 +238,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -193,13 +249,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -246,22 +302,22 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@14"
-                            },
-                            {
-                                "@type": "@15"
-                            },
-                            {
-                                "@type": "@16"
-                            },
-                            {
-                                "@type": "@17"
-                            },
-                            {
                                 "@type": "@18"
                             },
                             {
                                 "@type": "@19"
+                            },
+                            {
+                                "@type": "@21"
+                            },
+                            {
+                                "@type": "@23"
+                            },
+                            {
+                                "@type": "@24"
+                            },
+                            {
+                                "@type": "@25"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterTablePartitionByRange1.out
+++ b/tests/data/parser/parseAlterTablePartitionByRange1.out
@@ -7,13 +7,19 @@
         "last": 600,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 188,
+            "idx": 188,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "trips",
                     "value": "trips",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "PARTITION BY",
                     "value": "PARTITION BY",
                     "keyword": "PARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -85,7 +109,9 @@
                     "token": "RANGE",
                     "value": "RANGE",
                     "keyword": "RANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 31
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -103,7 +131,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 37
                 },
@@ -112,7 +144,9 @@
                     "token": "MONTH",
                     "value": "MONTH",
                     "keyword": "MONTH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 38
                 },
@@ -121,7 +155,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -130,7 +166,9 @@
                     "token": "trip_date",
                     "value": "trip_date",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -139,7 +177,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 53
                 },
@@ -148,7 +188,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 54
                 },
@@ -157,7 +199,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -166,7 +210,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 56
                 },
@@ -175,7 +221,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -184,7 +232,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 62
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -202,7 +254,9 @@
                     "token": "p01",
                     "value": "p01",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -220,7 +276,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 76
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -238,7 +298,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 83
                 },
@@ -247,7 +309,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -256,7 +320,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 93
                 },
@@ -265,7 +331,11 @@
                     "token": "02",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -274,7 +344,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 96
                 },
@@ -283,7 +355,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 97
                 },
@@ -292,7 +366,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -301,7 +377,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 103
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -319,7 +399,9 @@
                     "token": "p02",
                     "value": "p02",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -337,7 +421,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 117
                 },
@@ -346,7 +432,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -355,7 +443,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 124
                 },
@@ -364,7 +454,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -373,7 +465,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 134
                 },
@@ -382,7 +476,9 @@
                     "token": "03",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -391,7 +487,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 137
                 },
@@ -400,7 +498,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 138
                 },
@@ -409,7 +509,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -418,7 +520,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 144
                 },
@@ -427,7 +531,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 153
                 },
@@ -436,7 +542,9 @@
                     "token": "p03",
                     "value": "p03",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -445,7 +553,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -454,7 +564,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 158
                 },
@@ -463,7 +575,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 164
                 },
@@ -472,7 +586,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 165
                 },
@@ -481,7 +597,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 174
                 },
@@ -490,7 +608,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 175
                 },
@@ -499,7 +619,9 @@
                     "token": "04",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -508,7 +630,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 178
                 },
@@ -517,7 +641,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 179
                 },
@@ -526,7 +652,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 180
                 },
@@ -535,7 +663,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 185
                 },
@@ -544,7 +674,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 194
                 },
@@ -553,7 +685,9 @@
                     "token": "p04",
                     "value": "p04",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 195
                 },
@@ -562,7 +696,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 198
                 },
@@ -571,7 +707,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 199
                 },
@@ -580,7 +718,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 205
                 },
@@ -589,7 +729,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 206
                 },
@@ -598,7 +740,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 215
                 },
@@ -607,7 +751,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 216
                 },
@@ -616,7 +762,9 @@
                     "token": "05",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 217
                 },
@@ -625,7 +773,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 219
                 },
@@ -634,7 +784,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 220
                 },
@@ -643,7 +795,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 221
                 },
@@ -652,7 +806,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 226
                 },
@@ -661,7 +817,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 235
                 },
@@ -670,7 +828,9 @@
                     "token": "p05",
                     "value": "p05",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 236
                 },
@@ -679,7 +839,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 239
                 },
@@ -688,7 +850,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 240
                 },
@@ -697,7 +861,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 246
                 },
@@ -706,7 +872,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 247
                 },
@@ -715,7 +883,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 256
                 },
@@ -724,7 +894,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 257
                 },
@@ -733,7 +905,9 @@
                     "token": "06",
                     "value": 6,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 258
                 },
@@ -742,7 +916,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 260
                 },
@@ -751,7 +927,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 261
                 },
@@ -760,7 +938,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 262
                 },
@@ -769,7 +949,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 267
                 },
@@ -778,7 +960,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 276
                 },
@@ -787,7 +971,9 @@
                     "token": "p06",
                     "value": "p06",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 277
                 },
@@ -796,7 +982,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 280
                 },
@@ -805,7 +993,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 281
                 },
@@ -814,7 +1004,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 287
                 },
@@ -823,7 +1015,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 288
                 },
@@ -832,7 +1026,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 297
                 },
@@ -841,7 +1037,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 298
                 },
@@ -850,7 +1048,9 @@
                     "token": "07",
                     "value": 7,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 299
                 },
@@ -859,7 +1059,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 301
                 },
@@ -868,7 +1070,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 302
                 },
@@ -877,7 +1081,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 303
                 },
@@ -886,7 +1092,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 308
                 },
@@ -895,7 +1103,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 317
                 },
@@ -904,7 +1114,9 @@
                     "token": "p07",
                     "value": "p07",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 318
                 },
@@ -913,7 +1125,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 321
                 },
@@ -922,7 +1136,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 322
                 },
@@ -931,7 +1147,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 328
                 },
@@ -940,7 +1158,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 329
                 },
@@ -949,7 +1169,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 338
                 },
@@ -958,7 +1180,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 339
                 },
@@ -967,7 +1191,9 @@
                     "token": "08",
                     "value": 8,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 340
                 },
@@ -976,7 +1202,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 342
                 },
@@ -985,7 +1213,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 343
                 },
@@ -994,7 +1224,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 344
                 },
@@ -1003,7 +1235,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 349
                 },
@@ -1012,7 +1246,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 358
                 },
@@ -1021,7 +1257,9 @@
                     "token": "p08",
                     "value": "p08",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 359
                 },
@@ -1030,7 +1268,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 362
                 },
@@ -1039,7 +1279,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 363
                 },
@@ -1048,7 +1290,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 369
                 },
@@ -1057,7 +1301,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 370
                 },
@@ -1066,7 +1312,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 379
                 },
@@ -1075,7 +1323,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 380
                 },
@@ -1084,7 +1334,9 @@
                     "token": "09",
                     "value": 9,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 381
                 },
@@ -1093,7 +1345,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 383
                 },
@@ -1102,7 +1356,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 384
                 },
@@ -1111,7 +1367,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 385
                 },
@@ -1120,7 +1378,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 390
                 },
@@ -1129,7 +1389,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 399
                 },
@@ -1138,7 +1400,9 @@
                     "token": "p09",
                     "value": "p09",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 400
                 },
@@ -1147,7 +1411,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 403
                 },
@@ -1156,7 +1422,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 404
                 },
@@ -1165,7 +1433,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 410
                 },
@@ -1174,7 +1444,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 411
                 },
@@ -1183,7 +1455,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 420
                 },
@@ -1192,7 +1466,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 421
                 },
@@ -1201,7 +1477,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 422
                 },
@@ -1210,7 +1488,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 424
                 },
@@ -1219,7 +1499,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 425
                 },
@@ -1228,7 +1510,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 426
                 },
@@ -1237,7 +1521,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 431
                 },
@@ -1246,7 +1532,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 440
                 },
@@ -1255,7 +1543,9 @@
                     "token": "p10",
                     "value": "p10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 441
                 },
@@ -1264,7 +1554,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 444
                 },
@@ -1273,7 +1565,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 445
                 },
@@ -1282,7 +1576,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 451
                 },
@@ -1291,7 +1587,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 452
                 },
@@ -1300,7 +1598,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 461
                 },
@@ -1309,7 +1609,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 462
                 },
@@ -1318,7 +1620,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 463
                 },
@@ -1327,7 +1631,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 465
                 },
@@ -1336,7 +1642,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 466
                 },
@@ -1345,7 +1653,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 467
                 },
@@ -1354,7 +1664,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 472
                 },
@@ -1363,7 +1675,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 481
                 },
@@ -1372,7 +1686,9 @@
                     "token": "p11",
                     "value": "p11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 482
                 },
@@ -1381,7 +1697,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 485
                 },
@@ -1390,7 +1708,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 486
                 },
@@ -1399,7 +1719,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 492
                 },
@@ -1408,7 +1730,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 493
                 },
@@ -1417,7 +1741,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 502
                 },
@@ -1426,7 +1752,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 503
                 },
@@ -1435,7 +1763,9 @@
                     "token": "12",
                     "value": 12,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 504
                 },
@@ -1444,7 +1774,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 506
                 },
@@ -1453,7 +1785,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 507
                 },
@@ -1462,7 +1796,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 508
                 },
@@ -1471,7 +1807,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 513
                 },
@@ -1480,7 +1818,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 522
                 },
@@ -1489,7 +1829,9 @@
                     "token": "p12",
                     "value": "p12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 523
                 },
@@ -1498,7 +1840,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 526
                 },
@@ -1507,7 +1851,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 527
                 },
@@ -1516,7 +1862,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 533
                 },
@@ -1525,7 +1873,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 534
                 },
@@ -1534,7 +1884,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 543
                 },
@@ -1543,7 +1895,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 544
                 },
@@ -1552,7 +1906,9 @@
                     "token": "13",
                     "value": 13,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 545
                 },
@@ -1561,7 +1917,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 547
                 },
@@ -1570,7 +1928,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 548
                 },
@@ -1579,7 +1939,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 549
                 },
@@ -1588,7 +1950,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 554
                 },
@@ -1597,7 +1961,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 563
                 },
@@ -1606,7 +1972,9 @@
                     "token": "pmaxval",
                     "value": "pmaxval",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 564
                 },
@@ -1615,7 +1983,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 571
                 },
@@ -1624,7 +1994,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 572
                 },
@@ -1633,7 +2005,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 578
                 },
@@ -1642,7 +2016,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 579
                 },
@@ -1651,7 +2027,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 588
                 },
@@ -1660,7 +2038,9 @@
                     "token": "MAXVALUE",
                     "value": "MAXVALUE",
                     "keyword": "MAXVALUE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 589
                 },
@@ -1669,7 +2049,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 597
                 },
@@ -1678,7 +2060,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 598
                 },
@@ -1687,7 +2071,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 599
                 },
@@ -1696,13 +2084,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@194"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 188,
-            "idx": 188
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterTablePartitionByRange2.out
+++ b/tests/data/parser/parseAlterTablePartitionByRange2.out
@@ -7,13 +7,19 @@
         "last": 144,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 47,
+            "idx": 47,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "d",
                     "value": "d",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,9 @@
                     "token": "PARTITION BY",
                     "value": "PARTITION BY",
                     "keyword": "PARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 14
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,7 +109,9 @@
                     "token": "RANGE",
                     "value": "RANGE",
                     "keyword": "RANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +131,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": "MONTH",
                     "value": "MONTH",
                     "keyword": "MONTH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 34
                 },
@@ -121,7 +155,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 39
                 },
@@ -130,7 +166,9 @@
                     "token": "departure_date",
                     "value": "departure_date",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -139,7 +177,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 54
                 },
@@ -148,7 +188,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 55
                 },
@@ -157,7 +199,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -166,7 +210,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 57
                 },
@@ -175,7 +221,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -184,7 +232,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 59
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -202,7 +254,9 @@
                     "token": "p01",
                     "value": "p01",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -220,7 +276,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 73
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -238,7 +298,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 80
                 },
@@ -247,7 +309,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -256,7 +320,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 90
                 },
@@ -265,7 +331,11 @@
                     "token": "02",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -274,7 +344,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 93
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -292,7 +366,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 95
                 },
@@ -301,7 +377,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -310,7 +388,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 97
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -328,7 +410,9 @@
                     "token": "pmaxval",
                     "value": "pmaxval",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -346,7 +432,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 115
                 },
@@ -355,7 +443,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -364,7 +454,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 122
                 },
@@ -373,7 +465,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -382,7 +476,9 @@
                     "token": "MAXVALUE",
                     "value": "MAXVALUE",
                     "keyword": "MAXVALUE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 132
                 },
@@ -391,7 +487,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -400,7 +498,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 141
                 },
@@ -409,7 +509,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -418,7 +522,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -427,13 +533,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@52"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 47,
-            "idx": 47
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterTableRenameIndex1.out
+++ b/tests/data/parser/parseAlterTableRenameIndex1.out
@@ -7,13 +7,19 @@
         "last": 120,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 16,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`transactions`",
                     "value": "transactions",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -67,7 +87,9 @@
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -85,7 +109,9 @@
                     "token": "INDEX",
                     "value": "INDEX",
                     "keyword": "INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 34
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -103,7 +131,9 @@
                     "token": "`fk_transactions_catalog_entries1_idx`",
                     "value": "fk_transactions_catalog_entries1_idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 40
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -121,7 +153,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 79
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -139,7 +175,9 @@
                     "token": "`fk_transactions_catalog_entries2_idx`",
                     "value": "fk_transactions_catalog_entries2_idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 82
                 },
@@ -148,13 +186,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 16
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterTableRenameIndex2.out
+++ b/tests/data/parser/parseAlterTableRenameIndex2.out
@@ -7,13 +7,19 @@
         "last": 87,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 27,
+            "idx": 27,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "testtable",
                     "value": "testtable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -67,7 +87,9 @@
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +109,9 @@
                     "token": "INDEX",
                     "value": "INDEX",
                     "keyword": "INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 29
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -103,7 +131,9 @@
                     "token": "my_index",
                     "value": "my_index",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -121,7 +153,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -139,7 +175,9 @@
                     "token": "my_index2",
                     "value": "my_index2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -148,7 +186,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 56
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -166,7 +210,9 @@
                     "token": "ALGORITHM",
                     "value": "ALGORITHM",
                     "keyword": "ALGORITHM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 58
                 },
@@ -175,7 +221,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 67
                 },
@@ -184,7 +232,9 @@
                     "token": "INPLACE",
                     "value": "INPLACE",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -193,7 +243,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 75
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -211,7 +265,9 @@
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 77
                 },
@@ -220,7 +276,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 81
                 },
@@ -229,7 +287,9 @@
                     "token": "NONE",
                     "value": "NONE",
                     "keyword": "NONE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 82
                 },
@@ -238,7 +298,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -247,13 +311,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@32"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 27,
-            "idx": 27
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterTableSetAutoIncrementError.out
+++ b/tests/data/parser/parseAlterTableSetAutoIncrementError.out
@@ -7,13 +7,19 @@
         "last": 30,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 9,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -67,7 +87,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -76,7 +98,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -85,13 +109,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 9,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -155,7 +181,7 @@
             [
                 "Value/Expression for the option AUTO_INCREMENT was expected.",
                 {
-                    "@type": "@9"
+                    "@type": "@12"
                 },
                 0
             ]

--- a/tests/data/parser/parseAlterUser.out
+++ b/tests/data/parser/parseAlterUser.out
@@ -7,13 +7,19 @@
         "last": 80,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'jeffrey'@'localhost'",
                     "value": "jeffrey@localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +87,9 @@
                     "token": "IDENTIFIED",
                     "value": "IDENTIFIED",
                     "keyword": "IDENTIFIED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -85,7 +109,9 @@
                     "token": "BY",
                     "value": "BY",
                     "keyword": "BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 46
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -103,7 +131,11 @@
                     "token": "'new_password'",
                     "value": "new_password",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 49
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -121,7 +155,9 @@
                     "token": "PASSWORD",
                     "value": "PASSWORD",
                     "keyword": "PASSWORD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 64
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -139,7 +177,9 @@
                     "token": "EXPIRE",
                     "value": "EXPIRE",
                     "keyword": "EXPIRE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 73
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -157,13 +201,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterUser1.out
+++ b/tests/data/parser/parseAlterUser1.out
@@ -7,13 +7,19 @@
         "last": 31,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "trevor",
                     "value": "trevor",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "REQUIRE",
                     "value": "REQUIRE",
                     "keyword": "REQUIRE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -85,7 +109,9 @@
                     "token": "NONE",
                     "value": "NONE",
                     "keyword": "NONE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 26
                 },
@@ -94,7 +120,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,13 +133,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterUser10.out
+++ b/tests/data/parser/parseAlterUser10.out
@@ -7,13 +7,19 @@
         "last": 120,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 19,
+            "idx": 19,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'bob'@'localhost'",
                     "value": "bob@localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -67,7 +87,9 @@
                     "token": "IDENTIFIED WITH",
                     "value": "IDENTIFIED WITH",
                     "keyword": "IDENTIFIED WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 29
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -85,7 +109,11 @@
                     "token": "mysql_native_password",
                     "value": "mysql_native_password",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -103,7 +133,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 67
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -121,7 +155,9 @@
                     "token": "PASSWORD",
                     "value": "PASSWORD",
                     "keyword": "PASSWORD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 73
                 },
@@ -130,7 +166,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 81
                 },
@@ -139,7 +179,11 @@
                     "token": "'vp8LAf4#wu2V&Wi*iJWC#3KPotsHzx3u'",
                     "value": "vp8LAf4#wu2V&Wi*iJWC#3KPotsHzx3u",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 82
                 },
@@ -148,7 +192,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 16,
                     "position": 116
                 },
@@ -157,7 +203,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -166,7 +216,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -175,13 +227,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 19,
-            "idx": 19
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -224,22 +276,22 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
-                            },
-                            {
-                                "@type": "@14"
-                            },
-                            {
-                                "@type": "@15"
-                            },
-                            {
                                 "@type": "@16"
                             },
                             {
                                 "@type": "@17"
+                            },
+                            {
+                                "@type": "@18"
+                            },
+                            {
+                                "@type": "@19"
+                            },
+                            {
+                                "@type": "@21"
+                            },
+                            {
+                                "@type": "@23"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterUser2.out
+++ b/tests/data/parser/parseAlterUser2.out
@@ -7,13 +7,19 @@
         "last": 43,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'user'@'localhost'",
                     "value": "user@localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -67,7 +87,9 @@
                     "token": "ACCOUNT",
                     "value": "ACCOUNT",
                     "keyword": "ACCOUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 30
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -85,7 +109,9 @@
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 38
                 },
@@ -94,7 +120,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -103,13 +133,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterUser3.out
+++ b/tests/data/parser/parseAlterUser3.out
@@ -7,13 +7,19 @@
         "last": 68,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'testosama'",
                     "value": "testosama",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +87,9 @@
                     "token": "REQUIRE",
                     "value": "REQUIRE",
                     "keyword": "REQUIRE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 23
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -85,7 +109,9 @@
                     "token": "SSL",
                     "value": "SSL",
                     "keyword": "SSL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 31
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -103,7 +131,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 35
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -121,7 +153,9 @@
                     "token": "MAX_CONNECTIONS_PER_HOUR",
                     "value": "MAX_CONNECTIONS_PER_HOUR",
                     "keyword": "MAX_CONNECTIONS_PER_HOUR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 40
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -139,7 +175,11 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -157,13 +201,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -212,7 +256,7 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@16"
+                                "@type": "@19"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterUser4.out
+++ b/tests/data/parser/parseAlterUser4.out
@@ -7,13 +7,19 @@
         "last": 75,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'user'",
                     "value": "user",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "MAX_QUERIES_PER_HOUR",
                     "value": "MAX_QUERIES_PER_HOUR",
                     "keyword": "MAX_QUERIES_PER_HOUR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 25
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -103,7 +131,11 @@
                     "token": "500",
                     "value": 500,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -121,7 +155,9 @@
                     "token": "MAX_UPDATES_PER_HOUR",
                     "value": "MAX_UPDATES_PER_HOUR",
                     "keyword": "MAX_UPDATES_PER_HOUR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -139,7 +177,9 @@
                     "token": "100",
                     "value": 100,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -157,13 +201,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -206,19 +250,19 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
-                            },
-                            {
-                                "@type": "@14"
-                            },
-                            {
                                 "@type": "@15"
                             },
                             {
-                                "@type": "@16"
+                                "@type": "@17"
+                            },
+                            {
+                                "@type": "@18"
+                            },
+                            {
+                                "@type": "@19"
+                            },
+                            {
+                                "@type": "@20"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterUser5.out
+++ b/tests/data/parser/parseAlterUser5.out
@@ -7,13 +7,19 @@
         "last": 39,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 12,
+            "idx": 12,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'user'",
                     "value": "user",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "PASSWORD",
                     "value": "PASSWORD",
                     "keyword": "PASSWORD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,7 +109,9 @@
                     "token": "EXPIRE",
                     "value": "EXPIRE",
                     "keyword": "EXPIRE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 27
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -103,7 +131,9 @@
                     "token": "NEVER",
                     "value": "NEVER",
                     "keyword": "NEVER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 34
                 },
@@ -112,13 +142,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 12,
-            "idx": 12
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterUser6.out
+++ b/tests/data/parser/parseAlterUser6.out
@@ -7,13 +7,19 @@
         "last": 59,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'user'",
                     "value": "user",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,11 @@
                     "token": "ATTRIBUTE",
                     "value": "ATTRIBUTE",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -85,7 +111,9 @@
                     "token": "'{\"baz\": \"faz\", \"foo\": \"moo\"}'",
                     "value": "{\"baz\": \"faz\", \"foo\": \"moo\"}",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 28
                 },
@@ -94,7 +122,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -103,13 +135,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterUser7.out
+++ b/tests/data/parser/parseAlterUser7.out
@@ -7,13 +7,19 @@
         "last": 51,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'user'",
                     "value": "user",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "PASSWORD",
                     "value": "PASSWORD",
                     "keyword": "PASSWORD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,7 +109,9 @@
                     "token": "EXPIRE",
                     "value": "EXPIRE",
                     "keyword": "EXPIRE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 27
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -103,7 +131,9 @@
                     "token": "INTERVAL",
                     "value": "INTERVAL",
                     "keyword": "INTERVAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 34
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -121,7 +153,11 @@
                     "token": "180",
                     "value": 180,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -139,7 +177,9 @@
                     "token": "DAY",
                     "value": "DAY",
                     "keyword": "DAY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 47
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -157,13 +201,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -206,19 +250,19 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
-                            },
-                            {
-                                "@type": "@14"
-                            },
-                            {
                                 "@type": "@15"
                             },
                             {
                                 "@type": "@16"
+                            },
+                            {
+                                "@type": "@17"
+                            },
+                            {
+                                "@type": "@19"
+                            },
+                            {
+                                "@type": "@20"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterUser8.out
+++ b/tests/data/parser/parseAlterUser8.out
@@ -7,13 +7,19 @@
         "last": 28,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'user'",
                     "value": "user",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -85,7 +109,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 26
                 },
@@ -94,13 +120,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAlterUser9.out
+++ b/tests/data/parser/parseAlterUser9.out
@@ -7,13 +7,19 @@
         "last": 118,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "'bob'@'localhost'",
                     "value": "bob@localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -67,7 +87,9 @@
                     "token": "IDENTIFIED",
                     "value": "IDENTIFIED",
                     "keyword": "IDENTIFIED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 29
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -85,7 +109,11 @@
                     "token": "VIA",
                     "value": "VIA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -103,7 +133,9 @@
                     "token": "mysql_native_password",
                     "value": "mysql_native_password",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -121,7 +155,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 66
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -139,7 +177,9 @@
                     "token": "PASSWORD",
                     "value": "PASSWORD",
                     "keyword": "PASSWORD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 72
                 },
@@ -148,7 +188,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -157,7 +201,11 @@
                     "token": "'vp8LAf4#wu2V&Wi*iJWC#3KPotsHzx3u'",
                     "value": "vp8LAf4#wu2V&Wi*iJWC#3KPotsHzx3u",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 81
                 },
@@ -166,7 +214,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 16,
                     "position": 115
                 },
@@ -175,7 +225,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -184,7 +238,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -193,13 +249,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -246,18 +302,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
-                            },
-                            {
-                                "@type": "@14"
-                            },
-                            {
-                                "@type": "@15"
-                            },
-                            {
                                 "@type": "@16"
                             },
                             {
@@ -268,6 +312,18 @@
                             },
                             {
                                 "@type": "@19"
+                            },
+                            {
+                                "@type": "@20"
+                            },
+                            {
+                                "@type": "@21"
+                            },
+                            {
+                                "@type": "@23"
+                            },
+                            {
+                                "@type": "@25"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAlterWithInvisible.out
+++ b/tests/data/parser/parseAlterWithInvisible.out
@@ -7,13 +7,19 @@
         "last": 85,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 36,
+            "idx": 36,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "t",
                     "value": "t",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": "x",
                     "value": "x",
                     "keyword": "X",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 21
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -103,7 +131,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 23
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -121,7 +153,9 @@
                     "token": "INVISIBLE",
                     "value": "INVISIBLE",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -130,7 +164,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 36
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -148,7 +188,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 38
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,9 @@
                     "token": "y",
                     "value": "y",
                     "keyword": "Y",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 45
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -184,7 +232,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 47
                 },
@@ -193,7 +243,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 50
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -211,7 +265,9 @@
                     "token": "MODIFY",
                     "value": "MODIFY",
                     "keyword": "MODIFY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 52
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -229,7 +287,9 @@
                     "token": "z",
                     "value": "z",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -247,7 +309,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 61
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -265,7 +331,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 65
                 },
@@ -274,7 +342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -283,7 +353,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 74
                 },
@@ -292,7 +364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -301,7 +375,11 @@
                     "token": "4",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -310,7 +388,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -319,7 +401,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -328,13 +412,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@41"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 36,
-            "idx": 36
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -381,13 +465,13 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@12"
+                                "@type": "@15"
                             },
                             {
-                                "@type": "@13"
+                                "@type": "@16"
                             },
                             {
-                                "@type": "@14"
+                                "@type": "@17"
                             }
                         ]
                     },
@@ -412,7 +496,7 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@21"
+                                "@type": "@25"
                             }
                         ]
                     },
@@ -437,18 +521,6 @@
                         "partitions": null,
                         "unknown": [
                             {
-                                "@type": "@28"
-                            },
-                            {
-                                "@type": "@29"
-                            },
-                            {
-                                "@type": "@30"
-                            },
-                            {
-                                "@type": "@31"
-                            },
-                            {
                                 "@type": "@32"
                             },
                             {
@@ -456,6 +528,18 @@
                             },
                             {
                                 "@type": "@34"
+                            },
+                            {
+                                "@type": "@35"
+                            },
+                            {
+                                "@type": "@36"
+                            },
+                            {
+                                "@type": "@37"
+                            },
+                            {
+                                "@type": "@38"
                             }
                         ]
                     }

--- a/tests/data/parser/parseAnalyzeErr1.out
+++ b/tests/data/parser/parseAnalyzeErr1.out
@@ -7,13 +7,19 @@
         "last": 26,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 4,
+            "idx": 4,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ANALYZE",
                     "value": "ANALYZE",
                     "keyword": "ANALYZE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "NO_WRITE_TO_BINLOG",
                     "value": "NO_WRITE_TO_BINLOG",
                     "keyword": "NO_WRITE_TO_BINLOG",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,13 +52,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 4,
-            "idx": 4
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -85,7 +99,7 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@4"
+                    "@type": "@6"
                 },
                 0
             ]

--- a/tests/data/parser/parseAnalyzeErr2.out
+++ b/tests/data/parser/parseAnalyzeErr2.out
@@ -7,13 +7,19 @@
         "last": 7,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 2,
+            "idx": 2,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ANALYZE",
                     "value": "ANALYZE",
                     "keyword": "ANALYZE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,13 +28,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 2,
-            "idx": 2
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAnalyzeTable.out
+++ b/tests/data/parser/parseAnalyzeTable.out
@@ -7,13 +7,19 @@
         "last": 17,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 6,
+            "idx": 6,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ANALYZE",
                     "value": "ANALYZE",
                     "keyword": "ANALYZE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,11 @@
                     "token": "tbl",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,13 +76,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 6,
-            "idx": 6
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseAnalyzeTable1.out
+++ b/tests/data/parser/parseAnalyzeTable1.out
@@ -7,13 +7,19 @@
         "last": 36,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 8,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ANALYZE",
                     "value": "ANALYZE",
                     "keyword": "ANALYZE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "NO_WRITE_TO_BINLOG",
                     "value": "NO_WRITE_TO_BINLOG",
                     "keyword": "NO_WRITE_TO_BINLOG",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -49,7 +63,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +85,11 @@
                     "token": "tbl",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -76,13 +98,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 8
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseArrayErr1.out
+++ b/tests/data/parser/parseArrayErr1.out
@@ -7,13 +7,19 @@
         "last": 38,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -85,7 +111,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +133,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -112,7 +144,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -130,7 +166,9 @@
                     "token": "baz",
                     "value": "baz",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -139,7 +177,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 36
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -157,13 +201,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -237,28 +281,28 @@
             [
                 "An opening bracket was expected.",
                 {
-                    "@type": "@12"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
-                    "@type": "@13"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
-                    "@type": "@15"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
                     "@type": "@16"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@17"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@19"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@20"
                 },
                 0
             ]

--- a/tests/data/parser/parseArrayErr3.out
+++ b/tests/data/parser/parseArrayErr3.out
@@ -7,13 +7,19 @@
         "last": 38,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -85,7 +111,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +133,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 28
                 },
@@ -112,7 +144,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -121,7 +155,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -139,7 +177,9 @@
                     "token": "baz",
                     "value": "baz",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -157,13 +201,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -243,7 +287,7 @@
             [
                 "A closing bracket was expected.",
                 {
-                    "@type": "@17"
+                    "@type": "@21"
                 },
                 0
             ]

--- a/tests/data/parser/parseCall.out
+++ b/tests/data/parser/parseCall.out
@@ -7,13 +7,19 @@
         "last": 11,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 7,
+            "idx": 7,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CALL",
                     "value": "CALL",
                     "keyword": "CALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -40,7 +54,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 8
                 },
@@ -49,7 +67,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 9
                 },
@@ -58,7 +78,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -67,13 +91,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 7,
-            "idx": 7
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCall2.out
+++ b/tests/data/parser/parseCall2.out
@@ -7,13 +7,19 @@
         "last": 21,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CALL",
                     "value": "CALL",
                     "keyword": "CALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -40,7 +54,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 8
                 },
@@ -49,7 +67,11 @@
                     "token": "@bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 9
                 },
@@ -58,7 +80,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 13
                 },
@@ -67,7 +91,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +102,9 @@
                     "token": "@baz",
                     "value": "baz",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -85,7 +113,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -94,7 +124,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -103,13 +137,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCall3.out
+++ b/tests/data/parser/parseCall3.out
@@ -7,13 +7,19 @@
         "last": 9,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 5,
+            "idx": 5,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CALL",
                     "value": "CALL",
                     "keyword": "CALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -40,7 +54,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,13 +67,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 5,
-            "idx": 5
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCall4.out
+++ b/tests/data/parser/parseCall4.out
@@ -7,13 +7,19 @@
         "last": 15,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "call",
                     "value": "CALL",
                     "keyword": "CALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "e",
                     "value": "e",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -40,7 +54,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 6
                 },
@@ -49,7 +67,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -58,7 +78,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -67,7 +91,9 @@
                     "token": "call",
                     "value": "CALL",
                     "keyword": "CALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -76,7 +102,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -85,7 +113,9 @@
                     "token": "f",
                     "value": "f",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -94,13 +124,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCall5.out
+++ b/tests/data/parser/parseCall5.out
@@ -7,13 +7,19 @@
         "last": 13,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 8,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "call",
                     "value": "CALL",
                     "keyword": "CALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "e",
                     "value": "e",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -40,7 +54,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -49,7 +67,9 @@
                     "token": "call",
                     "value": "CALL",
                     "keyword": "CALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -67,7 +89,9 @@
                     "token": "f",
                     "value": "f",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -76,13 +100,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 8
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateDatabase.out
+++ b/tests/data/parser/parseCreateDatabase.out
@@ -7,13 +7,19 @@
         "last": 57,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 13,
+            "idx": 13,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "DATABASE",
                     "value": "DATABASE",
                     "keyword": "DATABASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -49,7 +63,9 @@
                     "token": "IF NOT EXISTS",
                     "value": "IF NOT EXISTS",
                     "keyword": "IF NOT EXISTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 16
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -67,7 +85,11 @@
                     "token": "pma",
                     "value": "pma",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -85,7 +109,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 34
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -103,7 +131,11 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -112,7 +144,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -121,13 +157,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 13,
-            "idx": 13
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateDatabaseErr.out
+++ b/tests/data/parser/parseCreateDatabaseErr.out
@@ -7,13 +7,19 @@
         "last": 72,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "DATABASE",
                     "value": "DATABASE",
                     "keyword": "DATABASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -49,7 +63,9 @@
                     "token": "IF NOT EXISTS",
                     "value": "IF NOT EXISTS",
                     "keyword": "IF NOT EXISTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 16
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -67,7 +85,11 @@
                     "token": "pma",
                     "value": "pma",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -85,7 +109,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 34
                 },
@@ -94,7 +120,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 40
                 },
@@ -103,7 +133,11 @@
                     "token": "'InnoDB'",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 41
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -121,7 +157,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 50
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -139,7 +179,9 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 66
                 },
@@ -148,13 +190,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -217,7 +261,7 @@
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@10"
+                    "@type": "@13"
                 },
                 0
             ]

--- a/tests/data/parser/parseCreateFunction.out
+++ b/tests/data/parser/parseCreateFunction.out
@@ -7,13 +7,19 @@
         "last": 193,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 60,
+            "idx": 60,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,11 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -40,7 +54,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +65,11 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": "FUNCTION",
                     "value": "FUNCTION",
                     "keyword": "FUNCTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +111,9 @@
                     "token": "F_TEST",
                     "value": "F_TEST",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -94,7 +122,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -103,7 +135,9 @@
                     "token": "uid",
                     "value": "uid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -121,7 +157,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 11,
                     "position": 40
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -148,7 +190,9 @@
                     "token": "RETURNS",
                     "value": "RETURNS",
                     "keyword": "RETURNS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 45
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -166,7 +212,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 11,
                     "position": 53
                 },
@@ -175,7 +223,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -184,7 +234,9 @@
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 61
                 },
@@ -193,7 +245,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -202,7 +256,9 @@
                     "token": "DECLARE",
                     "value": "DECLARE",
                     "keyword": "DECLARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 71
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -220,7 +278,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -238,7 +300,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 11,
                     "position": 88
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -256,7 +322,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 35,
                     "position": 96
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -274,7 +344,11 @@
                     "token": "\"\"",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 104
                 },
@@ -283,7 +357,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 106
                 },
@@ -292,7 +368,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -301,7 +379,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 112
                 },
@@ -310,7 +390,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -319,7 +401,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -337,7 +423,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 128
                 },
@@ -346,7 +434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -355,7 +445,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -364,7 +456,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -373,7 +467,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 142
                 },
@@ -382,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 146
                 },
@@ -391,7 +489,9 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -400,7 +500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -409,7 +511,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 153
                 },
@@ -418,7 +522,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -427,7 +533,9 @@
                     "token": "ID",
                     "value": "ID",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 159
                 },
@@ -436,7 +544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 161
                 },
@@ -445,7 +555,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 162
                 },
@@ -454,7 +566,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 163
                 },
@@ -463,7 +577,9 @@
                     "token": "uid",
                     "value": "uid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 164
                 },
@@ -472,7 +588,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 167
                 },
@@ -481,7 +599,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 168
                 },
@@ -490,7 +610,9 @@
                     "token": "RETURN",
                     "value": "RETURN",
                     "keyword": "RETURN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 173
                 },
@@ -499,7 +621,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 179
                 },
@@ -508,7 +632,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 180
                 },
@@ -517,7 +643,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 188
                 },
@@ -526,7 +654,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 189
                 },
@@ -535,7 +665,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 190
                 },
@@ -544,13 +676,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 60,
-            "idx": 60
+            ]
         },
         "delimiter": "$$",
         "delimiterLen": 2,
@@ -618,21 +750,6 @@
                 ],
                 "body": [
                     {
-                        "@type": "@21"
-                    },
-                    {
-                        "@type": "@22"
-                    },
-                    {
-                        "@type": "@23"
-                    },
-                    {
-                        "@type": "@24"
-                    },
-                    {
-                        "@type": "@25"
-                    },
-                    {
                         "@type": "@26"
                     },
                     {
@@ -664,9 +781,6 @@
                     },
                     {
                         "@type": "@36"
-                    },
-                    {
-                        "@type": "@37"
                     },
                     {
                         "@type": "@38"
@@ -736,6 +850,24 @@
                     },
                     {
                         "@type": "@60"
+                    },
+                    {
+                        "@type": "@61"
+                    },
+                    {
+                        "@type": "@62"
+                    },
+                    {
+                        "@type": "@63"
+                    },
+                    {
+                        "@type": "@64"
+                    },
+                    {
+                        "@type": "@65"
+                    },
+                    {
+                        "@type": "@66"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseCreateFunctionErr1.out
+++ b/tests/data/parser/parseCreateFunctionErr1.out
@@ -7,13 +7,19 @@
         "last": 177,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 56,
+            "idx": 56,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,11 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -40,7 +54,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +65,11 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": "FUNCTION",
                     "value": "FUNCTION",
                     "keyword": "FUNCTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +111,9 @@
                     "token": "F_TEST",
                     "value": "F_TEST",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -94,7 +122,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -103,7 +135,9 @@
                     "token": "uid",
                     "value": "uid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -121,7 +157,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 11,
                     "position": 40
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -139,7 +179,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -148,7 +190,9 @@
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 45
                 },
@@ -157,7 +201,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -166,7 +212,9 @@
                     "token": "DECLARE",
                     "value": "DECLARE",
                     "keyword": "DECLARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 55
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -184,7 +234,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 11,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -220,7 +278,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 35,
                     "position": 80
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -238,7 +300,11 @@
                     "token": "\"\"",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 88
                 },
@@ -247,7 +313,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 90
                 },
@@ -256,7 +324,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -265,7 +335,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -274,7 +346,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -283,7 +357,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -292,7 +368,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -301,7 +379,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 112
                 },
@@ -310,7 +390,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -319,7 +401,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -337,7 +423,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 126
                 },
@@ -346,7 +434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -355,7 +445,9 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -364,7 +456,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 136
                 },
@@ -373,7 +467,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 137
                 },
@@ -382,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -391,7 +489,9 @@
                     "token": "ID",
                     "value": "ID",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -400,7 +500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 145
                 },
@@ -409,7 +511,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 146
                 },
@@ -418,7 +522,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -427,7 +533,9 @@
                     "token": "uid",
                     "value": "uid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -436,7 +544,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 151
                 },
@@ -445,7 +555,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -454,7 +566,9 @@
                     "token": "RETURN",
                     "value": "RETURN",
                     "keyword": "RETURN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 157
                 },
@@ -463,7 +577,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 163
                 },
@@ -472,7 +588,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 164
                 },
@@ -481,7 +599,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 172
                 },
@@ -490,7 +610,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 173
                 },
@@ -499,7 +621,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 174
                 },
@@ -508,13 +632,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 56,
-            "idx": 56
+            ]
         },
         "delimiter": "$$",
         "delimiterLen": 2,
@@ -573,21 +697,6 @@
                 ],
                 "body": [
                     {
-                        "@type": "@19"
-                    },
-                    {
-                        "@type": "@20"
-                    },
-                    {
-                        "@type": "@21"
-                    },
-                    {
-                        "@type": "@22"
-                    },
-                    {
-                        "@type": "@23"
-                    },
-                    {
                         "@type": "@24"
                     },
                     {
@@ -613,9 +722,6 @@
                     },
                     {
                         "@type": "@32"
-                    },
-                    {
-                        "@type": "@33"
                     },
                     {
                         "@type": "@34"
@@ -685,6 +791,24 @@
                     },
                     {
                         "@type": "@56"
+                    },
+                    {
+                        "@type": "@57"
+                    },
+                    {
+                        "@type": "@58"
+                    },
+                    {
+                        "@type": "@59"
+                    },
+                    {
+                        "@type": "@60"
+                    },
+                    {
+                        "@type": "@61"
+                    },
+                    {
+                        "@type": "@62"
                     }
                 ],
                 "options": {
@@ -707,7 +831,7 @@
             [
                 "A \"RETURNS\" keyword was expected.",
                 {
-                    "@type": "@17"
+                    "@type": "@22"
                 },
                 0
             ]

--- a/tests/data/parser/parseCreateFunctionErr2.out
+++ b/tests/data/parser/parseCreateFunctionErr2.out
@@ -7,13 +7,19 @@
         "last": 30,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 12,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "FUNCTION",
                     "value": "FUNCTION",
                     "keyword": "FUNCTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -49,7 +63,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -58,7 +76,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 20
                 },
@@ -67,7 +89,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 21
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,7 +111,9 @@
                     "token": "RETURNS",
                     "value": "RETURNS",
                     "keyword": "RETURNS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 23
                 },
@@ -94,13 +122,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 12
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateFunctionErr3.out
+++ b/tests/data/parser/parseCreateFunctionErr3.out
@@ -7,13 +7,19 @@
         "last": 45,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,11 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -40,7 +54,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +65,11 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": "FUNCTION",
                     "value": "FUNCTION",
                     "keyword": "FUNCTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +111,9 @@
                     "token": "coincide",
                     "value": "coincide",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -94,7 +122,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -103,7 +133,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 38
                 },
@@ -112,7 +144,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -121,7 +157,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -130,7 +168,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -139,13 +179,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 17
+            ]
         },
         "delimiter": "$$",
         "delimiterLen": 2,
@@ -207,7 +247,7 @@
             [
                 "A \"RETURNS\" keyword was expected.",
                 {
-                    "@type": "@12"
+                    "@type": "@16"
                 },
                 0
             ]

--- a/tests/data/parser/parseCreateOrReplaceView1.out
+++ b/tests/data/parser/parseCreateOrReplaceView1.out
@@ -7,13 +7,19 @@
         "last": 172,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 53,
+            "idx": 53,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "OR REPLACE",
                     "value": "OR REPLACE",
                     "keyword": "OR REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -49,7 +63,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +85,11 @@
                     "token": "xviewmytable",
                     "value": "xviewmytable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -76,7 +98,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -85,7 +109,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 37
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -103,7 +131,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -121,7 +153,9 @@
                     "token": "mytable",
                     "value": "mytable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -130,7 +164,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 54
                 },
@@ -139,7 +177,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -157,7 +199,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 58
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -175,7 +221,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -184,7 +232,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 63
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -202,7 +254,9 @@
                     "token": "mytable",
                     "value": "mytable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -211,7 +265,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 72
                 },
@@ -220,7 +276,9 @@
                     "token": "personid",
                     "value": "personid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -238,7 +298,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -247,7 +309,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -256,7 +320,9 @@
                     "token": "personid",
                     "value": "personid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -265,7 +331,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -274,7 +342,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 94
                 },
@@ -283,7 +353,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -292,7 +364,9 @@
                     "token": "mytable",
                     "value": "mytable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -301,7 +375,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -310,7 +386,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 107
                 },
@@ -319,7 +397,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -328,7 +408,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 113
                 },
@@ -337,7 +419,9 @@
                     "token": "mytable",
                     "value": "mytable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -346,7 +430,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 121
                 },
@@ -355,7 +441,9 @@
                     "token": "birth",
                     "value": "birth",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -364,7 +452,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -373,7 +463,9 @@
                     "token": ">",
                     "value": ">",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 2,
                     "position": 128
                 },
@@ -382,7 +474,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -391,7 +485,11 @@
                     "token": "'1990-01-19'",
                     "value": "1990-01-19",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 130
                 },
@@ -400,7 +498,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 142
                 },
@@ -409,7 +509,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -418,7 +520,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 144
                 },
@@ -427,7 +531,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -436,7 +542,9 @@
                     "token": "mytable",
                     "value": "mytable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 153
                 },
@@ -445,7 +553,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 16,
                     "position": 160
                 },
@@ -454,7 +564,9 @@
                     "token": "personid",
                     "value": "personid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 161
                 },
@@ -463,7 +575,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 169
                 },
@@ -472,7 +586,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 171
                 },
@@ -481,13 +599,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@59"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 53,
-            "idx": 53
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateProcedure.out
+++ b/tests/data/parser/parseCreateProcedure.out
@@ -7,13 +7,19 @@
         "last": 102,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 36,
+            "idx": 36,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,11 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -40,7 +54,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +65,11 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": "PROCEDURE",
                     "value": "PROCEDURE",
                     "keyword": "PROCEDURE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -85,7 +111,9 @@
                     "token": "P_TEST",
                     "value": "P_TEST",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -94,7 +122,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 36
                 },
@@ -103,7 +135,9 @@
                     "token": "uid",
                     "value": "uid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -121,7 +157,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 11,
                     "position": 41
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 44
                 },
@@ -139,7 +179,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -148,7 +190,9 @@
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 46
                 },
@@ -157,7 +201,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -166,7 +212,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 56
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -184,7 +234,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -220,7 +278,9 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -238,7 +300,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 83
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -256,7 +322,9 @@
                     "token": "ID",
                     "value": "ID",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -274,7 +344,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 92
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -292,7 +366,9 @@
                     "token": "uid",
                     "value": "uid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -301,7 +377,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 97
                 },
@@ -310,7 +388,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -319,7 +399,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 99
                 },
@@ -328,13 +410,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 36,
-            "idx": 36
+            ]
         },
         "delimiter": "$$",
         "delimiterLen": 2,
@@ -393,21 +475,6 @@
                 ],
                 "body": [
                     {
-                        "@type": "@17"
-                    },
-                    {
-                        "@type": "@18"
-                    },
-                    {
-                        "@type": "@19"
-                    },
-                    {
-                        "@type": "@20"
-                    },
-                    {
-                        "@type": "@21"
-                    },
-                    {
                         "@type": "@22"
                     },
                     {
@@ -451,6 +518,21 @@
                     },
                     {
                         "@type": "@36"
+                    },
+                    {
+                        "@type": "@37"
+                    },
+                    {
+                        "@type": "@38"
+                    },
+                    {
+                        "@type": "@39"
+                    },
+                    {
+                        "@type": "@40"
+                    },
+                    {
+                        "@type": "@41"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseCreateProcedure1.out
+++ b/tests/data/parser/parseCreateProcedure1.out
@@ -7,13 +7,19 @@
         "last": 116,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 31,
+            "idx": 31,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 14
                 },
@@ -49,7 +65,11 @@
                     "token": "`root`@`%`",
                     "value": "root@%",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 15
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -67,7 +89,9 @@
                     "token": "PROCEDURE",
                     "value": "PROCEDURE",
                     "keyword": "PROCEDURE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 26
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -85,7 +111,9 @@
                     "token": "`test2`",
                     "value": "test2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 2,
                     "position": 36
                 },
@@ -94,7 +122,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -103,7 +133,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 44
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -121,7 +155,9 @@
                     "token": "`_var`",
                     "value": "_var",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 2,
                     "position": 47
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -139,7 +177,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 54
                 },
@@ -148,7 +188,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 57
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -166,7 +210,9 @@
                     "token": "NOT",
                     "value": "NOT",
                     "keyword": "NOT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 59
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -184,7 +232,9 @@
                     "token": "DETERMINISTIC",
                     "value": "DETERMINISTIC",
                     "keyword": "DETERMINISTIC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 63
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -202,7 +254,9 @@
                     "token": "NO SQL",
                     "value": "NO SQL",
                     "keyword": "NO SQL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 77
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -220,7 +276,9 @@
                     "token": "SQL SECURITY",
                     "value": "SQL SECURITY",
                     "keyword": "SQL SECURITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 84
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -238,7 +298,9 @@
                     "token": "INVOKER",
                     "value": "INVOKER",
                     "keyword": "INVOKER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 97
                 },
@@ -247,7 +309,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -256,7 +320,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 105
                 },
@@ -265,7 +331,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -274,7 +342,11 @@
                     "token": "_var",
                     "value": "_var",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -283,13 +355,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 31,
-            "idx": 31
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -362,13 +436,13 @@
                 ],
                 "body": [
                     {
-                        "@type": "@29"
+                        "@type": "@33"
                     },
                     {
-                        "@type": "@30"
+                        "@type": "@34"
                     },
                     {
-                        "@type": "@31"
+                        "@type": "@35"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseCreateProcedure2.out
+++ b/tests/data/parser/parseCreateProcedure2.out
@@ -7,13 +7,19 @@
         "last": 124,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 45,
+            "idx": 45,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,11 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -40,7 +54,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +65,11 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": "PROCEDURE",
                     "value": "PROCEDURE",
                     "keyword": "PROCEDURE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -85,7 +111,9 @@
                     "token": "P_TEST",
                     "value": "P_TEST",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -94,7 +122,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 36
                 },
@@ -103,7 +135,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 35,
                     "position": 37
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -121,7 +157,9 @@
                     "token": "uid",
                     "value": "uid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -139,7 +179,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 11,
                     "position": 44
                 },
@@ -148,7 +190,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 47
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -166,7 +212,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 35,
                     "position": 49
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -184,7 +234,9 @@
                     "token": "unused",
                     "value": "unused",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -202,7 +256,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 11,
                     "position": 59
                 },
@@ -211,7 +267,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 66
                 },
@@ -220,7 +278,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -229,7 +289,9 @@
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 68
                 },
@@ -238,7 +300,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -247,7 +311,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 78
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -265,7 +333,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -283,7 +355,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 94
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -301,7 +377,9 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -319,7 +399,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 3,
                     "position": 105
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -337,7 +421,9 @@
                     "token": "ID",
                     "value": "ID",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -346,7 +432,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -355,7 +443,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 114
                 },
@@ -364,7 +454,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -373,7 +465,9 @@
                     "token": "uid",
                     "value": "uid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -382,7 +476,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 119
                 },
@@ -391,7 +487,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -400,7 +498,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 1,
                     "position": 121
                 },
@@ -409,13 +509,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 45,
-            "idx": 45
+            ]
         },
         "delimiter": "$$",
         "delimiterLen": 2,
@@ -489,21 +589,6 @@
                 ],
                 "body": [
                     {
-                        "@type": "@26"
-                    },
-                    {
-                        "@type": "@27"
-                    },
-                    {
-                        "@type": "@28"
-                    },
-                    {
-                        "@type": "@29"
-                    },
-                    {
-                        "@type": "@30"
-                    },
-                    {
                         "@type": "@31"
                     },
                     {
@@ -547,6 +632,21 @@
                     },
                     {
                         "@type": "@45"
+                    },
+                    {
+                        "@type": "@46"
+                    },
+                    {
+                        "@type": "@47"
+                    },
+                    {
+                        "@type": "@48"
+                    },
+                    {
+                        "@type": "@49"
+                    },
+                    {
+                        "@type": "@50"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseCreateProcedure3.out
+++ b/tests/data/parser/parseCreateProcedure3.out
@@ -14,13 +14,19 @@
         "last": 1173,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 267,
+            "idx": 267,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -29,7 +35,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -38,7 +48,11 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -47,7 +61,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -56,7 +72,11 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -65,7 +85,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -74,7 +96,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 20
                 },
@@ -83,7 +107,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -92,7 +120,11 @@
                     "token": "`user`@`localhost`",
                     "value": "user@localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 28
                 },
@@ -101,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -110,7 +144,9 @@
                     "token": "PROCEDURE",
                     "value": "PROCEDURE",
                     "keyword": "PROCEDURE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 47
                 },
@@ -119,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -128,7 +166,9 @@
                     "token": "`multiDBqueryRun_V1`",
                     "value": "multiDBqueryRun_V1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 57
                 },
@@ -137,7 +177,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -146,7 +188,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 78
                 },
@@ -155,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -164,7 +210,9 @@
                     "token": "`query`",
                     "value": "query",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 81
                 },
@@ -173,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -182,7 +232,9 @@
                     "token": "TEXT",
                     "value": "TEXT",
                     "keyword": "TEXT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 9,
                     "position": 89
                 },
@@ -191,7 +243,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 93
                 },
@@ -200,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -209,7 +265,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 95
                 },
@@ -218,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -227,7 +287,9 @@
                     "token": "`table_name_var`",
                     "value": "table_name_var",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 98
                 },
@@ -236,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -245,7 +309,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 115
                 },
@@ -254,7 +320,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 122
                 },
@@ -263,7 +331,11 @@
                     "token": "255",
                     "value": 255,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -272,7 +344,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 126
                 },
@@ -281,7 +355,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 127
                 },
@@ -290,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 128
                 },
@@ -299,7 +377,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 129
                 },
@@ -308,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -317,7 +399,9 @@
                     "token": "`columns_used_var`",
                     "value": "columns_used_var",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 132
                 },
@@ -326,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 150
                 },
@@ -335,7 +421,9 @@
                     "token": "TEXT",
                     "value": "TEXT",
                     "keyword": "TEXT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 9,
                     "position": 151
                 },
@@ -344,7 +432,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 155
                 },
@@ -353,7 +443,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 156
                 },
@@ -362,7 +454,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 157
                 },
@@ -371,7 +465,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 159
                 },
@@ -380,7 +476,9 @@
                     "token": "`where_text_var`",
                     "value": "where_text_var",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 160
                 },
@@ -389,7 +487,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -398,7 +498,9 @@
                     "token": "TEXT",
                     "value": "TEXT",
                     "keyword": "TEXT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 9,
                     "position": 177
                 },
@@ -407,7 +509,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 181
                 },
@@ -416,7 +520,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 182
                 },
@@ -425,7 +531,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 183
                 },
@@ -434,7 +542,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 185
                 },
@@ -443,7 +553,9 @@
                     "token": "`separator_value_var`",
                     "value": "separator_value_var",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 186
                 },
@@ -452,7 +564,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 207
                 },
@@ -461,7 +575,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 208
                 },
@@ -470,7 +586,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 215
                 },
@@ -479,7 +597,9 @@
                     "token": "255",
                     "value": 255,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 216
                 },
@@ -488,7 +608,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 219
                 },
@@ -497,7 +619,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 220
                 },
@@ -506,7 +630,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 221
                 },
@@ -515,7 +641,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 222
                 },
@@ -524,7 +652,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 229
                 },
@@ -533,7 +663,11 @@
                     "token": "'Query: SingleDB → MultiDB (All DBs) + run it'",
                     "value": "Query: SingleDB → MultiDB (All DBs) + run it",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 230
                 },
@@ -542,7 +676,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 276
                 },
@@ -551,7 +687,9 @@
                     "token": "NOT",
                     "value": "NOT",
                     "keyword": "NOT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 277
                 },
@@ -560,7 +698,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 280
                 },
@@ -569,7 +709,9 @@
                     "token": "DETERMINISTIC",
                     "value": "DETERMINISTIC",
                     "keyword": "DETERMINISTIC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 281
                 },
@@ -578,7 +720,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 294
                 },
@@ -587,7 +731,9 @@
                     "token": "MODIFIES SQL DATA",
                     "value": "MODIFIES SQL DATA",
                     "keyword": "MODIFIES SQL DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 7,
                     "position": 295
                 },
@@ -596,7 +742,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 312
                 },
@@ -605,7 +753,9 @@
                     "token": "SQL SECURITY",
                     "value": "SQL SECURITY",
                     "keyword": "SQL SECURITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 7,
                     "position": 313
                 },
@@ -614,7 +764,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 325
                 },
@@ -623,7 +775,9 @@
                     "token": "INVOKER",
                     "value": "INVOKER",
                     "keyword": "INVOKER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 326
                 },
@@ -632,7 +786,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 333
                 },
@@ -641,7 +797,9 @@
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 334
                 },
@@ -650,7 +808,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 339
                 },
@@ -659,7 +819,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 340
                 },
@@ -668,7 +830,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 343
                 },
@@ -677,7 +841,9 @@
                     "token": "@TABLE_NAME",
                     "value": "TABLE_NAME",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 344
                 },
@@ -686,7 +852,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 355
                 },
@@ -695,7 +863,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 356
                 },
@@ -704,7 +874,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 357
                 },
@@ -713,7 +885,9 @@
                     "token": "table_name_var",
                     "value": "table_name_var",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 358
                 },
@@ -722,7 +896,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 372
                 },
@@ -731,7 +907,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 373
                 },
@@ -740,7 +918,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 374
                 },
@@ -749,7 +929,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 377
                 },
@@ -758,7 +940,9 @@
                     "token": "@WHERE_TEXT",
                     "value": "WHERE_TEXT",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 378
                 },
@@ -767,7 +951,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 389
                 },
@@ -776,7 +962,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 390
                 },
@@ -785,7 +973,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 391
                 },
@@ -794,7 +984,9 @@
                     "token": "where_text_var",
                     "value": "where_text_var",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 392
                 },
@@ -803,7 +995,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 406
                 },
@@ -812,7 +1006,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 407
                 },
@@ -821,7 +1017,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 408
                 },
@@ -830,7 +1028,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 411
                 },
@@ -839,7 +1039,9 @@
                     "token": "@COLUMNS_USED",
                     "value": "COLUMNS_USED",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 412
                 },
@@ -848,7 +1050,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 425
                 },
@@ -857,7 +1061,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 426
                 },
@@ -866,7 +1072,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 427
                 },
@@ -875,7 +1083,9 @@
                     "token": "columns_used_var",
                     "value": "columns_used_var",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 428
                 },
@@ -884,7 +1094,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 444
                 },
@@ -893,7 +1105,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 445
                 },
@@ -902,7 +1116,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 446
                 },
@@ -911,7 +1127,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 449
                 },
@@ -920,7 +1138,9 @@
                     "token": "@MULTIDB_QUERY",
                     "value": "MULTIDB_QUERY",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 450
                 },
@@ -929,7 +1149,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 464
                 },
@@ -938,7 +1160,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 465
                 },
@@ -947,7 +1171,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 466
                 },
@@ -956,7 +1182,9 @@
                     "token": "CONCAT",
                     "value": "CONCAT",
                     "keyword": "CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 467
                 },
@@ -965,7 +1193,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 473
                 },
@@ -974,7 +1204,9 @@
                     "token": "'SELECT \"$MULTIDB\" FROM `$MULTIDB`.'",
                     "value": "SELECT \"$MULTIDB\" FROM `$MULTIDB`.",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 474
                 },
@@ -983,7 +1215,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 510
                 },
@@ -992,7 +1226,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 511
                 },
@@ -1001,7 +1237,9 @@
                     "token": "@TABLE_NAME",
                     "value": "TABLE_NAME",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 512
                 },
@@ -1010,7 +1248,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 523
                 },
@@ -1019,7 +1259,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 524
                 },
@@ -1028,7 +1270,9 @@
                     "token": "@WHERE_TEXT",
                     "value": "WHERE_TEXT",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 525
                 },
@@ -1037,7 +1281,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 536
                 },
@@ -1046,7 +1292,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 537
                 },
@@ -1055,7 +1303,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 538
                 },
@@ -1064,7 +1314,11 @@
                     "token": "-- EXECUTION --",
                     "value": "-- EXECUTION --",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 540
                 },
@@ -1073,7 +1327,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 555
                 },
@@ -1082,7 +1338,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 556
                 },
@@ -1091,7 +1349,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 562
                 },
@@ -1100,7 +1360,9 @@
                     "token": "TEMPORARY",
                     "value": "TEMPORARY",
                     "keyword": "TEMPORARY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 563
                 },
@@ -1109,7 +1371,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 572
                 },
@@ -1118,7 +1382,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 573
                 },
@@ -1127,7 +1393,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 578
                 },
@@ -1136,7 +1404,9 @@
                     "token": "`MULTIDB_TEMP_DB_TBL_COLS`",
                     "value": "MULTIDB_TEMP_DB_TBL_COLS",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 579
                 },
@@ -1145,7 +1415,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 605
                 },
@@ -1154,7 +1426,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 606
                 },
@@ -1163,7 +1437,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 608
                 },
@@ -1172,7 +1448,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 609
                 },
@@ -1181,7 +1459,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 615
                 },
@@ -1190,7 +1470,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 616
                 },
@@ -1199,7 +1481,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 617
                 },
@@ -1208,7 +1492,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 618
                 },
@@ -1217,7 +1503,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 622
                 },
@@ -1226,7 +1514,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 623
                 },
@@ -1235,7 +1525,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 624
                 },
@@ -1244,7 +1536,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 627
                 },
@@ -1253,7 +1547,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 633
                 },
@@ -1262,7 +1558,9 @@
                     "token": "TABLE_SCHEMA",
                     "value": "TABLE_SCHEMA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 634
                 },
@@ -1271,7 +1569,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 646
                 },
@@ -1280,7 +1580,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 647
                 },
@@ -1289,7 +1591,9 @@
                     "token": "TABLE_NAME",
                     "value": "TABLE_NAME",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 648
                 },
@@ -1298,7 +1602,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 658
                 },
@@ -1307,7 +1613,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 659
                 },
@@ -1316,7 +1624,9 @@
                     "token": "COLUMN_NAME",
                     "value": "COLUMN_NAME",
                     "keyword": "COLUMN_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 660
                 },
@@ -1325,7 +1635,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 671
                 },
@@ -1334,7 +1646,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 674
                 },
@@ -1343,7 +1657,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 678
                 },
@@ -1352,7 +1668,9 @@
                     "token": "INFORMATION_SCHEMA",
                     "value": "INFORMATION_SCHEMA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 679
                 },
@@ -1361,7 +1679,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 697
                 },
@@ -1370,7 +1690,9 @@
                     "token": "COLUMNS",
                     "value": "COLUMNS",
                     "keyword": "COLUMNS",
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 698
                 },
@@ -1379,7 +1701,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 705
                 },
@@ -1388,7 +1712,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 708
                 },
@@ -1397,7 +1723,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 713
                 },
@@ -1406,7 +1734,9 @@
                     "token": "TABLE_SCHEMA",
                     "value": "TABLE_SCHEMA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 718
                 },
@@ -1415,7 +1745,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 730
                 },
@@ -1424,7 +1756,9 @@
                     "token": "NOT IN",
                     "value": "NOT IN",
                     "keyword": "NOT IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 39,
                     "position": 731
                 },
@@ -1433,7 +1767,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 737
                 },
@@ -1442,7 +1778,9 @@
                     "token": "'mysql'",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 738
                 },
@@ -1451,7 +1789,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 745
                 },
@@ -1460,7 +1800,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 746
                 },
@@ -1469,7 +1811,9 @@
                     "token": "'test'",
                     "value": "test",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 747
                 },
@@ -1478,7 +1822,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 753
                 },
@@ -1487,7 +1833,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 754
                 },
@@ -1496,7 +1844,9 @@
                     "token": "'tmp'",
                     "value": "tmp",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 755
                 },
@@ -1505,7 +1855,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 760
                 },
@@ -1514,7 +1866,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 761
                 },
@@ -1523,7 +1877,9 @@
                     "token": "'information_schema'",
                     "value": "information_schema",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 762
                 },
@@ -1532,7 +1888,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 782
                 },
@@ -1541,7 +1899,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 783
                 },
@@ -1550,7 +1910,9 @@
                     "token": "'sys'",
                     "value": "sys",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 784
                 },
@@ -1559,7 +1921,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 789
                 },
@@ -1568,7 +1932,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 790
                 },
@@ -1577,7 +1943,9 @@
                     "token": "'performance_schema'",
                     "value": "performance_schema",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 791
                 },
@@ -1586,7 +1954,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 811
                 },
@@ -1595,7 +1965,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 812
                 },
@@ -1604,7 +1976,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 813
                 },
@@ -1613,7 +1987,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 816
                 },
@@ -1622,7 +1998,9 @@
                     "token": "TABLE_NAME",
                     "value": "TABLE_NAME",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 821
                 },
@@ -1631,7 +2009,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 831
                 },
@@ -1640,7 +2020,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 832
                 },
@@ -1649,7 +2031,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 833
                 },
@@ -1658,7 +2042,9 @@
                     "token": "@TABLE_NAME",
                     "value": "TABLE_NAME",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 834
                 },
@@ -1667,7 +2053,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 845
                 },
@@ -1676,7 +2064,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 846
                 },
@@ -1685,7 +2075,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 849
                 },
@@ -1694,7 +2086,9 @@
                     "token": "FIND_IN_SET",
                     "value": "FIND_IN_SET",
                     "keyword": "FIND_IN_SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 854
                 },
@@ -1703,7 +2097,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 865
                 },
@@ -1712,7 +2108,9 @@
                     "token": "COLUMN_NAME",
                     "value": "COLUMN_NAME",
                     "keyword": "COLUMN_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 866
                 },
@@ -1721,7 +2119,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 877
                 },
@@ -1730,7 +2130,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 878
                 },
@@ -1739,7 +2141,9 @@
                     "token": "@COLUMNS_USED",
                     "value": "COLUMNS_USED",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 879
                 },
@@ -1748,7 +2152,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 892
                 },
@@ -1757,7 +2163,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 893
                 },
@@ -1766,7 +2174,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 894
                 },
@@ -1775,7 +2185,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 895
                 },
@@ -1784,7 +2196,9 @@
                     "token": "tbl",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 896
                 },
@@ -1793,7 +2207,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 899
                 },
@@ -1802,7 +2218,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 7,
                     "position": 900
                 },
@@ -1811,7 +2229,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 908
                 },
@@ -1820,7 +2240,9 @@
                     "token": "TABLE_SCHEMA",
                     "value": "TABLE_SCHEMA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 911
                 },
@@ -1829,7 +2251,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 923
                 },
@@ -1838,7 +2262,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 924
                 },
@@ -1847,7 +2273,9 @@
                     "token": "TABLE_NAME",
                     "value": "TABLE_NAME",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 927
                 },
@@ -1856,7 +2284,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 937
                 },
@@ -1865,7 +2295,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 938
                 },
@@ -1874,7 +2306,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 940
                 },
@@ -1883,7 +2317,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 946
                 },
@@ -1892,7 +2328,9 @@
                     "token": "GROUP_CONCAT",
                     "value": "GROUP_CONCAT",
                     "keyword": "GROUP_CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 947
                 },
@@ -1901,7 +2339,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 959
                 },
@@ -1910,7 +2350,9 @@
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 960
                 },
@@ -1919,7 +2361,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 967
                 },
@@ -1928,7 +2372,9 @@
                     "token": "@MULTIDB_QUERY",
                     "value": "MULTIDB_QUERY",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 968
                 },
@@ -1937,7 +2383,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 982
                 },
@@ -1946,7 +2394,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 983
                 },
@@ -1955,7 +2405,9 @@
                     "token": "'$MULTIDB'",
                     "value": "$MULTIDB",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 984
                 },
@@ -1964,7 +2416,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 994
                 },
@@ -1973,7 +2427,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 995
                 },
@@ -1982,7 +2438,9 @@
                     "token": "CONCAT",
                     "value": "CONCAT",
                     "keyword": "CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 996
                 },
@@ -1991,7 +2449,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1002
                 },
@@ -2000,7 +2460,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1003
                 },
@@ -2009,7 +2471,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1005
                 },
@@ -2018,7 +2482,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1006
                 },
@@ -2027,7 +2493,9 @@
                     "token": "TABLE_SCHEMA",
                     "value": "TABLE_SCHEMA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1007
                 },
@@ -2036,7 +2504,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1019
                 },
@@ -2045,7 +2515,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1020
                 },
@@ -2054,7 +2526,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1021
                 },
@@ -2063,7 +2537,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1023
                 },
@@ -2072,7 +2548,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1024
                 },
@@ -2081,7 +2559,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1025
                 },
@@ -2090,7 +2570,9 @@
                     "token": "SEPARATOR",
                     "value": "SEPARATOR",
                     "keyword": "SEPARATOR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1026
                 },
@@ -2099,7 +2581,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1035
                 },
@@ -2108,7 +2592,9 @@
                     "token": "\"\\nUNION ALL\\n\"",
                     "value": "\nUNION ALL\n",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 2,
                     "position": 1036
                 },
@@ -2117,7 +2603,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1051
                 },
@@ -2126,7 +2614,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1052
                 },
@@ -2135,7 +2625,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1053
                 },
@@ -2144,7 +2636,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1057
                 },
@@ -2153,7 +2647,9 @@
                     "token": "@stmt_sql",
                     "value": "stmt_sql",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 1058
                 },
@@ -2162,7 +2658,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1067
                 },
@@ -2171,7 +2669,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1068
                 },
@@ -2180,7 +2680,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1072
                 },
@@ -2189,7 +2691,9 @@
                     "token": "`MULTIDB_TEMP_DB_TBL_COLS`",
                     "value": "MULTIDB_TEMP_DB_TBL_COLS",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 1073
                 },
@@ -2198,7 +2702,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1099
                 },
@@ -2207,7 +2713,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1100
                 },
@@ -2216,7 +2724,9 @@
                     "token": "PREPARE",
                     "value": "PREPARE",
                     "keyword": "PREPARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1102
                 },
@@ -2225,7 +2735,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1109
                 },
@@ -2234,7 +2746,9 @@
                     "token": "stmt",
                     "value": "stmt",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1110
                 },
@@ -2243,7 +2757,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1114
                 },
@@ -2252,7 +2768,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1115
                 },
@@ -2261,7 +2779,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1119
                 },
@@ -2270,7 +2790,9 @@
                     "token": "@stmt_sql",
                     "value": "stmt_sql",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 1120
                 },
@@ -2279,7 +2801,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1129
                 },
@@ -2288,7 +2812,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1130
                 },
@@ -2297,7 +2823,9 @@
                     "token": "EXECUTE",
                     "value": "EXECUTE",
                     "keyword": "EXECUTE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1131
                 },
@@ -2306,7 +2834,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1138
                 },
@@ -2315,7 +2845,9 @@
                     "token": "stmt",
                     "value": "stmt",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1139
                 },
@@ -2324,7 +2856,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1143
                 },
@@ -2333,7 +2867,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1144
                 },
@@ -2342,7 +2878,9 @@
                     "token": "DEALLOCATE",
                     "value": "DEALLOCATE",
                     "keyword": "DEALLOCATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1145
                 },
@@ -2351,7 +2889,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1155
                 },
@@ -2360,7 +2900,9 @@
                     "token": "PREPARE",
                     "value": "PREPARE",
                     "keyword": "PREPARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1156
                 },
@@ -2369,7 +2911,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1163
                 },
@@ -2378,7 +2922,9 @@
                     "token": "stmt",
                     "value": "stmt",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1164
                 },
@@ -2387,7 +2933,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1168
                 },
@@ -2396,7 +2944,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1169
                 },
@@ -2405,7 +2955,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1170
                 },
@@ -2414,13 +2966,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 267,
-            "idx": 267
+            ]
         },
         "delimiter": "$$",
         "delimiterLen": 2,
@@ -2562,30 +3114,6 @@
                     }
                 ],
                 "body": [
-                    {
-                        "@type": "@72"
-                    },
-                    {
-                        "@type": "@73"
-                    },
-                    {
-                        "@type": "@74"
-                    },
-                    {
-                        "@type": "@75"
-                    },
-                    {
-                        "@type": "@76"
-                    },
-                    {
-                        "@type": "@77"
-                    },
-                    {
-                        "@type": "@78"
-                    },
-                    {
-                        "@type": "@79"
-                    },
                     {
                         "@type": "@80"
                     },
@@ -2729,9 +3257,6 @@
                     },
                     {
                         "@type": "@127"
-                    },
-                    {
-                        "@type": "@128"
                     },
                     {
                         "@type": "@129"
@@ -3152,6 +3677,33 @@
                     },
                     {
                         "@type": "@268"
+                    },
+                    {
+                        "@type": "@269"
+                    },
+                    {
+                        "@type": "@270"
+                    },
+                    {
+                        "@type": "@271"
+                    },
+                    {
+                        "@type": "@272"
+                    },
+                    {
+                        "@type": "@273"
+                    },
+                    {
+                        "@type": "@274"
+                    },
+                    {
+                        "@type": "@275"
+                    },
+                    {
+                        "@type": "@276"
+                    },
+                    {
+                        "@type": "@277"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseCreateProcedure4.out
+++ b/tests/data/parser/parseCreateProcedure4.out
@@ -14,13 +14,19 @@
         "last": 3083,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 926,
+            "idx": 926,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -29,7 +35,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -38,7 +48,11 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -47,7 +61,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -56,7 +72,11 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -65,7 +85,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -74,7 +96,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 20
                 },
@@ -83,7 +107,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -92,7 +120,11 @@
                     "token": "`user`@`localhost`",
                     "value": "user@localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 28
                 },
@@ -101,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -110,7 +144,9 @@
                     "token": "PROCEDURE",
                     "value": "PROCEDURE",
                     "keyword": "PROCEDURE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 47
                 },
@@ -119,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -128,7 +166,9 @@
                     "token": "`multiDBqueryRun_V12`",
                     "value": "multiDBqueryRun_V12",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 57
                 },
@@ -137,7 +177,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 78
                 },
@@ -146,7 +188,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 79
                 },
@@ -155,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -164,7 +210,9 @@
                     "token": "`query`",
                     "value": "query",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 82
                 },
@@ -173,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -182,7 +232,9 @@
                     "token": "TEXT",
                     "value": "TEXT",
                     "keyword": "TEXT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 9,
                     "position": 90
                 },
@@ -191,7 +243,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 94
                 },
@@ -200,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -209,7 +265,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 96
                 },
@@ -218,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -227,7 +287,9 @@
                     "token": "`table_name_var`",
                     "value": "table_name_var",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 99
                 },
@@ -236,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -245,7 +309,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 116
                 },
@@ -254,7 +320,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 123
                 },
@@ -263,7 +331,11 @@
                     "token": "255",
                     "value": 255,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -272,7 +344,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 127
                 },
@@ -281,7 +355,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 128
                 },
@@ -290,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -299,7 +377,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 130
                 },
@@ -308,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -317,7 +399,9 @@
                     "token": "`columns_used_var`",
                     "value": "columns_used_var",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 133
                 },
@@ -326,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 151
                 },
@@ -335,7 +421,9 @@
                     "token": "TEXT",
                     "value": "TEXT",
                     "keyword": "TEXT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 9,
                     "position": 152
                 },
@@ -344,7 +432,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 156
                 },
@@ -353,7 +443,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -362,7 +454,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 158
                 },
@@ -371,7 +465,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -380,7 +476,9 @@
                     "token": "`where_text_var`",
                     "value": "where_text_var",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 161
                 },
@@ -389,7 +487,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 177
                 },
@@ -398,7 +498,9 @@
                     "token": "TEXT",
                     "value": "TEXT",
                     "keyword": "TEXT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 9,
                     "position": 178
                 },
@@ -407,7 +509,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 182
                 },
@@ -416,7 +520,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 183
                 },
@@ -425,7 +531,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 184
                 },
@@ -434,7 +542,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 186
                 },
@@ -443,7 +553,9 @@
                     "token": "`separator_value_var`",
                     "value": "separator_value_var",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 187
                 },
@@ -452,7 +564,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 208
                 },
@@ -461,7 +575,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 209
                 },
@@ -470,7 +586,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 216
                 },
@@ -479,7 +597,9 @@
                     "token": "255",
                     "value": 255,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 217
                 },
@@ -488,7 +608,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 220
                 },
@@ -497,7 +619,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 221
                 },
@@ -506,7 +630,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 222
                 },
@@ -515,7 +641,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 223
                 },
@@ -524,7 +652,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 230
                 },
@@ -533,7 +663,11 @@
                     "token": "'Query: SingleDB → MultiDB (All DBs) + run it'",
                     "value": "Query: SingleDB → MultiDB (All DBs) + run it",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 231
                 },
@@ -542,7 +676,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 277
                 },
@@ -551,7 +687,9 @@
                     "token": "NOT",
                     "value": "NOT",
                     "keyword": "NOT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 278
                 },
@@ -560,7 +698,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 281
                 },
@@ -569,7 +709,9 @@
                     "token": "DETERMINISTIC",
                     "value": "DETERMINISTIC",
                     "keyword": "DETERMINISTIC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 282
                 },
@@ -578,7 +720,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 295
                 },
@@ -587,7 +731,9 @@
                     "token": "MODIFIES SQL DATA",
                     "value": "MODIFIES SQL DATA",
                     "keyword": "MODIFIES SQL DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 7,
                     "position": 296
                 },
@@ -596,7 +742,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 313
                 },
@@ -605,7 +753,9 @@
                     "token": "SQL SECURITY",
                     "value": "SQL SECURITY",
                     "keyword": "SQL SECURITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 7,
                     "position": 314
                 },
@@ -614,7 +764,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 326
                 },
@@ -623,7 +775,9 @@
                     "token": "INVOKER",
                     "value": "INVOKER",
                     "keyword": "INVOKER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 327
                 },
@@ -632,7 +786,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 334
                 },
@@ -641,7 +797,9 @@
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 335
                 },
@@ -650,7 +808,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 340
                 },
@@ -659,7 +819,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 341
                 },
@@ -668,7 +830,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 344
                 },
@@ -677,7 +841,9 @@
                     "token": "@TABLE_NAME",
                     "value": "TABLE_NAME",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 345
                 },
@@ -686,7 +852,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 356
                 },
@@ -695,7 +863,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 357
                 },
@@ -704,7 +874,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 358
                 },
@@ -713,7 +885,9 @@
                     "token": "table_name_var",
                     "value": "table_name_var",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 359
                 },
@@ -722,7 +896,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 373
                 },
@@ -731,7 +907,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 374
                 },
@@ -740,7 +918,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 375
                 },
@@ -749,7 +929,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 378
                 },
@@ -758,7 +940,9 @@
                     "token": "@WHERE_TEXT",
                     "value": "WHERE_TEXT",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 379
                 },
@@ -767,7 +951,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 390
                 },
@@ -776,7 +962,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 391
                 },
@@ -785,7 +973,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 392
                 },
@@ -794,7 +984,9 @@
                     "token": "where_text_var",
                     "value": "where_text_var",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 393
                 },
@@ -803,7 +995,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 407
                 },
@@ -812,7 +1006,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 408
                 },
@@ -821,7 +1017,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 409
                 },
@@ -830,7 +1028,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 412
                 },
@@ -839,7 +1039,9 @@
                     "token": "@COLUMNS_USED",
                     "value": "COLUMNS_USED",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 413
                 },
@@ -848,7 +1050,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 426
                 },
@@ -857,7 +1061,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 427
                 },
@@ -866,7 +1072,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 428
                 },
@@ -875,7 +1083,9 @@
                     "token": "columns_used_var",
                     "value": "columns_used_var",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 429
                 },
@@ -884,7 +1094,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 445
                 },
@@ -893,7 +1105,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 446
                 },
@@ -902,7 +1116,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 447
                 },
@@ -911,7 +1127,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 450
                 },
@@ -920,7 +1138,9 @@
                     "token": "@MULTIDB_QUERY",
                     "value": "MULTIDB_QUERY",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 451
                 },
@@ -929,7 +1149,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 465
                 },
@@ -938,7 +1160,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 466
                 },
@@ -947,7 +1171,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 467
                 },
@@ -956,7 +1182,9 @@
                     "token": "CONCAT",
                     "value": "CONCAT",
                     "keyword": "CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 468
                 },
@@ -965,7 +1193,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 474
                 },
@@ -974,7 +1204,9 @@
                     "token": "'SELECT \"$MULTIDB\" FROM `$MULTIDB`.'",
                     "value": "SELECT \"$MULTIDB\" FROM `$MULTIDB`.",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 475
                 },
@@ -983,7 +1215,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 511
                 },
@@ -992,7 +1226,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 512
                 },
@@ -1001,7 +1237,9 @@
                     "token": "@TABLE_NAME",
                     "value": "TABLE_NAME",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 513
                 },
@@ -1010,7 +1248,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 524
                 },
@@ -1019,7 +1259,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 525
                 },
@@ -1028,7 +1270,9 @@
                     "token": "@WHERE_TEXT",
                     "value": "WHERE_TEXT",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 526
                 },
@@ -1037,7 +1281,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 537
                 },
@@ -1046,7 +1292,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 538
                 },
@@ -1055,7 +1303,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 539
                 },
@@ -1064,7 +1314,11 @@
                     "token": "-- EXECUTION --",
                     "value": "-- EXECUTION --",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 541
                 },
@@ -1073,7 +1327,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 556
                 },
@@ -1082,7 +1338,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 557
                 },
@@ -1091,7 +1349,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 563
                 },
@@ -1100,7 +1360,9 @@
                     "token": "TEMPORARY",
                     "value": "TEMPORARY",
                     "keyword": "TEMPORARY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 564
                 },
@@ -1109,7 +1371,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 573
                 },
@@ -1118,7 +1382,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 574
                 },
@@ -1127,7 +1393,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 579
                 },
@@ -1136,7 +1404,9 @@
                     "token": "`MULTIDB_TEMP_DB_TBL_COLS`",
                     "value": "MULTIDB_TEMP_DB_TBL_COLS",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 580
                 },
@@ -1145,7 +1415,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 606
                 },
@@ -1154,7 +1426,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 607
                 },
@@ -1163,7 +1437,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 609
                 },
@@ -1172,7 +1448,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 610
                 },
@@ -1181,7 +1459,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 616
                 },
@@ -1190,7 +1470,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 617
                 },
@@ -1199,7 +1481,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 618
                 },
@@ -1208,7 +1492,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 619
                 },
@@ -1217,7 +1503,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 623
                 },
@@ -1226,7 +1514,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 624
                 },
@@ -1235,7 +1525,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 625
                 },
@@ -1244,7 +1536,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 628
                 },
@@ -1253,7 +1547,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 634
                 },
@@ -1262,7 +1558,9 @@
                     "token": "TABLE_SCHEMA",
                     "value": "TABLE_SCHEMA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 635
                 },
@@ -1271,7 +1569,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 647
                 },
@@ -1280,7 +1580,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 648
                 },
@@ -1289,7 +1591,9 @@
                     "token": "TABLE_NAME",
                     "value": "TABLE_NAME",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 649
                 },
@@ -1298,7 +1602,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 659
                 },
@@ -1307,7 +1613,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 660
                 },
@@ -1316,7 +1624,9 @@
                     "token": "COLUMN_NAME",
                     "value": "COLUMN_NAME",
                     "keyword": "COLUMN_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 661
                 },
@@ -1325,7 +1635,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 672
                 },
@@ -1334,7 +1646,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 675
                 },
@@ -1343,7 +1657,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 679
                 },
@@ -1352,7 +1668,9 @@
                     "token": "INFORMATION_SCHEMA",
                     "value": "INFORMATION_SCHEMA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 680
                 },
@@ -1361,7 +1679,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 698
                 },
@@ -1370,7 +1690,9 @@
                     "token": "COLUMNS",
                     "value": "COLUMNS",
                     "keyword": "COLUMNS",
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 699
                 },
@@ -1379,7 +1701,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 706
                 },
@@ -1388,7 +1712,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 709
                 },
@@ -1397,7 +1723,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 714
                 },
@@ -1406,7 +1734,9 @@
                     "token": "TABLE_SCHEMA",
                     "value": "TABLE_SCHEMA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 719
                 },
@@ -1415,7 +1745,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 731
                 },
@@ -1424,7 +1756,9 @@
                     "token": "NOT IN",
                     "value": "NOT IN",
                     "keyword": "NOT IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 39,
                     "position": 732
                 },
@@ -1433,7 +1767,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 738
                 },
@@ -1442,7 +1778,9 @@
                     "token": "'mysql'",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 739
                 },
@@ -1451,7 +1789,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 746
                 },
@@ -1460,7 +1800,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 747
                 },
@@ -1469,7 +1811,9 @@
                     "token": "'test'",
                     "value": "test",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 748
                 },
@@ -1478,7 +1822,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 754
                 },
@@ -1487,7 +1833,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 755
                 },
@@ -1496,7 +1844,9 @@
                     "token": "'tmp'",
                     "value": "tmp",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 756
                 },
@@ -1505,7 +1855,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 761
                 },
@@ -1514,7 +1866,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 762
                 },
@@ -1523,7 +1877,9 @@
                     "token": "'information_schema'",
                     "value": "information_schema",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 763
                 },
@@ -1532,7 +1888,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 783
                 },
@@ -1541,7 +1899,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 784
                 },
@@ -1550,7 +1910,9 @@
                     "token": "'sys'",
                     "value": "sys",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 785
                 },
@@ -1559,7 +1921,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 790
                 },
@@ -1568,7 +1932,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 791
                 },
@@ -1577,7 +1943,9 @@
                     "token": "'performance_schema'",
                     "value": "performance_schema",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 792
                 },
@@ -1586,7 +1954,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 812
                 },
@@ -1595,7 +1965,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 813
                 },
@@ -1604,7 +1976,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 814
                 },
@@ -1613,7 +1987,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 817
                 },
@@ -1622,7 +1998,9 @@
                     "token": "TABLE_NAME",
                     "value": "TABLE_NAME",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 822
                 },
@@ -1631,7 +2009,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 832
                 },
@@ -1640,7 +2020,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 833
                 },
@@ -1649,7 +2031,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 834
                 },
@@ -1658,7 +2042,9 @@
                     "token": "@TABLE_NAME",
                     "value": "TABLE_NAME",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 835
                 },
@@ -1667,7 +2053,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 846
                 },
@@ -1676,7 +2064,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 847
                 },
@@ -1685,7 +2075,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 850
                 },
@@ -1694,7 +2086,9 @@
                     "token": "FIND_IN_SET",
                     "value": "FIND_IN_SET",
                     "keyword": "FIND_IN_SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 855
                 },
@@ -1703,7 +2097,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 866
                 },
@@ -1712,7 +2108,9 @@
                     "token": "COLUMN_NAME",
                     "value": "COLUMN_NAME",
                     "keyword": "COLUMN_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 867
                 },
@@ -1721,7 +2119,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 878
                 },
@@ -1730,7 +2130,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 879
                 },
@@ -1739,7 +2141,9 @@
                     "token": "@COLUMNS_USED",
                     "value": "COLUMNS_USED",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 880
                 },
@@ -1748,7 +2152,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 893
                 },
@@ -1757,7 +2163,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 894
                 },
@@ -1766,7 +2174,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 895
                 },
@@ -1775,7 +2185,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 896
                 },
@@ -1784,7 +2196,9 @@
                     "token": "tbl",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 897
                 },
@@ -1793,7 +2207,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 900
                 },
@@ -1802,7 +2218,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 7,
                     "position": 901
                 },
@@ -1811,7 +2229,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 909
                 },
@@ -1820,7 +2240,9 @@
                     "token": "TABLE_SCHEMA",
                     "value": "TABLE_SCHEMA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 912
                 },
@@ -1829,7 +2251,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 924
                 },
@@ -1838,7 +2262,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 925
                 },
@@ -1847,7 +2273,9 @@
                     "token": "TABLE_NAME",
                     "value": "TABLE_NAME",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 928
                 },
@@ -1856,7 +2284,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 938
                 },
@@ -1865,7 +2295,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 939
                 },
@@ -1874,7 +2306,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 941
                 },
@@ -1883,7 +2317,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 947
                 },
@@ -1892,7 +2328,9 @@
                     "token": "GROUP_CONCAT",
                     "value": "GROUP_CONCAT",
                     "keyword": "GROUP_CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 948
                 },
@@ -1901,7 +2339,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 960
                 },
@@ -1910,7 +2350,9 @@
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 961
                 },
@@ -1919,7 +2361,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 968
                 },
@@ -1928,7 +2372,9 @@
                     "token": "@MULTIDB_QUERY",
                     "value": "MULTIDB_QUERY",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 969
                 },
@@ -1937,7 +2383,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 983
                 },
@@ -1946,7 +2394,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 984
                 },
@@ -1955,7 +2405,9 @@
                     "token": "'$MULTIDB'",
                     "value": "$MULTIDB",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 985
                 },
@@ -1964,7 +2416,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 995
                 },
@@ -1973,7 +2427,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 996
                 },
@@ -1982,7 +2438,9 @@
                     "token": "CONCAT",
                     "value": "CONCAT",
                     "keyword": "CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 997
                 },
@@ -1991,7 +2449,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1003
                 },
@@ -2000,7 +2460,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1004
                 },
@@ -2009,7 +2471,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1006
                 },
@@ -2018,7 +2482,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1007
                 },
@@ -2027,7 +2493,9 @@
                     "token": "TABLE_SCHEMA",
                     "value": "TABLE_SCHEMA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1008
                 },
@@ -2036,7 +2504,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1020
                 },
@@ -2045,7 +2515,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1021
                 },
@@ -2054,7 +2526,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1022
                 },
@@ -2063,7 +2537,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1024
                 },
@@ -2072,7 +2548,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1025
                 },
@@ -2081,7 +2559,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1026
                 },
@@ -2090,7 +2570,9 @@
                     "token": "SEPARATOR",
                     "value": "SEPARATOR",
                     "keyword": "SEPARATOR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1027
                 },
@@ -2099,7 +2581,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1036
                 },
@@ -2108,7 +2592,9 @@
                     "token": "\"\\nUNION ALL\\n\"",
                     "value": "\nUNION ALL\n",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 2,
                     "position": 1037
                 },
@@ -2117,7 +2603,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1052
                 },
@@ -2126,7 +2614,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1053
                 },
@@ -2135,7 +2625,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1054
                 },
@@ -2144,7 +2636,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1058
                 },
@@ -2153,7 +2647,9 @@
                     "token": "@stmt_sql",
                     "value": "stmt_sql",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 1059
                 },
@@ -2162,7 +2658,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1068
                 },
@@ -2171,7 +2669,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1069
                 },
@@ -2180,7 +2680,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1073
                 },
@@ -2189,7 +2691,9 @@
                     "token": "`MULTIDB_TEMP_DB_TBL_COLS`",
                     "value": "MULTIDB_TEMP_DB_TBL_COLS",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 1074
                 },
@@ -2198,7 +2702,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1100
                 },
@@ -2207,7 +2713,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1101
                 },
@@ -2216,7 +2724,9 @@
                     "token": "PREPARE",
                     "value": "PREPARE",
                     "keyword": "PREPARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1103
                 },
@@ -2225,7 +2735,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1110
                 },
@@ -2234,7 +2746,9 @@
                     "token": "stmt",
                     "value": "stmt",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1111
                 },
@@ -2243,7 +2757,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1115
                 },
@@ -2252,7 +2768,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1116
                 },
@@ -2261,7 +2779,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1120
                 },
@@ -2270,7 +2790,9 @@
                     "token": "@stmt_sql",
                     "value": "stmt_sql",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 1121
                 },
@@ -2279,7 +2801,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1130
                 },
@@ -2288,7 +2812,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1131
                 },
@@ -2297,7 +2823,9 @@
                     "token": "EXECUTE",
                     "value": "EXECUTE",
                     "keyword": "EXECUTE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1132
                 },
@@ -2306,7 +2834,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1139
                 },
@@ -2315,7 +2845,9 @@
                     "token": "stmt",
                     "value": "stmt",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1140
                 },
@@ -2324,7 +2856,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1144
                 },
@@ -2333,7 +2867,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1145
                 },
@@ -2342,7 +2878,9 @@
                     "token": "DEALLOCATE",
                     "value": "DEALLOCATE",
                     "keyword": "DEALLOCATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1146
                 },
@@ -2351,7 +2889,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1156
                 },
@@ -2360,7 +2900,9 @@
                     "token": "PREPARE",
                     "value": "PREPARE",
                     "keyword": "PREPARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1157
                 },
@@ -2369,7 +2911,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1164
                 },
@@ -2378,7 +2922,9 @@
                     "token": "stmt",
                     "value": "stmt",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1165
                 },
@@ -2387,7 +2933,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1169
                 },
@@ -2396,7 +2944,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1170
                 },
@@ -2405,7 +2955,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1171
                 },
@@ -2414,7 +2966,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 0,
                     "position": 1174
                 },
@@ -2423,7 +2977,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1176
                 },
@@ -2432,7 +2988,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@128"
+                    },
                     "flags": 4,
                     "position": 1178
                 },
@@ -2441,7 +2999,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1180
                 },
@@ -2450,7 +3010,9 @@
                     "token": "-- Functions",
                     "value": "-- Functions",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@128"
+                    },
                     "flags": 4,
                     "position": 1181
                 },
@@ -2459,7 +3021,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1193
                 },
@@ -2468,7 +3032,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@128"
+                    },
                     "flags": 4,
                     "position": 1194
                 },
@@ -2477,7 +3043,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1196
                 },
@@ -2486,7 +3054,9 @@
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1197
                 },
@@ -2495,7 +3065,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1206
                 },
@@ -2504,7 +3076,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 0,
                     "position": 1207
                 },
@@ -2513,7 +3087,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1209
                 },
@@ -2522,7 +3098,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1210
                 },
@@ -2531,7 +3109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1216
                 },
@@ -2540,7 +3120,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1217
                 },
@@ -2549,7 +3131,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 1224
                 },
@@ -2558,7 +3142,9 @@
                     "token": "`root`@`localhost`",
                     "value": "root@localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 4,
                     "position": 1225
                 },
@@ -2567,7 +3153,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1243
                 },
@@ -2576,7 +3164,9 @@
                     "token": "FUNCTION",
                     "value": "FUNCTION",
                     "keyword": "FUNCTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1244
                 },
@@ -2585,7 +3175,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1252
                 },
@@ -2594,7 +3186,9 @@
                     "token": "`attrParentShiftIds`",
                     "value": "attrParentShiftIds",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 1253
                 },
@@ -2603,7 +3197,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1273
                 },
@@ -2612,7 +3208,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1274
                 },
@@ -2621,7 +3219,9 @@
                     "token": "`parent_id`",
                     "value": "parent_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 1275
                 },
@@ -2630,7 +3230,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1286
                 },
@@ -2639,7 +3241,9 @@
                     "token": "TEXT",
                     "value": "TEXT",
                     "keyword": "TEXT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 9,
                     "position": 1287
                 },
@@ -2648,7 +3252,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1291
                 },
@@ -2657,7 +3263,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1292
                 },
@@ -2666,7 +3274,9 @@
                     "token": "`option_id_shift`",
                     "value": "option_id_shift",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 1293
                 },
@@ -2675,7 +3285,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1310
                 },
@@ -2684,7 +3296,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1311
                 },
@@ -2693,7 +3307,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1314
                 },
@@ -2702,7 +3318,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1315
                 },
@@ -2711,7 +3329,9 @@
                     "token": "`option_value_id_shift`",
                     "value": "option_value_id_shift",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 1316
                 },
@@ -2720,7 +3340,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1339
                 },
@@ -2729,7 +3351,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1340
                 },
@@ -2738,7 +3362,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1343
                 },
@@ -2747,7 +3373,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1344
                 },
@@ -2756,7 +3384,9 @@
                     "token": "RETURNS",
                     "value": "RETURNS",
                     "keyword": "RETURNS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1345
                 },
@@ -2765,7 +3395,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1352
                 },
@@ -2774,7 +3406,9 @@
                     "token": "TEXT",
                     "value": "TEXT",
                     "keyword": "TEXT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 9,
                     "position": 1353
                 },
@@ -2783,7 +3417,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1357
                 },
@@ -2792,7 +3428,9 @@
                     "token": "CHARSET",
                     "value": "CHARSET",
                     "keyword": "CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 1358
                 },
@@ -2801,7 +3439,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1365
                 },
@@ -2810,7 +3450,9 @@
                     "token": "utf8mb4",
                     "value": "utf8mb4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1366
                 },
@@ -2819,7 +3461,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1373
                 },
@@ -2828,7 +3472,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1374
                 },
@@ -2837,7 +3483,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1381
                 },
@@ -2846,7 +3494,9 @@
                     "token": "utf8mb4_unicode_520_ci",
                     "value": "utf8mb4_unicode_520_ci",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1382
                 },
@@ -2855,7 +3505,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1404
                 },
@@ -2864,7 +3516,9 @@
                     "token": "DETERMINISTIC",
                     "value": "DETERMINISTIC",
                     "keyword": "DETERMINISTIC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1405
                 },
@@ -2873,7 +3527,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1418
                 },
@@ -2882,7 +3538,9 @@
                     "token": "READS SQL DATA",
                     "value": "READS SQL DATA",
                     "keyword": "READS SQL DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 7,
                     "position": 1419
                 },
@@ -2891,7 +3549,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1433
                 },
@@ -2900,7 +3560,9 @@
                     "token": "SQL SECURITY",
                     "value": "SQL SECURITY",
                     "keyword": "SQL SECURITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 7,
                     "position": 1434
                 },
@@ -2909,7 +3571,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1446
                 },
@@ -2918,7 +3582,9 @@
                     "token": "INVOKER",
                     "value": "INVOKER",
                     "keyword": "INVOKER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1447
                 },
@@ -2927,7 +3593,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1454
                 },
@@ -2936,7 +3604,9 @@
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1455
                 },
@@ -2945,7 +3615,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1460
                 },
@@ -2954,7 +3626,9 @@
                     "token": "DECLARE",
                     "value": "DECLARE",
                     "keyword": "DECLARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1463
                 },
@@ -2963,7 +3637,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1470
                 },
@@ -2972,7 +3648,9 @@
                     "token": "i",
                     "value": "i",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1471
                 },
@@ -2981,7 +3659,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1472
                 },
@@ -2990,7 +3670,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1473
                 },
@@ -2999,7 +3681,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1476
                 },
@@ -3008,7 +3692,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1477
                 },
@@ -3017,7 +3703,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1485
                 },
@@ -3026,7 +3714,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 1486
                 },
@@ -3035,7 +3725,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1493
                 },
@@ -3044,7 +3736,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 1494
                 },
@@ -3053,7 +3747,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1495
                 },
@@ -3062,7 +3758,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1496
                 },
@@ -3071,7 +3769,9 @@
                     "token": "DECLARE",
                     "value": "DECLARE",
                     "keyword": "DECLARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1499
                 },
@@ -3080,7 +3780,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1506
                 },
@@ -3089,7 +3791,9 @@
                     "token": "pair_count",
                     "value": "pair_count",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1507
                 },
@@ -3098,7 +3802,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1517
                 },
@@ -3107,7 +3813,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1518
                 },
@@ -3116,7 +3824,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1521
                 },
@@ -3125,7 +3835,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1522
                 },
@@ -3134,7 +3846,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1530
                 },
@@ -3143,7 +3857,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1531
                 },
@@ -3152,7 +3868,9 @@
                     "token": "DECLARE",
                     "value": "DECLARE",
                     "keyword": "DECLARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1534
                 },
@@ -3161,7 +3879,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1541
                 },
@@ -3170,7 +3890,9 @@
                     "token": "result",
                     "value": "result",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1542
                 },
@@ -3179,7 +3901,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1548
                 },
@@ -3188,7 +3912,9 @@
                     "token": "TEXT",
                     "value": "TEXT",
                     "keyword": "TEXT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 9,
                     "position": 1549
                 },
@@ -3197,7 +3923,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1553
                 },
@@ -3206,7 +3934,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 1554
                 },
@@ -3215,7 +3945,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1561
                 },
@@ -3224,7 +3956,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1562
                 },
@@ -3233,7 +3967,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1564
                 },
@@ -3242,7 +3978,9 @@
                     "token": "\n\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1565
                 },
@@ -3251,7 +3989,9 @@
                     "token": "DECLARE",
                     "value": "DECLARE",
                     "keyword": "DECLARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1569
                 },
@@ -3260,7 +4000,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1576
                 },
@@ -3269,7 +4011,9 @@
                     "token": "pair",
                     "value": "pair",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1577
                 },
@@ -3278,7 +4022,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1581
                 },
@@ -3287,7 +4033,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1582
                 },
@@ -3296,7 +4044,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1589
                 },
@@ -3305,7 +4055,9 @@
                     "token": "255",
                     "value": 255,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 1590
                 },
@@ -3314,7 +4066,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1593
                 },
@@ -3323,7 +4077,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1594
                 },
@@ -3332,7 +4088,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 1595
                 },
@@ -3341,7 +4099,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1602
                 },
@@ -3350,7 +4110,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1603
                 },
@@ -3359,7 +4121,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1605
                 },
@@ -3368,7 +4132,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1606
                 },
@@ -3377,7 +4143,9 @@
                     "token": "DECLARE",
                     "value": "DECLARE",
                     "keyword": "DECLARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1609
                 },
@@ -3386,7 +4154,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1616
                 },
@@ -3395,7 +4165,9 @@
                     "token": "oid",
                     "value": "oid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1617
                 },
@@ -3404,7 +4176,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1620
                 },
@@ -3413,7 +4187,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1621
                 },
@@ -3422,7 +4198,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1624
                 },
@@ -3431,7 +4209,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 1625
                 },
@@ -3440,7 +4220,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1632
                 },
@@ -3449,7 +4231,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1633
                 },
@@ -3458,7 +4242,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1635
                 },
@@ -3467,7 +4253,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1636
                 },
@@ -3476,7 +4264,9 @@
                     "token": "DECLARE",
                     "value": "DECLARE",
                     "keyword": "DECLARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1639
                 },
@@ -3485,7 +4275,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1646
                 },
@@ -3494,7 +4286,9 @@
                     "token": "vid",
                     "value": "vid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1647
                 },
@@ -3503,7 +4297,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1650
                 },
@@ -3512,7 +4308,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1651
                 },
@@ -3521,7 +4319,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1654
                 },
@@ -3530,7 +4330,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 1655
                 },
@@ -3539,7 +4341,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1662
                 },
@@ -3548,7 +4352,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1663
                 },
@@ -3557,7 +4363,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1665
                 },
@@ -3566,7 +4374,9 @@
                     "token": "\n\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1666
                 },
@@ -3575,7 +4385,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1670
                 },
@@ -3584,7 +4396,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1673
                 },
@@ -3593,7 +4407,9 @@
                     "token": "pair_count",
                     "value": "pair_count",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1674
                 },
@@ -3602,7 +4418,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1684
                 },
@@ -3611,7 +4429,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 1685
                 },
@@ -3620,7 +4440,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1686
                 },
@@ -3629,7 +4451,9 @@
                     "token": "substrCount",
                     "value": "substrCount",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1687
                 },
@@ -3638,7 +4462,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1698
                 },
@@ -3647,7 +4473,9 @@
                     "token": "parent_id",
                     "value": "parent_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1699
                 },
@@ -3656,7 +4484,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1708
                 },
@@ -3665,7 +4495,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1709
                 },
@@ -3674,7 +4506,9 @@
                     "token": "','",
                     "value": ",",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1710
                 },
@@ -3683,7 +4517,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1713
                 },
@@ -3692,7 +4528,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1714
                 },
@@ -3701,7 +4539,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 1,
                     "position": 1715
                 },
@@ -3710,7 +4550,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1716
                 },
@@ -3719,7 +4561,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 1717
                 },
@@ -3728,7 +4572,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1718
                 },
@@ -3737,7 +4583,9 @@
                     "token": "\n\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1719
                 },
@@ -3746,7 +4594,9 @@
                     "token": "WHILE",
                     "value": "WHILE",
                     "keyword": "WHILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 1723
                 },
@@ -3755,7 +4605,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1728
                 },
@@ -3764,7 +4616,9 @@
                     "token": "i",
                     "value": "i",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1729
                 },
@@ -3773,7 +4627,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1730
                 },
@@ -3782,7 +4638,9 @@
                     "token": "<",
                     "value": "<",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 1731
                 },
@@ -3791,7 +4649,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1732
                 },
@@ -3800,7 +4660,9 @@
                     "token": "pair_count",
                     "value": "pair_count",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1733
                 },
@@ -3809,7 +4671,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1743
                 },
@@ -3818,7 +4682,9 @@
                     "token": "DO",
                     "value": "DO",
                     "keyword": "DO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 1744
                 },
@@ -3827,7 +4693,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1746
                 },
@@ -3836,7 +4704,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1751
                 },
@@ -3845,7 +4715,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1754
                 },
@@ -3854,7 +4726,9 @@
                     "token": "result",
                     "value": "result",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1755
                 },
@@ -3863,7 +4737,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1761
                 },
@@ -3872,7 +4748,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 1762
                 },
@@ -3881,7 +4759,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1763
                 },
@@ -3890,7 +4770,9 @@
                     "token": "CONCAT",
                     "value": "CONCAT",
                     "keyword": "CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 1764
                 },
@@ -3899,7 +4781,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1770
                 },
@@ -3908,7 +4792,9 @@
                     "token": "result",
                     "value": "result",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1771
                 },
@@ -3917,7 +4803,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1777
                 },
@@ -3926,7 +4814,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1778
                 },
@@ -3935,7 +4825,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 1779
                 },
@@ -3944,7 +4836,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1781
                 },
@@ -3953,7 +4847,9 @@
                     "token": "i",
                     "value": "i",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1782
                 },
@@ -3962,7 +4858,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1783
                 },
@@ -3971,7 +4869,9 @@
                     "token": "<=",
                     "value": "<=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 1784
                 },
@@ -3980,7 +4880,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1786
                 },
@@ -3989,7 +4891,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 1787
                 },
@@ -3998,7 +4902,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1788
                 },
@@ -4007,7 +4913,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1789
                 },
@@ -4016,7 +4924,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1790
                 },
@@ -4025,7 +4935,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1792
                 },
@@ -4034,7 +4946,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1793
                 },
@@ -4043,7 +4957,9 @@
                     "token": "','",
                     "value": ",",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1794
                 },
@@ -4052,7 +4968,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1797
                 },
@@ -4061,7 +4979,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1798
                 },
@@ -4070,7 +4990,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1799
                 },
@@ -4079,7 +5001,9 @@
                     "token": "\n\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1800
                 },
@@ -4088,7 +5012,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1806
                 },
@@ -4097,7 +5023,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1809
                 },
@@ -4106,7 +5034,9 @@
                     "token": "pair",
                     "value": "pair",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1810
                 },
@@ -4115,7 +5045,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1814
                 },
@@ -4124,7 +5056,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 1815
                 },
@@ -4133,7 +5067,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1816
                 },
@@ -4142,7 +5078,9 @@
                     "token": "split",
                     "value": "split",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1817
                 },
@@ -4151,7 +5089,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1822
                 },
@@ -4160,7 +5100,9 @@
                     "token": "parent_id",
                     "value": "parent_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1823
                 },
@@ -4169,7 +5111,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1832
                 },
@@ -4178,7 +5122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1833
                 },
@@ -4187,7 +5133,9 @@
                     "token": "','",
                     "value": ",",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1834
                 },
@@ -4196,7 +5144,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1837
                 },
@@ -4205,7 +5155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1838
                 },
@@ -4214,7 +5166,9 @@
                     "token": "i",
                     "value": "i",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1839
                 },
@@ -4223,7 +5177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1840
                 },
@@ -4232,7 +5188,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 1,
                     "position": 1841
                 },
@@ -4241,7 +5199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1842
                 },
@@ -4250,7 +5210,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 1843
                 },
@@ -4259,7 +5221,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1844
                 },
@@ -4268,7 +5232,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1845
                 },
@@ -4277,7 +5243,9 @@
                     "token": "\n\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1846
                 },
@@ -4286,7 +5254,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1852
                 },
@@ -4295,7 +5265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1855
                 },
@@ -4304,7 +5276,9 @@
                     "token": "oid",
                     "value": "oid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1856
                 },
@@ -4313,7 +5287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1859
                 },
@@ -4322,7 +5298,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 1860
                 },
@@ -4331,7 +5309,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1861
                 },
@@ -4340,7 +5320,9 @@
                     "token": "split",
                     "value": "split",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1862
                 },
@@ -4349,7 +5331,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1867
                 },
@@ -4358,7 +5342,9 @@
                     "token": "pair",
                     "value": "pair",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1868
                 },
@@ -4367,7 +5353,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1872
                 },
@@ -4376,7 +5364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1873
                 },
@@ -4385,7 +5375,9 @@
                     "token": "'-'",
                     "value": "-",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1874
                 },
@@ -4394,7 +5386,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1877
                 },
@@ -4403,7 +5397,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1878
                 },
@@ -4412,7 +5408,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 1879
                 },
@@ -4421,7 +5419,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1880
                 },
@@ -4430,7 +5430,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1881
                 },
@@ -4439,7 +5441,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 1,
                     "position": 1882
                 },
@@ -4448,7 +5452,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1883
                 },
@@ -4457,7 +5463,9 @@
                     "token": "option_id_shift",
                     "value": "option_id_shift",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1884
                 },
@@ -4466,7 +5474,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1899
                 },
@@ -4475,7 +5485,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1900
                 },
@@ -4484,7 +5496,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1905
                 },
@@ -4493,7 +5507,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1908
                 },
@@ -4502,7 +5518,9 @@
                     "token": "vid",
                     "value": "vid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1909
                 },
@@ -4511,7 +5529,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1912
                 },
@@ -4520,7 +5540,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 1913
                 },
@@ -4529,7 +5551,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1914
                 },
@@ -4538,7 +5562,9 @@
                     "token": "split",
                     "value": "split",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1915
                 },
@@ -4547,7 +5573,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1920
                 },
@@ -4556,7 +5584,9 @@
                     "token": "pair",
                     "value": "pair",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1921
                 },
@@ -4565,7 +5595,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1925
                 },
@@ -4574,7 +5606,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1926
                 },
@@ -4583,7 +5617,9 @@
                     "token": "'-'",
                     "value": "-",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1927
                 },
@@ -4592,7 +5628,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1930
                 },
@@ -4601,7 +5639,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1931
                 },
@@ -4610,7 +5650,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 1932
                 },
@@ -4619,7 +5661,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1933
                 },
@@ -4628,7 +5672,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1934
                 },
@@ -4637,7 +5683,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 1,
                     "position": 1935
                 },
@@ -4646,7 +5694,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1936
                 },
@@ -4655,7 +5705,9 @@
                     "token": "option_value_id_shift",
                     "value": "option_value_id_shift",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1937
                 },
@@ -4664,7 +5716,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1958
                 },
@@ -4673,7 +5727,9 @@
                     "token": "\n\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1959
                 },
@@ -4682,7 +5738,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 1965
                 },
@@ -4691,7 +5749,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1968
                 },
@@ -4700,7 +5760,9 @@
                     "token": "pair",
                     "value": "pair",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1969
                 },
@@ -4709,7 +5771,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1973
                 },
@@ -4718,7 +5782,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 1974
                 },
@@ -4727,7 +5793,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1975
                 },
@@ -4736,7 +5804,9 @@
                     "token": "CONCAT",
                     "value": "CONCAT",
                     "keyword": "CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 1976
                 },
@@ -4745,7 +5815,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1982
                 },
@@ -4754,7 +5826,9 @@
                     "token": "oid",
                     "value": "oid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1983
                 },
@@ -4763,7 +5837,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1986
                 },
@@ -4772,7 +5848,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1987
                 },
@@ -4781,7 +5859,9 @@
                     "token": "'-'",
                     "value": "-",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 1988
                 },
@@ -4790,7 +5870,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1991
                 },
@@ -4799,7 +5881,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1992
                 },
@@ -4808,7 +5892,9 @@
                     "token": "vid",
                     "value": "vid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 1993
                 },
@@ -4817,7 +5903,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1996
                 },
@@ -4826,7 +5914,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 1997
                 },
@@ -4835,7 +5925,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1998
                 },
@@ -4844,7 +5936,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2003
                 },
@@ -4853,7 +5947,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2006
                 },
@@ -4862,7 +5958,9 @@
                     "token": "result",
                     "value": "result",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2007
                 },
@@ -4871,7 +5969,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2013
                 },
@@ -4880,7 +5980,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2014
                 },
@@ -4889,7 +5991,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2015
                 },
@@ -4898,7 +6002,9 @@
                     "token": "CONCAT",
                     "value": "CONCAT",
                     "keyword": "CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2016
                 },
@@ -4907,7 +6013,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2022
                 },
@@ -4916,7 +6024,9 @@
                     "token": "result",
                     "value": "result",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2023
                 },
@@ -4925,7 +6035,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2029
                 },
@@ -4934,7 +6046,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2030
                 },
@@ -4943,7 +6057,9 @@
                     "token": "pair",
                     "value": "pair",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2031
                 },
@@ -4952,7 +6068,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2035
                 },
@@ -4961,7 +6079,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2036
                 },
@@ -4970,7 +6090,9 @@
                     "token": "\n\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2037
                 },
@@ -4979,7 +6101,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2043
                 },
@@ -4988,7 +6112,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2046
                 },
@@ -4997,7 +6123,9 @@
                     "token": "i",
                     "value": "i",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2047
                 },
@@ -5006,7 +6134,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2048
                 },
@@ -5015,7 +6145,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2049
                 },
@@ -5024,7 +6156,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2050
                 },
@@ -5033,7 +6167,9 @@
                     "token": "i",
                     "value": "i",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2051
                 },
@@ -5042,7 +6178,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2052
                 },
@@ -5051,7 +6189,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 1,
                     "position": 2053
                 },
@@ -5060,7 +6200,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2054
                 },
@@ -5069,7 +6211,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2055
                 },
@@ -5078,7 +6222,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2056
                 },
@@ -5087,7 +6233,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2057
                 },
@@ -5096,7 +6244,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2060
                 },
@@ -5105,7 +6255,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2063
                 },
@@ -5114,7 +6266,9 @@
                     "token": "WHILE",
                     "value": "WHILE",
                     "keyword": "WHILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2064
                 },
@@ -5123,7 +6277,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2069
                 },
@@ -5132,7 +6288,9 @@
                     "token": "\n\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2070
                 },
@@ -5141,7 +6299,9 @@
                     "token": "RETURN",
                     "value": "RETURN",
                     "keyword": "RETURN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2074
                 },
@@ -5150,7 +6310,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2080
                 },
@@ -5159,7 +6321,9 @@
                     "token": "result",
                     "value": "result",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2081
                 },
@@ -5168,7 +6332,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2087
                 },
@@ -5177,7 +6343,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2088
                 },
@@ -5186,7 +6354,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2089
                 },
@@ -5195,7 +6365,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 0,
                     "position": 2092
                 },
@@ -5204,7 +6376,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2094
                 },
@@ -5213,7 +6387,9 @@
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2096
                 },
@@ -5222,7 +6398,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2105
                 },
@@ -5231,7 +6409,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 0,
                     "position": 2106
                 },
@@ -5240,7 +6420,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2108
                 },
@@ -5249,7 +6431,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2109
                 },
@@ -5258,7 +6442,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2115
                 },
@@ -5267,7 +6453,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2116
                 },
@@ -5276,7 +6464,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2123
                 },
@@ -5285,7 +6475,9 @@
                     "token": "`user`@`localhost`",
                     "value": "user@localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 4,
                     "position": 2124
                 },
@@ -5294,7 +6486,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2142
                 },
@@ -5303,7 +6497,9 @@
                     "token": "FUNCTION",
                     "value": "FUNCTION",
                     "keyword": "FUNCTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2143
                 },
@@ -5312,7 +6508,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2151
                 },
@@ -5321,7 +6519,9 @@
                     "token": "`split`",
                     "value": "split",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 2152
                 },
@@ -5330,7 +6530,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2159
                 },
@@ -5339,7 +6541,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2160
                 },
@@ -5348,7 +6552,9 @@
                     "token": "`string`",
                     "value": "string",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 2161
                 },
@@ -5357,7 +6563,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2169
                 },
@@ -5366,7 +6574,9 @@
                     "token": "TEXT",
                     "value": "TEXT",
                     "keyword": "TEXT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 9,
                     "position": 2170
                 },
@@ -5375,7 +6585,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2174
                 },
@@ -5384,7 +6596,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2175
                 },
@@ -5393,7 +6607,9 @@
                     "token": "`delim`",
                     "value": "delim",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 2176
                 },
@@ -5402,7 +6618,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2183
                 },
@@ -5411,7 +6629,9 @@
                     "token": "TEXT",
                     "value": "TEXT",
                     "keyword": "TEXT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 9,
                     "position": 2184
                 },
@@ -5420,7 +6640,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2188
                 },
@@ -5429,7 +6651,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2189
                 },
@@ -5438,7 +6662,9 @@
                     "token": "`n`",
                     "value": "n",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 2190
                 },
@@ -5447,7 +6673,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2193
                 },
@@ -5456,7 +6684,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2194
                 },
@@ -5465,7 +6695,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2197
                 },
@@ -5474,7 +6706,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2198
                 },
@@ -5483,7 +6717,9 @@
                     "token": "RETURNS",
                     "value": "RETURNS",
                     "keyword": "RETURNS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2199
                 },
@@ -5492,7 +6728,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2206
                 },
@@ -5501,7 +6739,9 @@
                     "token": "TEXT",
                     "value": "TEXT",
                     "keyword": "TEXT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 9,
                     "position": 2207
                 },
@@ -5510,7 +6750,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2211
                 },
@@ -5519,7 +6761,9 @@
                     "token": "CHARSET",
                     "value": "CHARSET",
                     "keyword": "CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2212
                 },
@@ -5528,7 +6772,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2219
                 },
@@ -5537,7 +6783,9 @@
                     "token": "utf8mb4",
                     "value": "utf8mb4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2220
                 },
@@ -5546,7 +6794,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2227
                 },
@@ -5555,7 +6805,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2228
                 },
@@ -5564,7 +6816,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2235
                 },
@@ -5573,7 +6827,9 @@
                     "token": "utf8mb4_unicode_520_ci",
                     "value": "utf8mb4_unicode_520_ci",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2236
                 },
@@ -5582,7 +6838,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2258
                 },
@@ -5591,7 +6849,9 @@
                     "token": "DETERMINISTIC",
                     "value": "DETERMINISTIC",
                     "keyword": "DETERMINISTIC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2259
                 },
@@ -5600,7 +6860,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2272
                 },
@@ -5609,7 +6871,9 @@
                     "token": "SQL SECURITY",
                     "value": "SQL SECURITY",
                     "keyword": "SQL SECURITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 7,
                     "position": 2273
                 },
@@ -5618,7 +6882,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2285
                 },
@@ -5627,7 +6893,9 @@
                     "token": "INVOKER",
                     "value": "INVOKER",
                     "keyword": "INVOKER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2286
                 },
@@ -5636,7 +6904,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2293
                 },
@@ -5645,7 +6915,9 @@
                     "token": "RETURN",
                     "value": "RETURN",
                     "keyword": "RETURN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2294
                 },
@@ -5654,7 +6926,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2300
                 },
@@ -5663,7 +6937,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 2301
                 },
@@ -5672,7 +6948,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2303
                 },
@@ -5681,7 +6959,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2304
                 },
@@ -5690,7 +6970,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2309
                 },
@@ -5699,7 +6981,9 @@
                     "token": "LENGTH",
                     "value": "LENGTH",
                     "keyword": "LENGTH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2310
                 },
@@ -5708,7 +6992,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2316
                 },
@@ -5717,7 +7003,9 @@
                     "token": "string",
                     "value": "string",
                     "keyword": "STRING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2317
                 },
@@ -5726,7 +7014,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2323
                 },
@@ -5735,7 +7025,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2324
                 },
@@ -5744,7 +7036,9 @@
                     "token": "-",
                     "value": "-",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 1,
                     "position": 2325
                 },
@@ -5753,7 +7047,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2326
                 },
@@ -5762,7 +7058,9 @@
                     "token": "LENGTH",
                     "value": "LENGTH",
                     "keyword": "LENGTH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2327
                 },
@@ -5771,7 +7069,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2333
                 },
@@ -5780,7 +7080,9 @@
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 2334
                 },
@@ -5789,7 +7091,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2341
                 },
@@ -5798,7 +7102,9 @@
                     "token": "string",
                     "value": "string",
                     "keyword": "STRING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2342
                 },
@@ -5807,7 +7113,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2348
                 },
@@ -5816,7 +7124,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2349
                 },
@@ -5825,7 +7135,9 @@
                     "token": "delim",
                     "value": "delim",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2350
                 },
@@ -5834,7 +7146,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2355
                 },
@@ -5843,7 +7157,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2356
                 },
@@ -5852,7 +7168,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 2357
                 },
@@ -5861,7 +7179,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2359
                 },
@@ -5870,7 +7190,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2360
                 },
@@ -5879,7 +7201,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2361
                 },
@@ -5888,7 +7212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2362
                 },
@@ -5897,7 +7223,9 @@
                     "token": "/",
                     "value": "/",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 1,
                     "position": 2363
                 },
@@ -5906,7 +7234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2364
                 },
@@ -5915,7 +7245,9 @@
                     "token": "LENGTH",
                     "value": "LENGTH",
                     "keyword": "LENGTH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2365
                 },
@@ -5924,7 +7256,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2371
                 },
@@ -5933,7 +7267,9 @@
                     "token": "delim",
                     "value": "delim",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2372
                 },
@@ -5942,7 +7278,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2377
                 },
@@ -5951,7 +7289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2378
                 },
@@ -5960,7 +7300,9 @@
                     "token": "<",
                     "value": "<",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2379
                 },
@@ -5969,7 +7311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2380
                 },
@@ -5978,7 +7322,9 @@
                     "token": "n",
                     "value": "n",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2381
                 },
@@ -5987,7 +7333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2382
                 },
@@ -5996,7 +7344,9 @@
                     "token": "-",
                     "value": "-",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 1,
                     "position": 2383
                 },
@@ -6005,7 +7355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2384
                 },
@@ -6014,7 +7366,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2385
                 },
@@ -6023,7 +7377,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2386
                 },
@@ -6032,7 +7388,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2387
                 },
@@ -6041,7 +7399,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2392
                 },
@@ -6050,7 +7410,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2396
                 },
@@ -6059,7 +7421,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2397
                 },
@@ -6068,7 +7432,9 @@
                     "token": "SUBSTRING_INDEX",
                     "value": "SUBSTRING_INDEX",
                     "keyword": "SUBSTRING_INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2402
                 },
@@ -6077,7 +7443,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2417
                 },
@@ -6086,7 +7454,9 @@
                     "token": "SUBSTRING_INDEX",
                     "value": "SUBSTRING_INDEX",
                     "keyword": "SUBSTRING_INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2418
                 },
@@ -6095,7 +7465,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2433
                 },
@@ -6104,7 +7476,9 @@
                     "token": "string",
                     "value": "string",
                     "keyword": "STRING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2434
                 },
@@ -6113,7 +7487,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2440
                 },
@@ -6122,7 +7498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2441
                 },
@@ -6131,7 +7509,9 @@
                     "token": "delim",
                     "value": "delim",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2442
                 },
@@ -6140,7 +7520,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2447
                 },
@@ -6149,7 +7531,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2448
                 },
@@ -6158,7 +7542,9 @@
                     "token": "n",
                     "value": "n",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2449
                 },
@@ -6167,7 +7553,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2450
                 },
@@ -6176,7 +7564,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2451
                 },
@@ -6185,7 +7575,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2452
                 },
@@ -6194,7 +7586,9 @@
                     "token": "delim",
                     "value": "delim",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2453
                 },
@@ -6203,7 +7597,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2458
                 },
@@ -6212,7 +7608,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2459
                 },
@@ -6221,7 +7619,9 @@
                     "token": "-1",
                     "value": -1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 8,
                     "position": 2460
                 },
@@ -6230,7 +7630,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2462
                 },
@@ -6239,7 +7641,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2463
                 },
@@ -6248,7 +7652,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2464
                 },
@@ -6257,7 +7663,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 0,
                     "position": 2465
                 },
@@ -6266,7 +7674,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2467
                 },
@@ -6275,7 +7685,9 @@
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2469
                 },
@@ -6284,7 +7696,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2478
                 },
@@ -6293,7 +7707,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 0,
                     "position": 2479
                 },
@@ -6302,7 +7718,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2481
                 },
@@ -6311,7 +7729,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2482
                 },
@@ -6320,7 +7740,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2488
                 },
@@ -6329,7 +7751,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2489
                 },
@@ -6338,7 +7762,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2496
                 },
@@ -6347,7 +7773,9 @@
                     "token": "`root`@`localhost`",
                     "value": "root@localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 4,
                     "position": 2497
                 },
@@ -6356,7 +7784,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2515
                 },
@@ -6365,7 +7795,9 @@
                     "token": "FUNCTION",
                     "value": "FUNCTION",
                     "keyword": "FUNCTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2516
                 },
@@ -6374,7 +7806,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2524
                 },
@@ -6383,7 +7817,9 @@
                     "token": "`substrCount`",
                     "value": "substrCount",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 2525
                 },
@@ -6392,7 +7828,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2538
                 },
@@ -6401,7 +7839,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2539
                 },
@@ -6410,7 +7850,9 @@
                     "token": "`s`",
                     "value": "s",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 2540
                 },
@@ -6419,7 +7861,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2543
                 },
@@ -6428,7 +7872,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2544
                 },
@@ -6437,7 +7883,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2551
                 },
@@ -6446,7 +7894,9 @@
                     "token": "255",
                     "value": 255,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2552
                 },
@@ -6455,7 +7905,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2555
                 },
@@ -6464,7 +7916,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2556
                 },
@@ -6473,7 +7927,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2557
                 },
@@ -6482,7 +7938,9 @@
                     "token": "`ss`",
                     "value": "ss",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 2558
                 },
@@ -6491,7 +7949,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2562
                 },
@@ -6500,7 +7960,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2563
                 },
@@ -6509,7 +7971,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2570
                 },
@@ -6518,7 +7982,9 @@
                     "token": "255",
                     "value": 255,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2571
                 },
@@ -6527,7 +7993,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2574
                 },
@@ -6536,7 +8004,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2575
                 },
@@ -6545,7 +8015,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2576
                 },
@@ -6554,7 +8026,9 @@
                     "token": "RETURNS",
                     "value": "RETURNS",
                     "keyword": "RETURNS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2577
                 },
@@ -6563,7 +8037,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2584
                 },
@@ -6572,7 +8048,9 @@
                     "token": "TINYINT",
                     "value": "TINYINT",
                     "keyword": "TINYINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2585
                 },
@@ -6581,7 +8059,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2592
                 },
@@ -6590,7 +8070,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2593
                 },
@@ -6599,7 +8081,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2594
                 },
@@ -6608,7 +8092,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2595
                 },
@@ -6617,7 +8103,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2596
                 },
@@ -6626,7 +8114,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2604
                 },
@@ -6635,7 +8125,9 @@
                     "token": "DETERMINISTIC",
                     "value": "DETERMINISTIC",
                     "keyword": "DETERMINISTIC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2605
                 },
@@ -6644,7 +8136,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2618
                 },
@@ -6653,7 +8147,9 @@
                     "token": "READS SQL DATA",
                     "value": "READS SQL DATA",
                     "keyword": "READS SQL DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 7,
                     "position": 2619
                 },
@@ -6662,7 +8158,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2633
                 },
@@ -6671,7 +8169,9 @@
                     "token": "SQL SECURITY",
                     "value": "SQL SECURITY",
                     "keyword": "SQL SECURITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 7,
                     "position": 2634
                 },
@@ -6680,7 +8180,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2646
                 },
@@ -6689,7 +8191,9 @@
                     "token": "INVOKER",
                     "value": "INVOKER",
                     "keyword": "INVOKER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2647
                 },
@@ -6698,7 +8202,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2654
                 },
@@ -6707,7 +8213,9 @@
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2655
                 },
@@ -6716,7 +8224,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2660
                 },
@@ -6725,7 +8235,9 @@
                     "token": "DECLARE",
                     "value": "DECLARE",
                     "keyword": "DECLARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2661
                 },
@@ -6734,7 +8246,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2668
                 },
@@ -6743,7 +8257,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2669
                 },
@@ -6752,7 +8268,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2674
                 },
@@ -6761,7 +8279,9 @@
                     "token": "TINYINT",
                     "value": "TINYINT",
                     "keyword": "TINYINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2675
                 },
@@ -6770,7 +8290,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2682
                 },
@@ -6779,7 +8301,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2683
                 },
@@ -6788,7 +8312,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2684
                 },
@@ -6797,7 +8323,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2685
                 },
@@ -6806,7 +8334,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2686
                 },
@@ -6815,7 +8345,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2694
                 },
@@ -6824,7 +8356,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2695
                 },
@@ -6833,7 +8367,9 @@
                     "token": "DECLARE",
                     "value": "DECLARE",
                     "keyword": "DECLARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2696
                 },
@@ -6842,7 +8378,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2703
                 },
@@ -6851,7 +8389,9 @@
                     "token": "OFFSET_I",
                     "value": "OFFSET_I",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2704
                 },
@@ -6860,7 +8400,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2712
                 },
@@ -6869,7 +8411,9 @@
                     "token": "TINYINT",
                     "value": "TINYINT",
                     "keyword": "TINYINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2713
                 },
@@ -6878,7 +8422,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2720
                 },
@@ -6887,7 +8433,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2721
                 },
@@ -6896,7 +8444,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2722
                 },
@@ -6905,7 +8455,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2723
                 },
@@ -6914,7 +8466,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2724
                 },
@@ -6923,7 +8477,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2732
                 },
@@ -6932,7 +8488,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2733
                 },
@@ -6941,7 +8499,9 @@
                     "token": "DECLARE",
                     "value": "DECLARE",
                     "keyword": "DECLARE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2734
                 },
@@ -6950,7 +8510,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2741
                 },
@@ -6959,7 +8521,9 @@
                     "token": "CONTINUE",
                     "value": "CONTINUE",
                     "keyword": "CONTINUE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2742
                 },
@@ -6968,7 +8532,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2750
                 },
@@ -6977,7 +8543,9 @@
                     "token": "HANDLER",
                     "value": "HANDLER",
                     "keyword": "HANDLER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2751
                 },
@@ -6986,7 +8554,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2758
                 },
@@ -6995,7 +8565,9 @@
                     "token": "FOR",
                     "value": "FOR",
                     "keyword": "FOR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2759
                 },
@@ -7004,7 +8576,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2762
                 },
@@ -7013,7 +8587,9 @@
                     "token": "SQLSTATE",
                     "value": "SQLSTATE",
                     "keyword": "SQLSTATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2763
                 },
@@ -7022,7 +8598,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2771
                 },
@@ -7031,7 +8609,9 @@
                     "token": "'02000'",
                     "value": "02000",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@68"
+                    },
                     "flags": 1,
                     "position": 2772
                 },
@@ -7040,7 +8620,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2779
                 },
@@ -7049,7 +8631,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2780
                 },
@@ -7058,7 +8642,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2783
                 },
@@ -7067,7 +8653,9 @@
                     "token": "s",
                     "value": "s",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2784
                 },
@@ -7076,7 +8664,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2785
                 },
@@ -7085,7 +8675,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2786
                 },
@@ -7094,7 +8686,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2787
                 },
@@ -7103,7 +8697,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2788
                 },
@@ -7112,7 +8708,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2792
                 },
@@ -7121,7 +8719,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2793
                 },
@@ -7130,7 +8730,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2795
                 },
@@ -7139,7 +8741,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2798
                 },
@@ -7148,7 +8752,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2799
                 },
@@ -7157,7 +8763,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2804
                 },
@@ -7166,7 +8774,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2805
                 },
@@ -7175,7 +8785,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2806
                 },
@@ -7184,7 +8796,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2807
                 },
@@ -7193,7 +8807,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2808
                 },
@@ -7202,7 +8818,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2809
                 },
@@ -7211,7 +8829,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2810
                 },
@@ -7220,7 +8840,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2813
                 },
@@ -7229,7 +8851,9 @@
                     "token": "OFFSET_I",
                     "value": "OFFSET_I",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2814
                 },
@@ -7238,7 +8862,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2822
                 },
@@ -7247,7 +8873,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2823
                 },
@@ -7256,7 +8884,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2824
                 },
@@ -7265,7 +8895,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2825
                 },
@@ -7274,7 +8906,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2826
                 },
@@ -7283,7 +8917,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2827
                 },
@@ -7292,7 +8928,9 @@
                     "token": "REPEAT",
                     "value": "REPEAT",
                     "keyword": "REPEAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 2829
                 },
@@ -7301,7 +8939,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2835
                 },
@@ -7310,7 +8950,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 2836
                 },
@@ -7319,7 +8961,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2838
                 },
@@ -7328,7 +8972,9 @@
                     "token": "NOT",
                     "value": "NOT",
                     "keyword": "NOT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2839
                 },
@@ -7337,7 +8983,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2842
                 },
@@ -7346,7 +8994,9 @@
                     "token": "ISNULL",
                     "value": "ISNULL",
                     "keyword": "ISNULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2843
                 },
@@ -7355,7 +9005,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2849
                 },
@@ -7364,7 +9016,9 @@
                     "token": "s",
                     "value": "s",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2850
                 },
@@ -7373,7 +9027,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2851
                 },
@@ -7382,7 +9038,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2852
                 },
@@ -7391,7 +9049,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2853
                 },
@@ -7400,7 +9060,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2856
                 },
@@ -7409,7 +9071,9 @@
                     "token": "OFFSET_I",
                     "value": "OFFSET_I",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2857
                 },
@@ -7418,7 +9082,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2865
                 },
@@ -7427,7 +9093,9 @@
                     "token": ">",
                     "value": ">",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2866
                 },
@@ -7436,7 +9104,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2867
                 },
@@ -7445,7 +9115,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2868
                 },
@@ -7454,7 +9126,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2869
                 },
@@ -7463,7 +9137,9 @@
                     "token": "THEN",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2870
                 },
@@ -7472,7 +9148,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2874
                 },
@@ -7481,7 +9159,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2875
                 },
@@ -7490,7 +9170,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2878
                 },
@@ -7499,7 +9181,9 @@
                     "token": "OFFSET_I",
                     "value": "OFFSET_I",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2879
                 },
@@ -7508,7 +9192,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2887
                 },
@@ -7517,7 +9203,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2888
                 },
@@ -7526,7 +9214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2889
                 },
@@ -7535,7 +9225,9 @@
                     "token": "LOCATE",
                     "value": "LOCATE",
                     "keyword": "LOCATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2890
                 },
@@ -7544,7 +9236,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2896
                 },
@@ -7553,7 +9247,9 @@
                     "token": "ss",
                     "value": "ss",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2897
                 },
@@ -7562,7 +9258,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2899
                 },
@@ -7571,7 +9269,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2900
                 },
@@ -7580,7 +9280,9 @@
                     "token": "s",
                     "value": "s",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2901
                 },
@@ -7589,7 +9291,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2902
                 },
@@ -7598,7 +9302,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2903
                 },
@@ -7607,7 +9313,9 @@
                     "token": "OFFSET_I",
                     "value": "OFFSET_I",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2904
                 },
@@ -7616,7 +9324,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2912
                 },
@@ -7625,7 +9335,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2913
                 },
@@ -7634,7 +9346,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2914
                 },
@@ -7643,7 +9357,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 2915
                 },
@@ -7652,7 +9368,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2917
                 },
@@ -7661,7 +9379,9 @@
                     "token": "OFFSET_I",
                     "value": "OFFSET_I",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2918
                 },
@@ -7670,7 +9390,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2926
                 },
@@ -7679,7 +9401,9 @@
                     "token": ">",
                     "value": ">",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2927
                 },
@@ -7688,7 +9412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2928
                 },
@@ -7697,7 +9423,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2929
                 },
@@ -7706,7 +9434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2930
                 },
@@ -7715,7 +9445,9 @@
                     "token": "THEN",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 2931
                 },
@@ -7724,7 +9456,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2935
                 },
@@ -7733,7 +9467,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2936
                 },
@@ -7742,7 +9478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2939
                 },
@@ -7751,7 +9489,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2940
                 },
@@ -7760,7 +9500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2945
                 },
@@ -7769,7 +9511,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2946
                 },
@@ -7778,7 +9522,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2947
                 },
@@ -7787,7 +9533,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 2948
                 },
@@ -7796,7 +9544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2953
                 },
@@ -7805,7 +9555,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 1,
                     "position": 2954
                 },
@@ -7814,7 +9566,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2955
                 },
@@ -7823,7 +9577,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2956
                 },
@@ -7832,7 +9588,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2957
                 },
@@ -7841,7 +9599,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2958
                 },
@@ -7850,7 +9610,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 11,
                     "position": 2959
                 },
@@ -7859,7 +9621,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2962
                 },
@@ -7868,7 +9632,9 @@
                     "token": "OFFSET_I",
                     "value": "OFFSET_I",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2963
                 },
@@ -7877,7 +9643,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2971
                 },
@@ -7886,7 +9654,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 2972
                 },
@@ -7895,7 +9665,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2973
                 },
@@ -7904,7 +9676,9 @@
                     "token": "OFFSET_I",
                     "value": "OFFSET_I",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 2974
                 },
@@ -7913,7 +9687,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2982
                 },
@@ -7922,7 +9698,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 1,
                     "position": 2983
                 },
@@ -7931,7 +9709,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2984
                 },
@@ -7940,7 +9720,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 2985
                 },
@@ -7949,7 +9731,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2986
                 },
@@ -7958,7 +9742,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2987
                 },
@@ -7967,7 +9753,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2988
                 },
@@ -7976,7 +9764,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2991
                 },
@@ -7985,7 +9775,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 2992
                 },
@@ -7994,7 +9786,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 2994
                 },
@@ -8003,7 +9797,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2995
                 },
@@ -8012,7 +9808,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 2996
                 },
@@ -8021,7 +9819,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2999
                 },
@@ -8030,7 +9830,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 3000
                 },
@@ -8039,7 +9841,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 3002
                 },
@@ -8048,7 +9852,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3003
                 },
@@ -8057,7 +9863,9 @@
                     "token": "UNTIL",
                     "value": "UNTIL",
                     "keyword": "UNTIL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 3004
                 },
@@ -8066,7 +9874,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3009
                 },
@@ -8075,7 +9885,9 @@
                     "token": "ISNULL",
                     "value": "ISNULL",
                     "keyword": "ISNULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 3010
                 },
@@ -8084,7 +9896,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 3016
                 },
@@ -8093,7 +9907,9 @@
                     "token": "s",
                     "value": "s",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 3017
                 },
@@ -8102,7 +9918,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 3018
                 },
@@ -8111,7 +9929,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3019
                 },
@@ -8120,7 +9940,9 @@
                     "token": "OR",
                     "value": "OR",
                     "keyword": "OR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 3020
                 },
@@ -8129,7 +9951,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3022
                 },
@@ -8138,7 +9962,9 @@
                     "token": "OFFSET_I",
                     "value": "OFFSET_I",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 3023
                 },
@@ -8147,7 +9973,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3031
                 },
@@ -8156,7 +9984,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 3032
                 },
@@ -8165,7 +9995,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3033
                 },
@@ -8174,7 +10006,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 3034
                 },
@@ -8183,7 +10017,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3035
                 },
@@ -8192,7 +10028,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 3036
                 },
@@ -8201,7 +10039,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3039
                 },
@@ -8210,7 +10050,9 @@
                     "token": "REPEAT",
                     "value": "REPEAT",
                     "keyword": "REPEAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 35,
                     "position": 3040
                 },
@@ -8219,7 +10061,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 3046
                 },
@@ -8228,7 +10072,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3047
                 },
@@ -8237,7 +10083,9 @@
                     "token": "RETURN",
                     "value": "RETURN",
                     "keyword": "RETURN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 3,
                     "position": 3049
                 },
@@ -8246,7 +10094,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3055
                 },
@@ -8255,7 +10105,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 33,
                     "position": 3056
                 },
@@ -8264,7 +10116,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 3061
                 },
@@ -8273,7 +10127,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3062
                 },
@@ -8282,7 +10138,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 3063
                 },
@@ -8291,7 +10149,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 0,
                     "position": 3066
                 },
@@ -8300,7 +10160,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3068
                 },
@@ -8309,7 +10171,9 @@
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 0,
                     "position": 3070
                 },
@@ -8318,7 +10182,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3079
                 },
@@ -8327,7 +10193,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 0,
                     "position": 3080
                 },
@@ -8336,7 +10204,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 3081
                 },
@@ -8345,13 +10215,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 926,
-            "idx": 926
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -8493,30 +10363,6 @@
                     }
                 ],
                 "body": [
-                    {
-                        "@type": "@72"
-                    },
-                    {
-                        "@type": "@73"
-                    },
-                    {
-                        "@type": "@74"
-                    },
-                    {
-                        "@type": "@75"
-                    },
-                    {
-                        "@type": "@76"
-                    },
-                    {
-                        "@type": "@77"
-                    },
-                    {
-                        "@type": "@78"
-                    },
-                    {
-                        "@type": "@79"
-                    },
                     {
                         "@type": "@80"
                     },
@@ -8660,9 +10506,6 @@
                     },
                     {
                         "@type": "@127"
-                    },
-                    {
-                        "@type": "@128"
                     },
                     {
                         "@type": "@129"
@@ -9083,6 +10926,33 @@
                     },
                     {
                         "@type": "@268"
+                    },
+                    {
+                        "@type": "@269"
+                    },
+                    {
+                        "@type": "@270"
+                    },
+                    {
+                        "@type": "@271"
+                    },
+                    {
+                        "@type": "@272"
+                    },
+                    {
+                        "@type": "@273"
+                    },
+                    {
+                        "@type": "@274"
+                    },
+                    {
+                        "@type": "@275"
+                    },
+                    {
+                        "@type": "@276"
+                    },
+                    {
+                        "@type": "@277"
                     }
                 ],
                 "options": {
@@ -9215,33 +11085,6 @@
                     }
                 ],
                 "body": [
-                    {
-                        "@type": "@327"
-                    },
-                    {
-                        "@type": "@328"
-                    },
-                    {
-                        "@type": "@329"
-                    },
-                    {
-                        "@type": "@330"
-                    },
-                    {
-                        "@type": "@331"
-                    },
-                    {
-                        "@type": "@332"
-                    },
-                    {
-                        "@type": "@333"
-                    },
-                    {
-                        "@type": "@334"
-                    },
-                    {
-                        "@type": "@335"
-                    },
                     {
                         "@type": "@336"
                     },
@@ -9967,6 +11810,33 @@
                     },
                     {
                         "@type": "@577"
+                    },
+                    {
+                        "@type": "@578"
+                    },
+                    {
+                        "@type": "@579"
+                    },
+                    {
+                        "@type": "@580"
+                    },
+                    {
+                        "@type": "@581"
+                    },
+                    {
+                        "@type": "@582"
+                    },
+                    {
+                        "@type": "@583"
+                    },
+                    {
+                        "@type": "@584"
+                    },
+                    {
+                        "@type": "@585"
+                    },
+                    {
+                        "@type": "@586"
                     }
                 ],
                 "options": {
@@ -10098,33 +11968,6 @@
                     }
                 ],
                 "body": [
-                    {
-                        "@type": "@628"
-                    },
-                    {
-                        "@type": "@629"
-                    },
-                    {
-                        "@type": "@630"
-                    },
-                    {
-                        "@type": "@631"
-                    },
-                    {
-                        "@type": "@632"
-                    },
-                    {
-                        "@type": "@633"
-                    },
-                    {
-                        "@type": "@634"
-                    },
-                    {
-                        "@type": "@635"
-                    },
-                    {
-                        "@type": "@636"
-                    },
                     {
                         "@type": "@637"
                     },
@@ -10301,6 +12144,33 @@
                     },
                     {
                         "@type": "@695"
+                    },
+                    {
+                        "@type": "@696"
+                    },
+                    {
+                        "@type": "@697"
+                    },
+                    {
+                        "@type": "@698"
+                    },
+                    {
+                        "@type": "@699"
+                    },
+                    {
+                        "@type": "@700"
+                    },
+                    {
+                        "@type": "@701"
+                    },
+                    {
+                        "@type": "@702"
+                    },
+                    {
+                        "@type": "@703"
+                    },
+                    {
+                        "@type": "@704"
                     }
                 ],
                 "options": {
@@ -10413,33 +12283,6 @@
                     }
                 ],
                 "body": [
-                    {
-                        "@type": "@746"
-                    },
-                    {
-                        "@type": "@747"
-                    },
-                    {
-                        "@type": "@748"
-                    },
-                    {
-                        "@type": "@749"
-                    },
-                    {
-                        "@type": "@750"
-                    },
-                    {
-                        "@type": "@751"
-                    },
-                    {
-                        "@type": "@752"
-                    },
-                    {
-                        "@type": "@753"
-                    },
-                    {
-                        "@type": "@754"
-                    },
                     {
                         "@type": "@755"
                     },
@@ -10940,6 +12783,33 @@
                     },
                     {
                         "@type": "@921"
+                    },
+                    {
+                        "@type": "@922"
+                    },
+                    {
+                        "@type": "@923"
+                    },
+                    {
+                        "@type": "@924"
+                    },
+                    {
+                        "@type": "@925"
+                    },
+                    {
+                        "@type": "@926"
+                    },
+                    {
+                        "@type": "@927"
+                    },
+                    {
+                        "@type": "@928"
+                    },
+                    {
+                        "@type": "@929"
+                    },
+                    {
+                        "@type": "@930"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseCreateSchema.out
+++ b/tests/data/parser/parseCreateSchema.out
@@ -7,13 +7,19 @@
         "last": 57,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 13,
+            "idx": 13,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "DATABASE",
                     "value": "DATABASE",
                     "keyword": "DATABASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -49,7 +63,9 @@
                     "token": "IF NOT EXISTS",
                     "value": "IF NOT EXISTS",
                     "keyword": "IF NOT EXISTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 16
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -67,7 +85,11 @@
                     "token": "pma",
                     "value": "pma",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -85,7 +109,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 34
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -103,7 +131,11 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -112,7 +144,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -121,13 +157,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 13,
-            "idx": 13
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateSchemaErr.out
+++ b/tests/data/parser/parseCreateSchemaErr.out
@@ -7,13 +7,19 @@
         "last": 70,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "SCHEMA",
                     "value": "SCHEMA",
                     "keyword": "SCHEMA",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,9 @@
                     "token": "IF NOT EXISTS",
                     "value": "IF NOT EXISTS",
                     "keyword": "IF NOT EXISTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 14
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -67,7 +85,11 @@
                     "token": "pma",
                     "value": "pma",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -85,7 +109,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 32
                 },
@@ -94,7 +120,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 38
                 },
@@ -103,7 +133,11 @@
                     "token": "'InnoDB'",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 39
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -121,7 +157,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 48
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -139,7 +179,9 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 1,
                     "position": 64
                 },
@@ -148,13 +190,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -217,7 +261,7 @@
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@10"
+                    "@type": "@13"
                 },
                 0
             ]

--- a/tests/data/parser/parseCreateTable.out
+++ b/tests/data/parser/parseCreateTable.out
@@ -7,13 +7,19 @@
         "last": 229,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 65,
+            "idx": 65,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "IF NOT EXISTS",
                     "value": "IF NOT EXISTS",
                     "keyword": "IF NOT EXISTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -67,7 +85,11 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +109,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -94,7 +122,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -103,7 +133,11 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 39
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -121,7 +157,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 44
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -139,7 +179,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 48
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -157,7 +201,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 57
                 },
@@ -166,7 +212,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -175,7 +223,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -184,7 +234,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -202,7 +256,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 86
                 },
@@ -211,7 +267,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 93
                 },
@@ -220,7 +278,11 @@
                     "token": "64",
                     "value": 64,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -229,7 +291,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 96
                 },
@@ -238,7 +302,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -247,7 +313,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 98
                 },
@@ -256,7 +324,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 102
                 },
@@ -265,7 +335,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -274,7 +346,9 @@
                     "token": "`password`",
                     "value": "password",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 108
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -292,7 +368,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 119
                 },
@@ -301,7 +379,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 126
                 },
@@ -310,7 +390,9 @@
                     "token": "256",
                     "value": 256,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -319,7 +401,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 130
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -337,7 +423,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 132
                 },
@@ -346,7 +434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -355,7 +445,11 @@
                     "token": "'123456'",
                     "value": "123456",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 140
                 },
@@ -364,7 +458,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 148
                 },
@@ -373,7 +469,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -382,7 +480,9 @@
                     "token": "CONSTRAINT",
                     "value": "CONSTRAINT",
                     "keyword": "CONSTRAINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 154
                 },
@@ -391,7 +491,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 164
                 },
@@ -400,7 +502,9 @@
                     "token": "pk_id",
                     "value": "pk_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 165
                 },
@@ -409,7 +513,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 170
                 },
@@ -418,7 +524,9 @@
                     "token": "PRIMARY KEY",
                     "value": "PRIMARY KEY",
                     "keyword": "PRIMARY KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 171
                 },
@@ -427,7 +535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 182
                 },
@@ -436,7 +546,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 183
                 },
@@ -445,7 +557,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 184
                 },
@@ -454,7 +568,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 188
                 },
@@ -463,7 +579,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 189
                 },
@@ -472,7 +590,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 190
                 },
@@ -481,7 +601,9 @@
                     "token": "UNIQUE",
                     "value": "UNIQUE",
                     "keyword": "UNIQUE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 195
                 },
@@ -490,7 +612,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 201
                 },
@@ -499,7 +623,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 202
                 },
@@ -508,7 +634,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 203
                 },
@@ -517,7 +645,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 211
                 },
@@ -526,7 +656,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 212
                 },
@@ -535,7 +667,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 213
                 },
@@ -544,7 +678,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 214
                 },
@@ -553,7 +689,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 215
                 },
@@ -562,7 +700,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 221
                 },
@@ -571,7 +711,9 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 222
                 },
@@ -580,7 +722,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 228
                 },
@@ -589,13 +735,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@73"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 65,
-            "idx": 65
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable10.out
+++ b/tests/data/parser/parseCreateTable10.out
@@ -7,13 +7,19 @@
         "last": 383,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 95,
+            "idx": 95,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`trips2`",
                     "value": "trips2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 22
                 },
@@ -76,7 +100,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +111,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 28
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +133,9 @@
                     "token": "bigint",
                     "value": "BIGINT",
                     "keyword": "BIGINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 39
                 },
@@ -121,7 +155,11 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -148,7 +190,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -166,7 +212,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 53
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -184,7 +234,9 @@
                     "token": "PRIMARY KEY",
                     "value": "PRIMARY KEY",
                     "keyword": "PRIMARY KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 62
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -202,7 +256,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 74
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -220,7 +278,11 @@
                     "token": "'Unique trip Id'",
                     "value": "Unique trip Id",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 82
                 },
@@ -229,7 +291,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 98
                 },
@@ -238,7 +302,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -247,7 +313,9 @@
                     "token": "`trip_code`",
                     "value": "trip_code",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 104
                 },
@@ -256,7 +324,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -265,7 +335,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 116
                 },
@@ -274,7 +346,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 119
                 },
@@ -283,7 +357,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -292,7 +368,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 122
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -310,7 +390,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 124
                 },
@@ -319,7 +401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -328,7 +412,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 133
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -346,7 +434,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 142
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -364,7 +456,9 @@
                     "token": "'Trip code'",
                     "value": "Trip code",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 1,
                     "position": 150
                 },
@@ -373,7 +467,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 161
                 },
@@ -382,7 +478,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 162
                 },
@@ -391,7 +489,9 @@
                     "token": "`trip_category`",
                     "value": "trip_category",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 167
                 },
@@ -400,7 +500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 182
                 },
@@ -409,7 +511,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 183
                 },
@@ -418,7 +522,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 186
                 },
@@ -427,7 +533,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 187
                 },
@@ -436,7 +544,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 189
                 },
@@ -445,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 190
                 },
@@ -454,7 +566,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 191
                 },
@@ -463,7 +577,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 199
                 },
@@ -472,7 +588,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 200
                 },
@@ -481,7 +599,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 208
                 },
@@ -490,7 +610,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 209
                 },
@@ -499,7 +621,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 216
                 },
@@ -508,7 +632,9 @@
                     "token": "'Trip category'",
                     "value": "Trip category",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 1,
                     "position": 217
                 },
@@ -517,7 +643,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 232
                 },
@@ -526,7 +654,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 233
                 },
@@ -535,7 +665,9 @@
                     "token": "`trip_date`",
                     "value": "trip_date",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 238
                 },
@@ -544,7 +676,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 249
                 },
@@ -553,7 +687,9 @@
                     "token": "date",
                     "value": "date",
                     "keyword": "DATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 250
                 },
@@ -562,7 +698,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 254
                 },
@@ -571,7 +709,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 255
                 },
@@ -580,7 +720,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 263
                 },
@@ -589,7 +731,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 264
                 },
@@ -598,7 +742,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 271
                 },
@@ -607,7 +753,9 @@
                     "token": "'The trip date'",
                     "value": "The trip date",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 1,
                     "position": 272
                 },
@@ -616,7 +764,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 287
                 },
@@ -625,7 +775,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 288
                 },
@@ -634,7 +786,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 289
                 },
@@ -643,7 +797,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 290
                 },
@@ -652,7 +808,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 296
                 },
@@ -661,7 +819,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 297
                 },
@@ -670,7 +830,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 298
                 },
@@ -679,7 +841,11 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 299
                 },
@@ -688,7 +854,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 305
                 },
@@ -697,7 +865,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 306
                 },
@@ -706,7 +876,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 321
                 },
@@ -715,7 +887,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 322
                 },
@@ -724,7 +898,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 323
                 },
@@ -733,7 +909,9 @@
                     "token": "utf8mb4",
                     "value": "utf8mb4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@83"
+                    },
                     "flags": 0,
                     "position": 324
                 },
@@ -742,7 +920,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 331
                 },
@@ -751,7 +931,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 332
                 },
@@ -760,7 +942,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 339
                 },
@@ -769,7 +953,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 340
                 },
@@ -778,7 +964,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 341
                 },
@@ -787,7 +975,9 @@
                     "token": "utf8mb4_unicode_ci",
                     "value": "utf8mb4_unicode_ci",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@83"
+                    },
                     "flags": 0,
                     "position": 342
                 },
@@ -796,7 +986,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 360
                 },
@@ -805,7 +997,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 361
                 },
@@ -814,7 +1008,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 368
                 },
@@ -823,7 +1019,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 369
                 },
@@ -832,7 +1030,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 370
                 },
@@ -841,7 +1041,9 @@
                     "token": "'The trips'",
                     "value": "The trips",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 1,
                     "position": 371
                 },
@@ -850,7 +1052,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 382
                 },
@@ -859,13 +1065,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@103"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 95,
-            "idx": 95
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable11.out
+++ b/tests/data/parser/parseCreateTable11.out
@@ -7,13 +7,19 @@
         "last": 18500,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 2224,
+            "idx": 2224,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`trips`",
                     "value": "trips",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 21
                 },
@@ -76,7 +100,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,7 +111,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +133,9 @@
                     "token": "bigint",
                     "value": "BIGINT",
                     "keyword": "BIGINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -121,7 +155,11 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -148,7 +190,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 43
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -166,7 +212,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 52
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -184,7 +234,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 61
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -202,7 +256,11 @@
                     "token": "'Unique trip Id'",
                     "value": "Unique trip Id",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 69
                 },
@@ -211,7 +269,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 85
                 },
@@ -220,7 +280,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -229,7 +291,9 @@
                     "token": "`trip_category`",
                     "value": "trip_category",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 91
                 },
@@ -238,7 +302,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -247,7 +313,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 107
                 },
@@ -256,7 +324,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 110
                 },
@@ -265,7 +335,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -274,7 +346,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 113
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -292,7 +368,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 115
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -310,7 +390,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 124
                 },
@@ -319,7 +401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -328,7 +412,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 133
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -346,7 +434,9 @@
                     "token": "'Trip category'",
                     "value": "Trip category",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 141
                 },
@@ -355,7 +445,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 156
                 },
@@ -364,7 +456,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -373,7 +467,9 @@
                     "token": "`trip_month`",
                     "value": "trip_month",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 162
                 },
@@ -382,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 174
                 },
@@ -391,7 +489,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 175
                 },
@@ -400,7 +500,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 178
                 },
@@ -409,7 +511,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 179
                 },
@@ -418,7 +522,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 181
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 182
                 },
@@ -436,7 +544,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 183
                 },
@@ -445,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 191
                 },
@@ -454,7 +566,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 192
                 },
@@ -463,7 +577,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 200
                 },
@@ -472,7 +588,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 201
                 },
@@ -481,7 +599,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 208
                 },
@@ -490,7 +610,9 @@
                     "token": "'Trip month'",
                     "value": "Trip month",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 209
                 },
@@ -499,7 +621,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 221
                 },
@@ -508,7 +632,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 222
                 },
@@ -517,7 +643,9 @@
                     "token": "`trip_date`",
                     "value": "trip_date",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 227
                 },
@@ -526,7 +654,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 238
                 },
@@ -535,7 +665,9 @@
                     "token": "date",
                     "value": "date",
                     "keyword": "DATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 239
                 },
@@ -544,7 +676,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 243
                 },
@@ -553,7 +687,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 244
                 },
@@ -562,7 +698,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 252
                 },
@@ -571,7 +709,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 253
                 },
@@ -580,7 +720,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 260
                 },
@@ -589,7 +731,9 @@
                     "token": "'The trip date'",
                     "value": "The trip date",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 261
                 },
@@ -598,7 +742,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 276
                 },
@@ -607,7 +753,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 277
                 },
@@ -616,7 +764,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 278
                 },
@@ -625,7 +775,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 279
                 },
@@ -634,7 +786,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 285
                 },
@@ -643,7 +797,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 286
                 },
@@ -652,7 +808,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 287
                 },
@@ -661,7 +819,11 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 288
                 },
@@ -670,7 +832,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 294
                 },
@@ -679,7 +843,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 295
                 },
@@ -688,7 +854,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 310
                 },
@@ -697,7 +865,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 311
                 },
@@ -706,7 +876,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 312
                 },
@@ -715,7 +887,9 @@
                     "token": "utf8mb4",
                     "value": "utf8mb4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 313
                 },
@@ -724,7 +898,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 320
                 },
@@ -733,7 +909,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 321
                 },
@@ -742,7 +920,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 328
                 },
@@ -751,7 +931,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 329
                 },
@@ -760,7 +942,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 330
                 },
@@ -769,7 +953,9 @@
                     "token": "utf8mb4_unicode_ci",
                     "value": "utf8mb4_unicode_ci",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 331
                 },
@@ -778,7 +964,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 349
                 },
@@ -787,7 +975,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 350
                 },
@@ -796,7 +986,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 357
                 },
@@ -805,7 +997,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 358
                 },
@@ -814,7 +1008,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 359
                 },
@@ -823,7 +1019,9 @@
                     "token": "'The trips'",
                     "value": "The trips",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 360
                 },
@@ -832,7 +1030,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 371
                 },
@@ -841,7 +1041,9 @@
                     "token": "PARTITION BY",
                     "value": "PARTITION BY",
                     "keyword": "PARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 372
                 },
@@ -850,7 +1052,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 384
                 },
@@ -859,7 +1063,9 @@
                     "token": "RANGE",
                     "value": "RANGE",
                     "keyword": "RANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 385
                 },
@@ -868,7 +1074,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 390
                 },
@@ -877,7 +1085,9 @@
                     "token": "trip_month",
                     "value": "trip_month",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 391
                 },
@@ -886,7 +1096,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 401
                 },
@@ -895,7 +1107,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 402
                 },
@@ -904,7 +1118,9 @@
                     "token": "SUBPARTITION BY",
                     "value": "SUBPARTITION BY",
                     "keyword": "SUBPARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 403
                 },
@@ -913,7 +1129,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 418
                 },
@@ -922,7 +1140,9 @@
                     "token": "HASH",
                     "value": "HASH",
                     "keyword": "HASH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 419
                 },
@@ -931,7 +1151,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 423
                 },
@@ -940,7 +1162,9 @@
                     "token": "DAY",
                     "value": "DAY",
                     "keyword": "DAY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 424
                 },
@@ -949,7 +1173,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 427
                 },
@@ -958,7 +1184,9 @@
                     "token": "trip_date",
                     "value": "trip_date",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 428
                 },
@@ -967,7 +1195,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 437
                 },
@@ -976,7 +1206,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 438
                 },
@@ -985,7 +1217,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 439
                 },
@@ -994,7 +1228,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 440
                 },
@@ -1003,7 +1239,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 441
                 },
@@ -1012,7 +1250,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 446
                 },
@@ -1021,7 +1261,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 455
                 },
@@ -1030,7 +1272,9 @@
                     "token": "p_month_Jan",
                     "value": "p_month_Jan",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 456
                 },
@@ -1039,7 +1283,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 467
                 },
@@ -1048,7 +1294,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 472
                 },
@@ -1057,7 +1305,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 478
                 },
@@ -1066,7 +1316,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 487
                 },
@@ -1075,7 +1327,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 496
                 },
@@ -1084,7 +1338,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 497
                 },
@@ -1093,7 +1349,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 498
                 },
@@ -1102,7 +1360,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 499
                 },
@@ -1111,7 +1371,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 500
                 },
@@ -1120,7 +1382,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 501
                 },
@@ -1129,7 +1393,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 502
                 },
@@ -1138,7 +1404,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 515
                 },
@@ -1147,7 +1415,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 527
                 },
@@ -1156,7 +1426,9 @@
                     "token": "p_month_Jan_day_0",
                     "value": "p_month_Jan_day_0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 528
                 },
@@ -1165,7 +1437,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 545
                 },
@@ -1174,7 +1448,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 546
                 },
@@ -1183,7 +1459,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 559
                 },
@@ -1192,7 +1470,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 571
                 },
@@ -1201,7 +1481,9 @@
                     "token": "p_month_Jan_day_1",
                     "value": "p_month_Jan_day_1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 572
                 },
@@ -1210,7 +1492,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 589
                 },
@@ -1219,7 +1503,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 590
                 },
@@ -1228,7 +1514,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 603
                 },
@@ -1237,7 +1525,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 615
                 },
@@ -1246,7 +1536,9 @@
                     "token": "p_month_Jan_day_2",
                     "value": "p_month_Jan_day_2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 616
                 },
@@ -1255,7 +1547,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 633
                 },
@@ -1264,7 +1558,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 634
                 },
@@ -1273,7 +1569,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 647
                 },
@@ -1282,7 +1580,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 659
                 },
@@ -1291,7 +1591,9 @@
                     "token": "p_month_Jan_day_3",
                     "value": "p_month_Jan_day_3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 660
                 },
@@ -1300,7 +1602,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 677
                 },
@@ -1309,7 +1613,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 678
                 },
@@ -1318,7 +1624,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 691
                 },
@@ -1327,7 +1635,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 703
                 },
@@ -1336,7 +1646,9 @@
                     "token": "p_month_Jan_day_4",
                     "value": "p_month_Jan_day_4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 704
                 },
@@ -1345,7 +1657,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 721
                 },
@@ -1354,7 +1668,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 722
                 },
@@ -1363,7 +1679,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 735
                 },
@@ -1372,7 +1690,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 747
                 },
@@ -1381,7 +1701,9 @@
                     "token": "p_month_Jan_day_5",
                     "value": "p_month_Jan_day_5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 748
                 },
@@ -1390,7 +1712,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 765
                 },
@@ -1399,7 +1723,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 766
                 },
@@ -1408,7 +1734,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 779
                 },
@@ -1417,7 +1745,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 791
                 },
@@ -1426,7 +1756,9 @@
                     "token": "p_month_Jan_day_6",
                     "value": "p_month_Jan_day_6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 792
                 },
@@ -1435,7 +1767,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 809
                 },
@@ -1444,7 +1778,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 810
                 },
@@ -1453,7 +1789,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 823
                 },
@@ -1462,7 +1800,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 835
                 },
@@ -1471,7 +1811,9 @@
                     "token": "p_month_Jan_day_7",
                     "value": "p_month_Jan_day_7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 836
                 },
@@ -1480,7 +1822,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 853
                 },
@@ -1489,7 +1833,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 854
                 },
@@ -1498,7 +1844,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 867
                 },
@@ -1507,7 +1855,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 879
                 },
@@ -1516,7 +1866,9 @@
                     "token": "p_month_Jan_day_8",
                     "value": "p_month_Jan_day_8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 880
                 },
@@ -1525,7 +1877,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 897
                 },
@@ -1534,7 +1888,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 898
                 },
@@ -1543,7 +1899,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 911
                 },
@@ -1552,7 +1910,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 923
                 },
@@ -1561,7 +1921,9 @@
                     "token": "p_month_Jan_day_9",
                     "value": "p_month_Jan_day_9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 924
                 },
@@ -1570,7 +1932,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 941
                 },
@@ -1579,7 +1943,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 942
                 },
@@ -1588,7 +1954,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 955
                 },
@@ -1597,7 +1965,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 967
                 },
@@ -1606,7 +1976,9 @@
                     "token": "p_month_Jan_day_10",
                     "value": "p_month_Jan_day_10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 968
                 },
@@ -1615,7 +1987,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 986
                 },
@@ -1624,7 +1998,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 987
                 },
@@ -1633,7 +2009,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1000
                 },
@@ -1642,7 +2020,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1012
                 },
@@ -1651,7 +2031,9 @@
                     "token": "p_month_Jan_day_11",
                     "value": "p_month_Jan_day_11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1013
                 },
@@ -1660,7 +2042,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1031
                 },
@@ -1669,7 +2053,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1032
                 },
@@ -1678,7 +2064,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1045
                 },
@@ -1687,7 +2075,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1057
                 },
@@ -1696,7 +2086,9 @@
                     "token": "p_month_Jan_day_12",
                     "value": "p_month_Jan_day_12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1058
                 },
@@ -1705,7 +2097,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1076
                 },
@@ -1714,7 +2108,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1077
                 },
@@ -1723,7 +2119,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1090
                 },
@@ -1732,7 +2130,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1102
                 },
@@ -1741,7 +2141,9 @@
                     "token": "p_month_Jan_day_13",
                     "value": "p_month_Jan_day_13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1103
                 },
@@ -1750,7 +2152,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1121
                 },
@@ -1759,7 +2163,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1122
                 },
@@ -1768,7 +2174,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1135
                 },
@@ -1777,7 +2185,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1147
                 },
@@ -1786,7 +2196,9 @@
                     "token": "p_month_Jan_day_14",
                     "value": "p_month_Jan_day_14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1148
                 },
@@ -1795,7 +2207,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1166
                 },
@@ -1804,7 +2218,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1167
                 },
@@ -1813,7 +2229,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1180
                 },
@@ -1822,7 +2240,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1192
                 },
@@ -1831,7 +2251,9 @@
                     "token": "p_month_Jan_day_15",
                     "value": "p_month_Jan_day_15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1193
                 },
@@ -1840,7 +2262,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1211
                 },
@@ -1849,7 +2273,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1212
                 },
@@ -1858,7 +2284,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1225
                 },
@@ -1867,7 +2295,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1237
                 },
@@ -1876,7 +2306,9 @@
                     "token": "p_month_Jan_day_16",
                     "value": "p_month_Jan_day_16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1238
                 },
@@ -1885,7 +2317,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1256
                 },
@@ -1894,7 +2328,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1257
                 },
@@ -1903,7 +2339,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1270
                 },
@@ -1912,7 +2350,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1282
                 },
@@ -1921,7 +2361,9 @@
                     "token": "p_month_Jan_day_17",
                     "value": "p_month_Jan_day_17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1283
                 },
@@ -1930,7 +2372,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1301
                 },
@@ -1939,7 +2383,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1302
                 },
@@ -1948,7 +2394,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1315
                 },
@@ -1957,7 +2405,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1327
                 },
@@ -1966,7 +2416,9 @@
                     "token": "p_month_Jan_day_18",
                     "value": "p_month_Jan_day_18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1328
                 },
@@ -1975,7 +2427,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1346
                 },
@@ -1984,7 +2438,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1347
                 },
@@ -1993,7 +2449,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1360
                 },
@@ -2002,7 +2460,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1372
                 },
@@ -2011,7 +2471,9 @@
                     "token": "p_month_Jan_day_19",
                     "value": "p_month_Jan_day_19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1373
                 },
@@ -2020,7 +2482,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1391
                 },
@@ -2029,7 +2493,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1392
                 },
@@ -2038,7 +2504,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1405
                 },
@@ -2047,7 +2515,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1417
                 },
@@ -2056,7 +2526,9 @@
                     "token": "p_month_Jan_day_20",
                     "value": "p_month_Jan_day_20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1418
                 },
@@ -2065,7 +2537,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1436
                 },
@@ -2074,7 +2548,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1437
                 },
@@ -2083,7 +2559,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1450
                 },
@@ -2092,7 +2570,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1462
                 },
@@ -2101,7 +2581,9 @@
                     "token": "p_month_Jan_day_21",
                     "value": "p_month_Jan_day_21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1463
                 },
@@ -2110,7 +2592,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1481
                 },
@@ -2119,7 +2603,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1482
                 },
@@ -2128,7 +2614,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1495
                 },
@@ -2137,7 +2625,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1507
                 },
@@ -2146,7 +2636,9 @@
                     "token": "p_month_Jan_day_22",
                     "value": "p_month_Jan_day_22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1508
                 },
@@ -2155,7 +2647,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1526
                 },
@@ -2164,7 +2658,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1527
                 },
@@ -2173,7 +2669,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1540
                 },
@@ -2182,7 +2680,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1552
                 },
@@ -2191,7 +2691,9 @@
                     "token": "p_month_Jan_day_23",
                     "value": "p_month_Jan_day_23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1553
                 },
@@ -2200,7 +2702,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1571
                 },
@@ -2209,7 +2713,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1572
                 },
@@ -2218,7 +2724,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1585
                 },
@@ -2227,7 +2735,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1597
                 },
@@ -2236,7 +2746,9 @@
                     "token": "p_month_Jan_day_24",
                     "value": "p_month_Jan_day_24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1598
                 },
@@ -2245,7 +2757,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1616
                 },
@@ -2254,7 +2768,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1617
                 },
@@ -2263,7 +2779,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1630
                 },
@@ -2272,7 +2790,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1642
                 },
@@ -2281,7 +2801,9 @@
                     "token": "p_month_Jan_day_25",
                     "value": "p_month_Jan_day_25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1643
                 },
@@ -2290,7 +2812,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1661
                 },
@@ -2299,7 +2823,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1662
                 },
@@ -2308,7 +2834,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1675
                 },
@@ -2317,7 +2845,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1687
                 },
@@ -2326,7 +2856,9 @@
                     "token": "p_month_Jan_day_26",
                     "value": "p_month_Jan_day_26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1688
                 },
@@ -2335,7 +2867,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1706
                 },
@@ -2344,7 +2878,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1707
                 },
@@ -2353,7 +2889,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1720
                 },
@@ -2362,7 +2900,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1732
                 },
@@ -2371,7 +2911,9 @@
                     "token": "p_month_Jan_day_27",
                     "value": "p_month_Jan_day_27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1733
                 },
@@ -2380,7 +2922,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1751
                 },
@@ -2389,7 +2933,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1752
                 },
@@ -2398,7 +2944,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1765
                 },
@@ -2407,7 +2955,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1777
                 },
@@ -2416,7 +2966,9 @@
                     "token": "p_month_Jan_day_28",
                     "value": "p_month_Jan_day_28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1778
                 },
@@ -2425,7 +2977,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1796
                 },
@@ -2434,7 +2988,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1797
                 },
@@ -2443,7 +2999,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1810
                 },
@@ -2452,7 +3010,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1822
                 },
@@ -2461,7 +3021,9 @@
                     "token": "p_month_Jan_day_29",
                     "value": "p_month_Jan_day_29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1823
                 },
@@ -2470,7 +3032,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1841
                 },
@@ -2479,7 +3043,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1842
                 },
@@ -2488,7 +3054,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1855
                 },
@@ -2497,7 +3065,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1867
                 },
@@ -2506,7 +3076,9 @@
                     "token": "p_month_Jan_day_30",
                     "value": "p_month_Jan_day_30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1868
                 },
@@ -2515,7 +3087,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1886
                 },
@@ -2524,7 +3098,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1887
                 },
@@ -2533,7 +3109,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1900
                 },
@@ -2542,7 +3120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1912
                 },
@@ -2551,7 +3131,9 @@
                     "token": "p_month_Jan_day_31",
                     "value": "p_month_Jan_day_31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1913
                 },
@@ -2560,7 +3142,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1931
                 },
@@ -2569,7 +3153,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1940
                 },
@@ -2578,7 +3164,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1941
                 },
@@ -2587,7 +3175,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1942
                 },
@@ -2596,7 +3186,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1951
                 },
@@ -2605,7 +3197,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1960
                 },
@@ -2614,7 +3208,9 @@
                     "token": "p_month_Feb",
                     "value": "p_month_Feb",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1961
                 },
@@ -2623,7 +3219,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1972
                 },
@@ -2632,7 +3230,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1977
                 },
@@ -2641,7 +3241,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1983
                 },
@@ -2650,7 +3252,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 1992
                 },
@@ -2659,7 +3263,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2001
                 },
@@ -2668,7 +3274,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2002
                 },
@@ -2677,7 +3285,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 2003
                 },
@@ -2686,7 +3296,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2004
                 },
@@ -2695,7 +3307,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2005
                 },
@@ -2704,7 +3318,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2006
                 },
@@ -2713,7 +3329,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2007
                 },
@@ -2722,7 +3340,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2020
                 },
@@ -2731,7 +3351,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2032
                 },
@@ -2740,7 +3362,9 @@
                     "token": "p_month_Feb_day_0",
                     "value": "p_month_Feb_day_0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2033
                 },
@@ -2749,7 +3373,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2050
                 },
@@ -2758,7 +3384,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2051
                 },
@@ -2767,7 +3395,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2064
                 },
@@ -2776,7 +3406,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2076
                 },
@@ -2785,7 +3417,9 @@
                     "token": "p_month_Feb_day_1",
                     "value": "p_month_Feb_day_1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2077
                 },
@@ -2794,7 +3428,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2094
                 },
@@ -2803,7 +3439,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2095
                 },
@@ -2812,7 +3450,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2108
                 },
@@ -2821,7 +3461,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2120
                 },
@@ -2830,7 +3472,9 @@
                     "token": "p_month_Feb_day_2",
                     "value": "p_month_Feb_day_2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2121
                 },
@@ -2839,7 +3483,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2138
                 },
@@ -2848,7 +3494,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2139
                 },
@@ -2857,7 +3505,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2152
                 },
@@ -2866,7 +3516,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2164
                 },
@@ -2875,7 +3527,9 @@
                     "token": "p_month_Feb_day_3",
                     "value": "p_month_Feb_day_3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2165
                 },
@@ -2884,7 +3538,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2182
                 },
@@ -2893,7 +3549,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2183
                 },
@@ -2902,7 +3560,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2196
                 },
@@ -2911,7 +3571,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2208
                 },
@@ -2920,7 +3582,9 @@
                     "token": "p_month_Feb_day_4",
                     "value": "p_month_Feb_day_4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2209
                 },
@@ -2929,7 +3593,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2226
                 },
@@ -2938,7 +3604,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2227
                 },
@@ -2947,7 +3615,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2240
                 },
@@ -2956,7 +3626,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2252
                 },
@@ -2965,7 +3637,9 @@
                     "token": "p_month_Feb_day_5",
                     "value": "p_month_Feb_day_5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2253
                 },
@@ -2974,7 +3648,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2270
                 },
@@ -2983,7 +3659,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2271
                 },
@@ -2992,7 +3670,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2284
                 },
@@ -3001,7 +3681,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2296
                 },
@@ -3010,7 +3692,9 @@
                     "token": "p_month_Feb_day_6",
                     "value": "p_month_Feb_day_6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2297
                 },
@@ -3019,7 +3703,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2314
                 },
@@ -3028,7 +3714,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2315
                 },
@@ -3037,7 +3725,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2328
                 },
@@ -3046,7 +3736,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2340
                 },
@@ -3055,7 +3747,9 @@
                     "token": "p_month_Feb_day_7",
                     "value": "p_month_Feb_day_7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2341
                 },
@@ -3064,7 +3758,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2358
                 },
@@ -3073,7 +3769,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2359
                 },
@@ -3082,7 +3780,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2372
                 },
@@ -3091,7 +3791,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2384
                 },
@@ -3100,7 +3802,9 @@
                     "token": "p_month_Feb_day_8",
                     "value": "p_month_Feb_day_8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2385
                 },
@@ -3109,7 +3813,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2402
                 },
@@ -3118,7 +3824,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2403
                 },
@@ -3127,7 +3835,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2416
                 },
@@ -3136,7 +3846,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2428
                 },
@@ -3145,7 +3857,9 @@
                     "token": "p_month_Feb_day_9",
                     "value": "p_month_Feb_day_9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2429
                 },
@@ -3154,7 +3868,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2446
                 },
@@ -3163,7 +3879,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2447
                 },
@@ -3172,7 +3890,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2460
                 },
@@ -3181,7 +3901,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2472
                 },
@@ -3190,7 +3912,9 @@
                     "token": "p_month_Feb_day_10",
                     "value": "p_month_Feb_day_10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2473
                 },
@@ -3199,7 +3923,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2491
                 },
@@ -3208,7 +3934,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2492
                 },
@@ -3217,7 +3945,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2505
                 },
@@ -3226,7 +3956,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2517
                 },
@@ -3235,7 +3967,9 @@
                     "token": "p_month_Feb_day_11",
                     "value": "p_month_Feb_day_11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2518
                 },
@@ -3244,7 +3978,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2536
                 },
@@ -3253,7 +3989,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2537
                 },
@@ -3262,7 +4000,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2550
                 },
@@ -3271,7 +4011,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2562
                 },
@@ -3280,7 +4022,9 @@
                     "token": "p_month_Feb_day_12",
                     "value": "p_month_Feb_day_12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2563
                 },
@@ -3289,7 +4033,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2581
                 },
@@ -3298,7 +4044,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2582
                 },
@@ -3307,7 +4055,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2595
                 },
@@ -3316,7 +4066,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2607
                 },
@@ -3325,7 +4077,9 @@
                     "token": "p_month_Feb_day_13",
                     "value": "p_month_Feb_day_13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2608
                 },
@@ -3334,7 +4088,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2626
                 },
@@ -3343,7 +4099,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2627
                 },
@@ -3352,7 +4110,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2640
                 },
@@ -3361,7 +4121,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2652
                 },
@@ -3370,7 +4132,9 @@
                     "token": "p_month_Feb_day_14",
                     "value": "p_month_Feb_day_14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2653
                 },
@@ -3379,7 +4143,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2671
                 },
@@ -3388,7 +4154,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2672
                 },
@@ -3397,7 +4165,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2685
                 },
@@ -3406,7 +4176,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2697
                 },
@@ -3415,7 +4187,9 @@
                     "token": "p_month_Feb_day_15",
                     "value": "p_month_Feb_day_15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2698
                 },
@@ -3424,7 +4198,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2716
                 },
@@ -3433,7 +4209,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2717
                 },
@@ -3442,7 +4220,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2730
                 },
@@ -3451,7 +4231,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2742
                 },
@@ -3460,7 +4242,9 @@
                     "token": "p_month_Feb_day_16",
                     "value": "p_month_Feb_day_16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2743
                 },
@@ -3469,7 +4253,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2761
                 },
@@ -3478,7 +4264,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2762
                 },
@@ -3487,7 +4275,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2775
                 },
@@ -3496,7 +4286,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2787
                 },
@@ -3505,7 +4297,9 @@
                     "token": "p_month_Feb_day_17",
                     "value": "p_month_Feb_day_17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2788
                 },
@@ -3514,7 +4308,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2806
                 },
@@ -3523,7 +4319,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2807
                 },
@@ -3532,7 +4330,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2820
                 },
@@ -3541,7 +4341,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2832
                 },
@@ -3550,7 +4352,9 @@
                     "token": "p_month_Feb_day_18",
                     "value": "p_month_Feb_day_18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2833
                 },
@@ -3559,7 +4363,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2851
                 },
@@ -3568,7 +4374,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2852
                 },
@@ -3577,7 +4385,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2865
                 },
@@ -3586,7 +4396,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2877
                 },
@@ -3595,7 +4407,9 @@
                     "token": "p_month_Feb_day_19",
                     "value": "p_month_Feb_day_19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2878
                 },
@@ -3604,7 +4418,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2896
                 },
@@ -3613,7 +4429,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2897
                 },
@@ -3622,7 +4440,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2910
                 },
@@ -3631,7 +4451,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2922
                 },
@@ -3640,7 +4462,9 @@
                     "token": "p_month_Feb_day_20",
                     "value": "p_month_Feb_day_20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2923
                 },
@@ -3649,7 +4473,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2941
                 },
@@ -3658,7 +4484,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2942
                 },
@@ -3667,7 +4495,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 2955
                 },
@@ -3676,7 +4506,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2967
                 },
@@ -3685,7 +4517,9 @@
                     "token": "p_month_Feb_day_21",
                     "value": "p_month_Feb_day_21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 2968
                 },
@@ -3694,7 +4528,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 2986
                 },
@@ -3703,7 +4539,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2987
                 },
@@ -3712,7 +4550,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3000
                 },
@@ -3721,7 +4561,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3012
                 },
@@ -3730,7 +4572,9 @@
                     "token": "p_month_Feb_day_22",
                     "value": "p_month_Feb_day_22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3013
                 },
@@ -3739,7 +4583,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3031
                 },
@@ -3748,7 +4594,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3032
                 },
@@ -3757,7 +4605,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3045
                 },
@@ -3766,7 +4616,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3057
                 },
@@ -3775,7 +4627,9 @@
                     "token": "p_month_Feb_day_23",
                     "value": "p_month_Feb_day_23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3058
                 },
@@ -3784,7 +4638,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3076
                 },
@@ -3793,7 +4649,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3077
                 },
@@ -3802,7 +4660,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3090
                 },
@@ -3811,7 +4671,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3102
                 },
@@ -3820,7 +4682,9 @@
                     "token": "p_month_Feb_day_24",
                     "value": "p_month_Feb_day_24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3103
                 },
@@ -3829,7 +4693,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3121
                 },
@@ -3838,7 +4704,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3122
                 },
@@ -3847,7 +4715,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3135
                 },
@@ -3856,7 +4726,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3147
                 },
@@ -3865,7 +4737,9 @@
                     "token": "p_month_Feb_day_25",
                     "value": "p_month_Feb_day_25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3148
                 },
@@ -3874,7 +4748,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3166
                 },
@@ -3883,7 +4759,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3167
                 },
@@ -3892,7 +4770,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3180
                 },
@@ -3901,7 +4781,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3192
                 },
@@ -3910,7 +4792,9 @@
                     "token": "p_month_Feb_day_26",
                     "value": "p_month_Feb_day_26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3193
                 },
@@ -3919,7 +4803,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3211
                 },
@@ -3928,7 +4814,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3212
                 },
@@ -3937,7 +4825,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3225
                 },
@@ -3946,7 +4836,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3237
                 },
@@ -3955,7 +4847,9 @@
                     "token": "p_month_Feb_day_27",
                     "value": "p_month_Feb_day_27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3238
                 },
@@ -3964,7 +4858,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3256
                 },
@@ -3973,7 +4869,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3257
                 },
@@ -3982,7 +4880,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3270
                 },
@@ -3991,7 +4891,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3282
                 },
@@ -4000,7 +4902,9 @@
                     "token": "p_month_Feb_day_28",
                     "value": "p_month_Feb_day_28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3283
                 },
@@ -4009,7 +4913,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3301
                 },
@@ -4018,7 +4924,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3302
                 },
@@ -4027,7 +4935,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3315
                 },
@@ -4036,7 +4946,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3327
                 },
@@ -4045,7 +4957,9 @@
                     "token": "p_month_Feb_day_29",
                     "value": "p_month_Feb_day_29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3328
                 },
@@ -4054,7 +4968,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3346
                 },
@@ -4063,7 +4979,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3347
                 },
@@ -4072,7 +4990,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3360
                 },
@@ -4081,7 +5001,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3372
                 },
@@ -4090,7 +5012,9 @@
                     "token": "p_month_Feb_day_30",
                     "value": "p_month_Feb_day_30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3373
                 },
@@ -4099,7 +5023,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3391
                 },
@@ -4108,7 +5034,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3392
                 },
@@ -4117,7 +5045,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3405
                 },
@@ -4126,7 +5056,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3417
                 },
@@ -4135,7 +5067,9 @@
                     "token": "p_month_Feb_day_31",
                     "value": "p_month_Feb_day_31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3418
                 },
@@ -4144,7 +5078,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3436
                 },
@@ -4153,7 +5089,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3445
                 },
@@ -4162,7 +5100,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3446
                 },
@@ -4171,7 +5111,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3447
                 },
@@ -4180,7 +5122,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3456
                 },
@@ -4189,7 +5133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3465
                 },
@@ -4198,7 +5144,9 @@
                     "token": "p_month_Mar",
                     "value": "p_month_Mar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3466
                 },
@@ -4207,7 +5155,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3477
                 },
@@ -4216,7 +5166,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 3482
                 },
@@ -4225,7 +5177,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3488
                 },
@@ -4234,7 +5188,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 3497
                 },
@@ -4243,7 +5199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3506
                 },
@@ -4252,7 +5210,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3507
                 },
@@ -4261,7 +5221,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 3508
                 },
@@ -4270,7 +5232,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3509
                 },
@@ -4279,7 +5243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3510
                 },
@@ -4288,7 +5254,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3511
                 },
@@ -4297,7 +5265,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3512
                 },
@@ -4306,7 +5276,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3525
                 },
@@ -4315,7 +5287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3537
                 },
@@ -4324,7 +5298,9 @@
                     "token": "p_month_Mar_day_0",
                     "value": "p_month_Mar_day_0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3538
                 },
@@ -4333,7 +5309,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3555
                 },
@@ -4342,7 +5320,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3556
                 },
@@ -4351,7 +5331,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3569
                 },
@@ -4360,7 +5342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3581
                 },
@@ -4369,7 +5353,9 @@
                     "token": "p_month_Mar_day_1",
                     "value": "p_month_Mar_day_1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3582
                 },
@@ -4378,7 +5364,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3599
                 },
@@ -4387,7 +5375,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3600
                 },
@@ -4396,7 +5386,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3613
                 },
@@ -4405,7 +5397,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3625
                 },
@@ -4414,7 +5408,9 @@
                     "token": "p_month_Mar_day_2",
                     "value": "p_month_Mar_day_2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3626
                 },
@@ -4423,7 +5419,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3643
                 },
@@ -4432,7 +5430,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3644
                 },
@@ -4441,7 +5441,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3657
                 },
@@ -4450,7 +5452,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3669
                 },
@@ -4459,7 +5463,9 @@
                     "token": "p_month_Mar_day_3",
                     "value": "p_month_Mar_day_3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3670
                 },
@@ -4468,7 +5474,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3687
                 },
@@ -4477,7 +5485,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3688
                 },
@@ -4486,7 +5496,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3701
                 },
@@ -4495,7 +5507,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3713
                 },
@@ -4504,7 +5518,9 @@
                     "token": "p_month_Mar_day_4",
                     "value": "p_month_Mar_day_4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3714
                 },
@@ -4513,7 +5529,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3731
                 },
@@ -4522,7 +5540,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3732
                 },
@@ -4531,7 +5551,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3745
                 },
@@ -4540,7 +5562,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3757
                 },
@@ -4549,7 +5573,9 @@
                     "token": "p_month_Mar_day_5",
                     "value": "p_month_Mar_day_5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3758
                 },
@@ -4558,7 +5584,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3775
                 },
@@ -4567,7 +5595,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3776
                 },
@@ -4576,7 +5606,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3789
                 },
@@ -4585,7 +5617,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3801
                 },
@@ -4594,7 +5628,9 @@
                     "token": "p_month_Mar_day_6",
                     "value": "p_month_Mar_day_6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3802
                 },
@@ -4603,7 +5639,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3819
                 },
@@ -4612,7 +5650,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3820
                 },
@@ -4621,7 +5661,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3833
                 },
@@ -4630,7 +5672,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3845
                 },
@@ -4639,7 +5683,9 @@
                     "token": "p_month_Mar_day_7",
                     "value": "p_month_Mar_day_7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3846
                 },
@@ -4648,7 +5694,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3863
                 },
@@ -4657,7 +5705,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3864
                 },
@@ -4666,7 +5716,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3877
                 },
@@ -4675,7 +5727,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3889
                 },
@@ -4684,7 +5738,9 @@
                     "token": "p_month_Mar_day_8",
                     "value": "p_month_Mar_day_8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3890
                 },
@@ -4693,7 +5749,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3907
                 },
@@ -4702,7 +5760,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3908
                 },
@@ -4711,7 +5771,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3921
                 },
@@ -4720,7 +5782,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3933
                 },
@@ -4729,7 +5793,9 @@
                     "token": "p_month_Mar_day_9",
                     "value": "p_month_Mar_day_9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3934
                 },
@@ -4738,7 +5804,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3951
                 },
@@ -4747,7 +5815,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3952
                 },
@@ -4756,7 +5826,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 3965
                 },
@@ -4765,7 +5837,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3977
                 },
@@ -4774,7 +5848,9 @@
                     "token": "p_month_Mar_day_10",
                     "value": "p_month_Mar_day_10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 3978
                 },
@@ -4783,7 +5859,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 3996
                 },
@@ -4792,7 +5870,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3997
                 },
@@ -4801,7 +5881,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4010
                 },
@@ -4810,7 +5892,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4022
                 },
@@ -4819,7 +5903,9 @@
                     "token": "p_month_Mar_day_11",
                     "value": "p_month_Mar_day_11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4023
                 },
@@ -4828,7 +5914,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4041
                 },
@@ -4837,7 +5925,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4042
                 },
@@ -4846,7 +5936,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4055
                 },
@@ -4855,7 +5947,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4067
                 },
@@ -4864,7 +5958,9 @@
                     "token": "p_month_Mar_day_12",
                     "value": "p_month_Mar_day_12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4068
                 },
@@ -4873,7 +5969,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4086
                 },
@@ -4882,7 +5980,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4087
                 },
@@ -4891,7 +5991,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4100
                 },
@@ -4900,7 +6002,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4112
                 },
@@ -4909,7 +6013,9 @@
                     "token": "p_month_Mar_day_13",
                     "value": "p_month_Mar_day_13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4113
                 },
@@ -4918,7 +6024,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4131
                 },
@@ -4927,7 +6035,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4132
                 },
@@ -4936,7 +6046,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4145
                 },
@@ -4945,7 +6057,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4157
                 },
@@ -4954,7 +6068,9 @@
                     "token": "p_month_Mar_day_14",
                     "value": "p_month_Mar_day_14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4158
                 },
@@ -4963,7 +6079,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4176
                 },
@@ -4972,7 +6090,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4177
                 },
@@ -4981,7 +6101,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4190
                 },
@@ -4990,7 +6112,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4202
                 },
@@ -4999,7 +6123,9 @@
                     "token": "p_month_Mar_day_15",
                     "value": "p_month_Mar_day_15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4203
                 },
@@ -5008,7 +6134,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4221
                 },
@@ -5017,7 +6145,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4222
                 },
@@ -5026,7 +6156,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4235
                 },
@@ -5035,7 +6167,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4247
                 },
@@ -5044,7 +6178,9 @@
                     "token": "p_month_Mar_day_16",
                     "value": "p_month_Mar_day_16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4248
                 },
@@ -5053,7 +6189,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4266
                 },
@@ -5062,7 +6200,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4267
                 },
@@ -5071,7 +6211,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4280
                 },
@@ -5080,7 +6222,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4292
                 },
@@ -5089,7 +6233,9 @@
                     "token": "p_month_Mar_day_17",
                     "value": "p_month_Mar_day_17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4293
                 },
@@ -5098,7 +6244,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4311
                 },
@@ -5107,7 +6255,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4312
                 },
@@ -5116,7 +6266,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4325
                 },
@@ -5125,7 +6277,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4337
                 },
@@ -5134,7 +6288,9 @@
                     "token": "p_month_Mar_day_18",
                     "value": "p_month_Mar_day_18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4338
                 },
@@ -5143,7 +6299,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4356
                 },
@@ -5152,7 +6310,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4357
                 },
@@ -5161,7 +6321,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4370
                 },
@@ -5170,7 +6332,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4382
                 },
@@ -5179,7 +6343,9 @@
                     "token": "p_month_Mar_day_19",
                     "value": "p_month_Mar_day_19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4383
                 },
@@ -5188,7 +6354,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4401
                 },
@@ -5197,7 +6365,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4402
                 },
@@ -5206,7 +6376,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4415
                 },
@@ -5215,7 +6387,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4427
                 },
@@ -5224,7 +6398,9 @@
                     "token": "p_month_Mar_day_20",
                     "value": "p_month_Mar_day_20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4428
                 },
@@ -5233,7 +6409,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4446
                 },
@@ -5242,7 +6420,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4447
                 },
@@ -5251,7 +6431,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4460
                 },
@@ -5260,7 +6442,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4472
                 },
@@ -5269,7 +6453,9 @@
                     "token": "p_month_Mar_day_21",
                     "value": "p_month_Mar_day_21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4473
                 },
@@ -5278,7 +6464,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4491
                 },
@@ -5287,7 +6475,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4492
                 },
@@ -5296,7 +6486,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4505
                 },
@@ -5305,7 +6497,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4517
                 },
@@ -5314,7 +6508,9 @@
                     "token": "p_month_Mar_day_22",
                     "value": "p_month_Mar_day_22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4518
                 },
@@ -5323,7 +6519,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4536
                 },
@@ -5332,7 +6530,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4537
                 },
@@ -5341,7 +6541,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4550
                 },
@@ -5350,7 +6552,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4562
                 },
@@ -5359,7 +6563,9 @@
                     "token": "p_month_Mar_day_23",
                     "value": "p_month_Mar_day_23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4563
                 },
@@ -5368,7 +6574,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4581
                 },
@@ -5377,7 +6585,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4582
                 },
@@ -5386,7 +6596,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4595
                 },
@@ -5395,7 +6607,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4607
                 },
@@ -5404,7 +6618,9 @@
                     "token": "p_month_Mar_day_24",
                     "value": "p_month_Mar_day_24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4608
                 },
@@ -5413,7 +6629,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4626
                 },
@@ -5422,7 +6640,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4627
                 },
@@ -5431,7 +6651,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4640
                 },
@@ -5440,7 +6662,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4652
                 },
@@ -5449,7 +6673,9 @@
                     "token": "p_month_Mar_day_25",
                     "value": "p_month_Mar_day_25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4653
                 },
@@ -5458,7 +6684,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4671
                 },
@@ -5467,7 +6695,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4672
                 },
@@ -5476,7 +6706,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4685
                 },
@@ -5485,7 +6717,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4697
                 },
@@ -5494,7 +6728,9 @@
                     "token": "p_month_Mar_day_26",
                     "value": "p_month_Mar_day_26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4698
                 },
@@ -5503,7 +6739,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4716
                 },
@@ -5512,7 +6750,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4717
                 },
@@ -5521,7 +6761,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4730
                 },
@@ -5530,7 +6772,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4742
                 },
@@ -5539,7 +6783,9 @@
                     "token": "p_month_Mar_day_27",
                     "value": "p_month_Mar_day_27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4743
                 },
@@ -5548,7 +6794,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4761
                 },
@@ -5557,7 +6805,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4762
                 },
@@ -5566,7 +6816,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4775
                 },
@@ -5575,7 +6827,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4787
                 },
@@ -5584,7 +6838,9 @@
                     "token": "p_month_Mar_day_28",
                     "value": "p_month_Mar_day_28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4788
                 },
@@ -5593,7 +6849,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4806
                 },
@@ -5602,7 +6860,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4807
                 },
@@ -5611,7 +6871,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4820
                 },
@@ -5620,7 +6882,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4832
                 },
@@ -5629,7 +6893,9 @@
                     "token": "p_month_Mar_day_29",
                     "value": "p_month_Mar_day_29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4833
                 },
@@ -5638,7 +6904,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4851
                 },
@@ -5647,7 +6915,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4852
                 },
@@ -5656,7 +6926,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4865
                 },
@@ -5665,7 +6937,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4877
                 },
@@ -5674,7 +6948,9 @@
                     "token": "p_month_Mar_day_30",
                     "value": "p_month_Mar_day_30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4878
                 },
@@ -5683,7 +6959,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4896
                 },
@@ -5692,7 +6970,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4897
                 },
@@ -5701,7 +6981,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4910
                 },
@@ -5710,7 +6992,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4922
                 },
@@ -5719,7 +7003,9 @@
                     "token": "p_month_Mar_day_31",
                     "value": "p_month_Mar_day_31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4923
                 },
@@ -5728,7 +7014,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4941
                 },
@@ -5737,7 +7025,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4950
                 },
@@ -5746,7 +7036,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 4951
                 },
@@ -5755,7 +7047,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4952
                 },
@@ -5764,7 +7058,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 4961
                 },
@@ -5773,7 +7069,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4970
                 },
@@ -5782,7 +7080,9 @@
                     "token": "p_month_Apr",
                     "value": "p_month_Apr",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 4971
                 },
@@ -5791,7 +7091,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4982
                 },
@@ -5800,7 +7102,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 4987
                 },
@@ -5809,7 +7113,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 4993
                 },
@@ -5818,7 +7124,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 5002
                 },
@@ -5827,7 +7135,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5011
                 },
@@ -5836,7 +7146,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5012
                 },
@@ -5845,7 +7157,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 5013
                 },
@@ -5854,7 +7168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5014
                 },
@@ -5863,7 +7179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5015
                 },
@@ -5872,7 +7190,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5016
                 },
@@ -5881,7 +7201,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5017
                 },
@@ -5890,7 +7212,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5030
                 },
@@ -5899,7 +7223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5042
                 },
@@ -5908,7 +7234,9 @@
                     "token": "p_month_Apr_day_0",
                     "value": "p_month_Apr_day_0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5043
                 },
@@ -5917,7 +7245,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5060
                 },
@@ -5926,7 +7256,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5061
                 },
@@ -5935,7 +7267,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5074
                 },
@@ -5944,7 +7278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5086
                 },
@@ -5953,7 +7289,9 @@
                     "token": "p_month_Apr_day_1",
                     "value": "p_month_Apr_day_1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5087
                 },
@@ -5962,7 +7300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5104
                 },
@@ -5971,7 +7311,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5105
                 },
@@ -5980,7 +7322,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5118
                 },
@@ -5989,7 +7333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5130
                 },
@@ -5998,7 +7344,9 @@
                     "token": "p_month_Apr_day_2",
                     "value": "p_month_Apr_day_2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5131
                 },
@@ -6007,7 +7355,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5148
                 },
@@ -6016,7 +7366,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5149
                 },
@@ -6025,7 +7377,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5162
                 },
@@ -6034,7 +7388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5174
                 },
@@ -6043,7 +7399,9 @@
                     "token": "p_month_Apr_day_3",
                     "value": "p_month_Apr_day_3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5175
                 },
@@ -6052,7 +7410,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5192
                 },
@@ -6061,7 +7421,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5193
                 },
@@ -6070,7 +7432,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5206
                 },
@@ -6079,7 +7443,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5218
                 },
@@ -6088,7 +7454,9 @@
                     "token": "p_month_Apr_day_4",
                     "value": "p_month_Apr_day_4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5219
                 },
@@ -6097,7 +7465,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5236
                 },
@@ -6106,7 +7476,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5237
                 },
@@ -6115,7 +7487,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5250
                 },
@@ -6124,7 +7498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5262
                 },
@@ -6133,7 +7509,9 @@
                     "token": "p_month_Apr_day_5",
                     "value": "p_month_Apr_day_5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5263
                 },
@@ -6142,7 +7520,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5280
                 },
@@ -6151,7 +7531,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5281
                 },
@@ -6160,7 +7542,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5294
                 },
@@ -6169,7 +7553,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5306
                 },
@@ -6178,7 +7564,9 @@
                     "token": "p_month_Apr_day_6",
                     "value": "p_month_Apr_day_6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5307
                 },
@@ -6187,7 +7575,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5324
                 },
@@ -6196,7 +7586,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5325
                 },
@@ -6205,7 +7597,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5338
                 },
@@ -6214,7 +7608,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5350
                 },
@@ -6223,7 +7619,9 @@
                     "token": "p_month_Apr_day_7",
                     "value": "p_month_Apr_day_7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5351
                 },
@@ -6232,7 +7630,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5368
                 },
@@ -6241,7 +7641,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5369
                 },
@@ -6250,7 +7652,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5382
                 },
@@ -6259,7 +7663,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5394
                 },
@@ -6268,7 +7674,9 @@
                     "token": "p_month_Apr_day_8",
                     "value": "p_month_Apr_day_8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5395
                 },
@@ -6277,7 +7685,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5412
                 },
@@ -6286,7 +7696,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5413
                 },
@@ -6295,7 +7707,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5426
                 },
@@ -6304,7 +7718,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5438
                 },
@@ -6313,7 +7729,9 @@
                     "token": "p_month_Apr_day_9",
                     "value": "p_month_Apr_day_9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5439
                 },
@@ -6322,7 +7740,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5456
                 },
@@ -6331,7 +7751,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5457
                 },
@@ -6340,7 +7762,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5470
                 },
@@ -6349,7 +7773,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5482
                 },
@@ -6358,7 +7784,9 @@
                     "token": "p_month_Apr_day_10",
                     "value": "p_month_Apr_day_10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5483
                 },
@@ -6367,7 +7795,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5501
                 },
@@ -6376,7 +7806,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5502
                 },
@@ -6385,7 +7817,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5515
                 },
@@ -6394,7 +7828,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5527
                 },
@@ -6403,7 +7839,9 @@
                     "token": "p_month_Apr_day_11",
                     "value": "p_month_Apr_day_11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5528
                 },
@@ -6412,7 +7850,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5546
                 },
@@ -6421,7 +7861,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5547
                 },
@@ -6430,7 +7872,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5560
                 },
@@ -6439,7 +7883,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5572
                 },
@@ -6448,7 +7894,9 @@
                     "token": "p_month_Apr_day_12",
                     "value": "p_month_Apr_day_12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5573
                 },
@@ -6457,7 +7905,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5591
                 },
@@ -6466,7 +7916,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5592
                 },
@@ -6475,7 +7927,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5605
                 },
@@ -6484,7 +7938,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5617
                 },
@@ -6493,7 +7949,9 @@
                     "token": "p_month_Apr_day_13",
                     "value": "p_month_Apr_day_13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5618
                 },
@@ -6502,7 +7960,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5636
                 },
@@ -6511,7 +7971,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5637
                 },
@@ -6520,7 +7982,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5650
                 },
@@ -6529,7 +7993,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5662
                 },
@@ -6538,7 +8004,9 @@
                     "token": "p_month_Apr_day_14",
                     "value": "p_month_Apr_day_14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5663
                 },
@@ -6547,7 +8015,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5681
                 },
@@ -6556,7 +8026,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5682
                 },
@@ -6565,7 +8037,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5695
                 },
@@ -6574,7 +8048,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5707
                 },
@@ -6583,7 +8059,9 @@
                     "token": "p_month_Apr_day_15",
                     "value": "p_month_Apr_day_15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5708
                 },
@@ -6592,7 +8070,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5726
                 },
@@ -6601,7 +8081,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5727
                 },
@@ -6610,7 +8092,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5740
                 },
@@ -6619,7 +8103,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5752
                 },
@@ -6628,7 +8114,9 @@
                     "token": "p_month_Apr_day_16",
                     "value": "p_month_Apr_day_16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5753
                 },
@@ -6637,7 +8125,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5771
                 },
@@ -6646,7 +8136,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5772
                 },
@@ -6655,7 +8147,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5785
                 },
@@ -6664,7 +8158,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5797
                 },
@@ -6673,7 +8169,9 @@
                     "token": "p_month_Apr_day_17",
                     "value": "p_month_Apr_day_17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5798
                 },
@@ -6682,7 +8180,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5816
                 },
@@ -6691,7 +8191,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5817
                 },
@@ -6700,7 +8202,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5830
                 },
@@ -6709,7 +8213,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5842
                 },
@@ -6718,7 +8224,9 @@
                     "token": "p_month_Apr_day_18",
                     "value": "p_month_Apr_day_18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5843
                 },
@@ -6727,7 +8235,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5861
                 },
@@ -6736,7 +8246,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5862
                 },
@@ -6745,7 +8257,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5875
                 },
@@ -6754,7 +8268,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5887
                 },
@@ -6763,7 +8279,9 @@
                     "token": "p_month_Apr_day_19",
                     "value": "p_month_Apr_day_19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5888
                 },
@@ -6772,7 +8290,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5906
                 },
@@ -6781,7 +8301,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5907
                 },
@@ -6790,7 +8312,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5920
                 },
@@ -6799,7 +8323,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5932
                 },
@@ -6808,7 +8334,9 @@
                     "token": "p_month_Apr_day_20",
                     "value": "p_month_Apr_day_20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5933
                 },
@@ -6817,7 +8345,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5951
                 },
@@ -6826,7 +8356,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5952
                 },
@@ -6835,7 +8367,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5965
                 },
@@ -6844,7 +8378,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5977
                 },
@@ -6853,7 +8389,9 @@
                     "token": "p_month_Apr_day_21",
                     "value": "p_month_Apr_day_21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 5978
                 },
@@ -6862,7 +8400,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 5996
                 },
@@ -6871,7 +8411,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 5997
                 },
@@ -6880,7 +8422,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6010
                 },
@@ -6889,7 +8433,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6022
                 },
@@ -6898,7 +8444,9 @@
                     "token": "p_month_Apr_day_22",
                     "value": "p_month_Apr_day_22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6023
                 },
@@ -6907,7 +8455,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6041
                 },
@@ -6916,7 +8466,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6042
                 },
@@ -6925,7 +8477,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6055
                 },
@@ -6934,7 +8488,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6067
                 },
@@ -6943,7 +8499,9 @@
                     "token": "p_month_Apr_day_23",
                     "value": "p_month_Apr_day_23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6068
                 },
@@ -6952,7 +8510,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6086
                 },
@@ -6961,7 +8521,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6087
                 },
@@ -6970,7 +8532,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6100
                 },
@@ -6979,7 +8543,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6112
                 },
@@ -6988,7 +8554,9 @@
                     "token": "p_month_Apr_day_24",
                     "value": "p_month_Apr_day_24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6113
                 },
@@ -6997,7 +8565,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6131
                 },
@@ -7006,7 +8576,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6132
                 },
@@ -7015,7 +8587,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6145
                 },
@@ -7024,7 +8598,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6157
                 },
@@ -7033,7 +8609,9 @@
                     "token": "p_month_Apr_day_25",
                     "value": "p_month_Apr_day_25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6158
                 },
@@ -7042,7 +8620,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6176
                 },
@@ -7051,7 +8631,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6177
                 },
@@ -7060,7 +8642,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6190
                 },
@@ -7069,7 +8653,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6202
                 },
@@ -7078,7 +8664,9 @@
                     "token": "p_month_Apr_day_26",
                     "value": "p_month_Apr_day_26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6203
                 },
@@ -7087,7 +8675,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6221
                 },
@@ -7096,7 +8686,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6222
                 },
@@ -7105,7 +8697,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6235
                 },
@@ -7114,7 +8708,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6247
                 },
@@ -7123,7 +8719,9 @@
                     "token": "p_month_Apr_day_27",
                     "value": "p_month_Apr_day_27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6248
                 },
@@ -7132,7 +8730,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6266
                 },
@@ -7141,7 +8741,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6267
                 },
@@ -7150,7 +8752,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6280
                 },
@@ -7159,7 +8763,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6292
                 },
@@ -7168,7 +8774,9 @@
                     "token": "p_month_Apr_day_28",
                     "value": "p_month_Apr_day_28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6293
                 },
@@ -7177,7 +8785,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6311
                 },
@@ -7186,7 +8796,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6312
                 },
@@ -7195,7 +8807,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6325
                 },
@@ -7204,7 +8818,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6337
                 },
@@ -7213,7 +8829,9 @@
                     "token": "p_month_Apr_day_29",
                     "value": "p_month_Apr_day_29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6338
                 },
@@ -7222,7 +8840,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6356
                 },
@@ -7231,7 +8851,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6357
                 },
@@ -7240,7 +8862,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6370
                 },
@@ -7249,7 +8873,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6382
                 },
@@ -7258,7 +8884,9 @@
                     "token": "p_month_Apr_day_30",
                     "value": "p_month_Apr_day_30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6383
                 },
@@ -7267,7 +8895,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6401
                 },
@@ -7276,7 +8906,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6402
                 },
@@ -7285,7 +8917,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6415
                 },
@@ -7294,7 +8928,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6427
                 },
@@ -7303,7 +8939,9 @@
                     "token": "p_month_Apr_day_31",
                     "value": "p_month_Apr_day_31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6428
                 },
@@ -7312,7 +8950,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6446
                 },
@@ -7321,7 +8961,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6455
                 },
@@ -7330,7 +8972,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6456
                 },
@@ -7339,7 +8983,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6457
                 },
@@ -7348,7 +8994,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 6466
                 },
@@ -7357,7 +9005,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6475
                 },
@@ -7366,7 +9016,9 @@
                     "token": "p_month_Mai",
                     "value": "p_month_Mai",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6476
                 },
@@ -7375,7 +9027,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6487
                 },
@@ -7384,7 +9038,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 6492
                 },
@@ -7393,7 +9049,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6498
                 },
@@ -7402,7 +9060,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 6507
                 },
@@ -7411,7 +9071,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6516
                 },
@@ -7420,7 +9082,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6517
                 },
@@ -7429,7 +9093,9 @@
                     "token": "4",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 6518
                 },
@@ -7438,7 +9104,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6519
                 },
@@ -7447,7 +9115,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6520
                 },
@@ -7456,7 +9126,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6521
                 },
@@ -7465,7 +9137,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6522
                 },
@@ -7474,7 +9148,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6535
                 },
@@ -7483,7 +9159,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6547
                 },
@@ -7492,7 +9170,9 @@
                     "token": "p_month_Mai_day_0",
                     "value": "p_month_Mai_day_0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6548
                 },
@@ -7501,7 +9181,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6565
                 },
@@ -7510,7 +9192,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6566
                 },
@@ -7519,7 +9203,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6579
                 },
@@ -7528,7 +9214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6591
                 },
@@ -7537,7 +9225,9 @@
                     "token": "p_month_Mai_day_1",
                     "value": "p_month_Mai_day_1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6592
                 },
@@ -7546,7 +9236,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6609
                 },
@@ -7555,7 +9247,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6610
                 },
@@ -7564,7 +9258,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6623
                 },
@@ -7573,7 +9269,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6635
                 },
@@ -7582,7 +9280,9 @@
                     "token": "p_month_Mai_day_2",
                     "value": "p_month_Mai_day_2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6636
                 },
@@ -7591,7 +9291,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6653
                 },
@@ -7600,7 +9302,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6654
                 },
@@ -7609,7 +9313,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6667
                 },
@@ -7618,7 +9324,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6679
                 },
@@ -7627,7 +9335,9 @@
                     "token": "p_month_Mai_day_3",
                     "value": "p_month_Mai_day_3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6680
                 },
@@ -7636,7 +9346,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6697
                 },
@@ -7645,7 +9357,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6698
                 },
@@ -7654,7 +9368,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6711
                 },
@@ -7663,7 +9379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6723
                 },
@@ -7672,7 +9390,9 @@
                     "token": "p_month_Mai_day_4",
                     "value": "p_month_Mai_day_4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6724
                 },
@@ -7681,7 +9401,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6741
                 },
@@ -7690,7 +9412,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6742
                 },
@@ -7699,7 +9423,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6755
                 },
@@ -7708,7 +9434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6767
                 },
@@ -7717,7 +9445,9 @@
                     "token": "p_month_Mai_day_5",
                     "value": "p_month_Mai_day_5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6768
                 },
@@ -7726,7 +9456,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6785
                 },
@@ -7735,7 +9467,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6786
                 },
@@ -7744,7 +9478,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6799
                 },
@@ -7753,7 +9489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6811
                 },
@@ -7762,7 +9500,9 @@
                     "token": "p_month_Mai_day_6",
                     "value": "p_month_Mai_day_6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6812
                 },
@@ -7771,7 +9511,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6829
                 },
@@ -7780,7 +9522,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6830
                 },
@@ -7789,7 +9533,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6843
                 },
@@ -7798,7 +9544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6855
                 },
@@ -7807,7 +9555,9 @@
                     "token": "p_month_Mai_day_7",
                     "value": "p_month_Mai_day_7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6856
                 },
@@ -7816,7 +9566,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6873
                 },
@@ -7825,7 +9577,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6874
                 },
@@ -7834,7 +9588,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6887
                 },
@@ -7843,7 +9599,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6899
                 },
@@ -7852,7 +9610,9 @@
                     "token": "p_month_Mai_day_8",
                     "value": "p_month_Mai_day_8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6900
                 },
@@ -7861,7 +9621,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6917
                 },
@@ -7870,7 +9632,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6918
                 },
@@ -7879,7 +9643,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6931
                 },
@@ -7888,7 +9654,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6943
                 },
@@ -7897,7 +9665,9 @@
                     "token": "p_month_Mai_day_9",
                     "value": "p_month_Mai_day_9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6944
                 },
@@ -7906,7 +9676,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 6961
                 },
@@ -7915,7 +9687,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6962
                 },
@@ -7924,7 +9698,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6975
                 },
@@ -7933,7 +9709,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 6987
                 },
@@ -7942,7 +9720,9 @@
                     "token": "p_month_Mai_day_10",
                     "value": "p_month_Mai_day_10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 6988
                 },
@@ -7951,7 +9731,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7006
                 },
@@ -7960,7 +9742,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7007
                 },
@@ -7969,7 +9753,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7020
                 },
@@ -7978,7 +9764,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7032
                 },
@@ -7987,7 +9775,9 @@
                     "token": "p_month_Mai_day_11",
                     "value": "p_month_Mai_day_11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7033
                 },
@@ -7996,7 +9786,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7051
                 },
@@ -8005,7 +9797,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7052
                 },
@@ -8014,7 +9808,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7065
                 },
@@ -8023,7 +9819,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7077
                 },
@@ -8032,7 +9830,9 @@
                     "token": "p_month_Mai_day_12",
                     "value": "p_month_Mai_day_12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7078
                 },
@@ -8041,7 +9841,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7096
                 },
@@ -8050,7 +9852,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7097
                 },
@@ -8059,7 +9863,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7110
                 },
@@ -8068,7 +9874,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7122
                 },
@@ -8077,7 +9885,9 @@
                     "token": "p_month_Mai_day_13",
                     "value": "p_month_Mai_day_13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7123
                 },
@@ -8086,7 +9896,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7141
                 },
@@ -8095,7 +9907,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7142
                 },
@@ -8104,7 +9918,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7155
                 },
@@ -8113,7 +9929,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7167
                 },
@@ -8122,7 +9940,9 @@
                     "token": "p_month_Mai_day_14",
                     "value": "p_month_Mai_day_14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7168
                 },
@@ -8131,7 +9951,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7186
                 },
@@ -8140,7 +9962,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7187
                 },
@@ -8149,7 +9973,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7200
                 },
@@ -8158,7 +9984,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7212
                 },
@@ -8167,7 +9995,9 @@
                     "token": "p_month_Mai_day_15",
                     "value": "p_month_Mai_day_15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7213
                 },
@@ -8176,7 +10006,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7231
                 },
@@ -8185,7 +10017,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7232
                 },
@@ -8194,7 +10028,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7245
                 },
@@ -8203,7 +10039,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7257
                 },
@@ -8212,7 +10050,9 @@
                     "token": "p_month_Mai_day_16",
                     "value": "p_month_Mai_day_16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7258
                 },
@@ -8221,7 +10061,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7276
                 },
@@ -8230,7 +10072,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7277
                 },
@@ -8239,7 +10083,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7290
                 },
@@ -8248,7 +10094,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7302
                 },
@@ -8257,7 +10105,9 @@
                     "token": "p_month_Mai_day_17",
                     "value": "p_month_Mai_day_17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7303
                 },
@@ -8266,7 +10116,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7321
                 },
@@ -8275,7 +10127,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7322
                 },
@@ -8284,7 +10138,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7335
                 },
@@ -8293,7 +10149,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7347
                 },
@@ -8302,7 +10160,9 @@
                     "token": "p_month_Mai_day_18",
                     "value": "p_month_Mai_day_18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7348
                 },
@@ -8311,7 +10171,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7366
                 },
@@ -8320,7 +10182,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7367
                 },
@@ -8329,7 +10193,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7380
                 },
@@ -8338,7 +10204,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7392
                 },
@@ -8347,7 +10215,9 @@
                     "token": "p_month_Mai_day_19",
                     "value": "p_month_Mai_day_19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7393
                 },
@@ -8356,7 +10226,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7411
                 },
@@ -8365,7 +10237,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7412
                 },
@@ -8374,7 +10248,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7425
                 },
@@ -8383,7 +10259,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7437
                 },
@@ -8392,7 +10270,9 @@
                     "token": "p_month_Mai_day_20",
                     "value": "p_month_Mai_day_20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7438
                 },
@@ -8401,7 +10281,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7456
                 },
@@ -8410,7 +10292,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7457
                 },
@@ -8419,7 +10303,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7470
                 },
@@ -8428,7 +10314,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7482
                 },
@@ -8437,7 +10325,9 @@
                     "token": "p_month_Mai_day_21",
                     "value": "p_month_Mai_day_21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7483
                 },
@@ -8446,7 +10336,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7501
                 },
@@ -8455,7 +10347,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7502
                 },
@@ -8464,7 +10358,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7515
                 },
@@ -8473,7 +10369,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7527
                 },
@@ -8482,7 +10380,9 @@
                     "token": "p_month_Mai_day_22",
                     "value": "p_month_Mai_day_22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7528
                 },
@@ -8491,7 +10391,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7546
                 },
@@ -8500,7 +10402,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7547
                 },
@@ -8509,7 +10413,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7560
                 },
@@ -8518,7 +10424,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7572
                 },
@@ -8527,7 +10435,9 @@
                     "token": "p_month_Mai_day_23",
                     "value": "p_month_Mai_day_23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7573
                 },
@@ -8536,7 +10446,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7591
                 },
@@ -8545,7 +10457,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7592
                 },
@@ -8554,7 +10468,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7605
                 },
@@ -8563,7 +10479,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7617
                 },
@@ -8572,7 +10490,9 @@
                     "token": "p_month_Mai_day_24",
                     "value": "p_month_Mai_day_24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7618
                 },
@@ -8581,7 +10501,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7636
                 },
@@ -8590,7 +10512,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7637
                 },
@@ -8599,7 +10523,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7650
                 },
@@ -8608,7 +10534,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7662
                 },
@@ -8617,7 +10545,9 @@
                     "token": "p_month_Mai_day_25",
                     "value": "p_month_Mai_day_25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7663
                 },
@@ -8626,7 +10556,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7681
                 },
@@ -8635,7 +10567,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7682
                 },
@@ -8644,7 +10578,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7695
                 },
@@ -8653,7 +10589,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7707
                 },
@@ -8662,7 +10600,9 @@
                     "token": "p_month_Mai_day_26",
                     "value": "p_month_Mai_day_26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7708
                 },
@@ -8671,7 +10611,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7726
                 },
@@ -8680,7 +10622,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7727
                 },
@@ -8689,7 +10633,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7740
                 },
@@ -8698,7 +10644,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7752
                 },
@@ -8707,7 +10655,9 @@
                     "token": "p_month_Mai_day_27",
                     "value": "p_month_Mai_day_27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7753
                 },
@@ -8716,7 +10666,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7771
                 },
@@ -8725,7 +10677,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7772
                 },
@@ -8734,7 +10688,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7785
                 },
@@ -8743,7 +10699,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7797
                 },
@@ -8752,7 +10710,9 @@
                     "token": "p_month_Mai_day_28",
                     "value": "p_month_Mai_day_28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7798
                 },
@@ -8761,7 +10721,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7816
                 },
@@ -8770,7 +10732,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7817
                 },
@@ -8779,7 +10743,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7830
                 },
@@ -8788,7 +10754,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7842
                 },
@@ -8797,7 +10765,9 @@
                     "token": "p_month_Mai_day_29",
                     "value": "p_month_Mai_day_29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7843
                 },
@@ -8806,7 +10776,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7861
                 },
@@ -8815,7 +10787,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7862
                 },
@@ -8824,7 +10798,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7875
                 },
@@ -8833,7 +10809,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7887
                 },
@@ -8842,7 +10820,9 @@
                     "token": "p_month_Mai_day_30",
                     "value": "p_month_Mai_day_30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7888
                 },
@@ -8851,7 +10831,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7906
                 },
@@ -8860,7 +10842,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7907
                 },
@@ -8869,7 +10853,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7920
                 },
@@ -8878,7 +10864,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7932
                 },
@@ -8887,7 +10875,9 @@
                     "token": "p_month_Mai_day_31",
                     "value": "p_month_Mai_day_31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7933
                 },
@@ -8896,7 +10886,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7951
                 },
@@ -8905,7 +10897,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7960
                 },
@@ -8914,7 +10908,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 7961
                 },
@@ -8923,7 +10919,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7962
                 },
@@ -8932,7 +10930,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7971
                 },
@@ -8941,7 +10941,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7980
                 },
@@ -8950,7 +10952,9 @@
                     "token": "p_month_Jun",
                     "value": "p_month_Jun",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 7981
                 },
@@ -8959,7 +10963,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 7992
                 },
@@ -8968,7 +10974,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 7997
                 },
@@ -8977,7 +10985,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8003
                 },
@@ -8986,7 +10996,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 8012
                 },
@@ -8995,7 +11007,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8021
                 },
@@ -9004,7 +11018,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8022
                 },
@@ -9013,7 +11029,9 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 8023
                 },
@@ -9022,7 +11040,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8024
                 },
@@ -9031,7 +11051,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8025
                 },
@@ -9040,7 +11062,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8026
                 },
@@ -9049,7 +11073,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8027
                 },
@@ -9058,7 +11084,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8040
                 },
@@ -9067,7 +11095,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8052
                 },
@@ -9076,7 +11106,9 @@
                     "token": "p_month_Jun_day_0",
                     "value": "p_month_Jun_day_0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8053
                 },
@@ -9085,7 +11117,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8070
                 },
@@ -9094,7 +11128,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8071
                 },
@@ -9103,7 +11139,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8084
                 },
@@ -9112,7 +11150,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8096
                 },
@@ -9121,7 +11161,9 @@
                     "token": "p_month_Jun_day_1",
                     "value": "p_month_Jun_day_1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8097
                 },
@@ -9130,7 +11172,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8114
                 },
@@ -9139,7 +11183,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8115
                 },
@@ -9148,7 +11194,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8128
                 },
@@ -9157,7 +11205,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8140
                 },
@@ -9166,7 +11216,9 @@
                     "token": "p_month_Jun_day_2",
                     "value": "p_month_Jun_day_2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8141
                 },
@@ -9175,7 +11227,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8158
                 },
@@ -9184,7 +11238,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8159
                 },
@@ -9193,7 +11249,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8172
                 },
@@ -9202,7 +11260,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8184
                 },
@@ -9211,7 +11271,9 @@
                     "token": "p_month_Jun_day_3",
                     "value": "p_month_Jun_day_3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8185
                 },
@@ -9220,7 +11282,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8202
                 },
@@ -9229,7 +11293,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8203
                 },
@@ -9238,7 +11304,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8216
                 },
@@ -9247,7 +11315,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8228
                 },
@@ -9256,7 +11326,9 @@
                     "token": "p_month_Jun_day_4",
                     "value": "p_month_Jun_day_4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8229
                 },
@@ -9265,7 +11337,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8246
                 },
@@ -9274,7 +11348,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8247
                 },
@@ -9283,7 +11359,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8260
                 },
@@ -9292,7 +11370,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8272
                 },
@@ -9301,7 +11381,9 @@
                     "token": "p_month_Jun_day_5",
                     "value": "p_month_Jun_day_5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8273
                 },
@@ -9310,7 +11392,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8290
                 },
@@ -9319,7 +11403,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8291
                 },
@@ -9328,7 +11414,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8304
                 },
@@ -9337,7 +11425,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8316
                 },
@@ -9346,7 +11436,9 @@
                     "token": "p_month_Jun_day_6",
                     "value": "p_month_Jun_day_6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8317
                 },
@@ -9355,7 +11447,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8334
                 },
@@ -9364,7 +11458,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8335
                 },
@@ -9373,7 +11469,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8348
                 },
@@ -9382,7 +11480,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8360
                 },
@@ -9391,7 +11491,9 @@
                     "token": "p_month_Jun_day_7",
                     "value": "p_month_Jun_day_7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8361
                 },
@@ -9400,7 +11502,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8378
                 },
@@ -9409,7 +11513,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8379
                 },
@@ -9418,7 +11524,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8392
                 },
@@ -9427,7 +11535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8404
                 },
@@ -9436,7 +11546,9 @@
                     "token": "p_month_Jun_day_8",
                     "value": "p_month_Jun_day_8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8405
                 },
@@ -9445,7 +11557,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8422
                 },
@@ -9454,7 +11568,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8423
                 },
@@ -9463,7 +11579,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8436
                 },
@@ -9472,7 +11590,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8448
                 },
@@ -9481,7 +11601,9 @@
                     "token": "p_month_Jun_day_9",
                     "value": "p_month_Jun_day_9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8449
                 },
@@ -9490,7 +11612,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8466
                 },
@@ -9499,7 +11623,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8467
                 },
@@ -9508,7 +11634,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8480
                 },
@@ -9517,7 +11645,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8492
                 },
@@ -9526,7 +11656,9 @@
                     "token": "p_month_Jun_day_10",
                     "value": "p_month_Jun_day_10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8493
                 },
@@ -9535,7 +11667,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8511
                 },
@@ -9544,7 +11678,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8512
                 },
@@ -9553,7 +11689,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8525
                 },
@@ -9562,7 +11700,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8537
                 },
@@ -9571,7 +11711,9 @@
                     "token": "p_month_Jun_day_11",
                     "value": "p_month_Jun_day_11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8538
                 },
@@ -9580,7 +11722,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8556
                 },
@@ -9589,7 +11733,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8557
                 },
@@ -9598,7 +11744,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8570
                 },
@@ -9607,7 +11755,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8582
                 },
@@ -9616,7 +11766,9 @@
                     "token": "p_month_Jun_day_12",
                     "value": "p_month_Jun_day_12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8583
                 },
@@ -9625,7 +11777,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8601
                 },
@@ -9634,7 +11788,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8602
                 },
@@ -9643,7 +11799,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8615
                 },
@@ -9652,7 +11810,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8627
                 },
@@ -9661,7 +11821,9 @@
                     "token": "p_month_Jun_day_13",
                     "value": "p_month_Jun_day_13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8628
                 },
@@ -9670,7 +11832,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8646
                 },
@@ -9679,7 +11843,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8647
                 },
@@ -9688,7 +11854,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8660
                 },
@@ -9697,7 +11865,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8672
                 },
@@ -9706,7 +11876,9 @@
                     "token": "p_month_Jun_day_14",
                     "value": "p_month_Jun_day_14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8673
                 },
@@ -9715,7 +11887,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8691
                 },
@@ -9724,7 +11898,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8692
                 },
@@ -9733,7 +11909,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8705
                 },
@@ -9742,7 +11920,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8717
                 },
@@ -9751,7 +11931,9 @@
                     "token": "p_month_Jun_day_15",
                     "value": "p_month_Jun_day_15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8718
                 },
@@ -9760,7 +11942,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8736
                 },
@@ -9769,7 +11953,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8737
                 },
@@ -9778,7 +11964,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8750
                 },
@@ -9787,7 +11975,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8762
                 },
@@ -9796,7 +11986,9 @@
                     "token": "p_month_Jun_day_16",
                     "value": "p_month_Jun_day_16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8763
                 },
@@ -9805,7 +11997,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8781
                 },
@@ -9814,7 +12008,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8782
                 },
@@ -9823,7 +12019,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8795
                 },
@@ -9832,7 +12030,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8807
                 },
@@ -9841,7 +12041,9 @@
                     "token": "p_month_Jun_day_17",
                     "value": "p_month_Jun_day_17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8808
                 },
@@ -9850,7 +12052,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8826
                 },
@@ -9859,7 +12063,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8827
                 },
@@ -9868,7 +12074,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8840
                 },
@@ -9877,7 +12085,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8852
                 },
@@ -9886,7 +12096,9 @@
                     "token": "p_month_Jun_day_18",
                     "value": "p_month_Jun_day_18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8853
                 },
@@ -9895,7 +12107,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8871
                 },
@@ -9904,7 +12118,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8872
                 },
@@ -9913,7 +12129,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8885
                 },
@@ -9922,7 +12140,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8897
                 },
@@ -9931,7 +12151,9 @@
                     "token": "p_month_Jun_day_19",
                     "value": "p_month_Jun_day_19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8898
                 },
@@ -9940,7 +12162,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8916
                 },
@@ -9949,7 +12173,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8917
                 },
@@ -9958,7 +12184,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8930
                 },
@@ -9967,7 +12195,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8942
                 },
@@ -9976,7 +12206,9 @@
                     "token": "p_month_Jun_day_20",
                     "value": "p_month_Jun_day_20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8943
                 },
@@ -9985,7 +12217,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 8961
                 },
@@ -9994,7 +12228,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8962
                 },
@@ -10003,7 +12239,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 8975
                 },
@@ -10012,7 +12250,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8987
                 },
@@ -10021,7 +12261,9 @@
                     "token": "p_month_Jun_day_21",
                     "value": "p_month_Jun_day_21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 8988
                 },
@@ -10030,7 +12272,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9006
                 },
@@ -10039,7 +12283,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9007
                 },
@@ -10048,7 +12294,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9020
                 },
@@ -10057,7 +12305,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9032
                 },
@@ -10066,7 +12316,9 @@
                     "token": "p_month_Jun_day_22",
                     "value": "p_month_Jun_day_22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9033
                 },
@@ -10075,7 +12327,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9051
                 },
@@ -10084,7 +12338,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9052
                 },
@@ -10093,7 +12349,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9065
                 },
@@ -10102,7 +12360,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9077
                 },
@@ -10111,7 +12371,9 @@
                     "token": "p_month_Jun_day_23",
                     "value": "p_month_Jun_day_23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9078
                 },
@@ -10120,7 +12382,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9096
                 },
@@ -10129,7 +12393,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9097
                 },
@@ -10138,7 +12404,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9110
                 },
@@ -10147,7 +12415,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9122
                 },
@@ -10156,7 +12426,9 @@
                     "token": "p_month_Jun_day_24",
                     "value": "p_month_Jun_day_24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9123
                 },
@@ -10165,7 +12437,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9141
                 },
@@ -10174,7 +12448,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9142
                 },
@@ -10183,7 +12459,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9155
                 },
@@ -10192,7 +12470,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9167
                 },
@@ -10201,7 +12481,9 @@
                     "token": "p_month_Jun_day_25",
                     "value": "p_month_Jun_day_25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9168
                 },
@@ -10210,7 +12492,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9186
                 },
@@ -10219,7 +12503,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9187
                 },
@@ -10228,7 +12514,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9200
                 },
@@ -10237,7 +12525,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9212
                 },
@@ -10246,7 +12536,9 @@
                     "token": "p_month_Jun_day_26",
                     "value": "p_month_Jun_day_26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9213
                 },
@@ -10255,7 +12547,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9231
                 },
@@ -10264,7 +12558,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9232
                 },
@@ -10273,7 +12569,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9245
                 },
@@ -10282,7 +12580,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9257
                 },
@@ -10291,7 +12591,9 @@
                     "token": "p_month_Jun_day_27",
                     "value": "p_month_Jun_day_27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9258
                 },
@@ -10300,7 +12602,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9276
                 },
@@ -10309,7 +12613,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9277
                 },
@@ -10318,7 +12624,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9290
                 },
@@ -10327,7 +12635,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9302
                 },
@@ -10336,7 +12646,9 @@
                     "token": "p_month_Jun_day_28",
                     "value": "p_month_Jun_day_28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9303
                 },
@@ -10345,7 +12657,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9321
                 },
@@ -10354,7 +12668,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9322
                 },
@@ -10363,7 +12679,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9335
                 },
@@ -10372,7 +12690,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9347
                 },
@@ -10381,7 +12701,9 @@
                     "token": "p_month_Jun_day_29",
                     "value": "p_month_Jun_day_29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9348
                 },
@@ -10390,7 +12712,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9366
                 },
@@ -10399,7 +12723,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9367
                 },
@@ -10408,7 +12734,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9380
                 },
@@ -10417,7 +12745,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9392
                 },
@@ -10426,7 +12756,9 @@
                     "token": "p_month_Jun_day_30",
                     "value": "p_month_Jun_day_30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9393
                 },
@@ -10435,7 +12767,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9411
                 },
@@ -10444,7 +12778,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9412
                 },
@@ -10453,7 +12789,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9425
                 },
@@ -10462,7 +12800,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9437
                 },
@@ -10471,7 +12811,9 @@
                     "token": "p_month_Jun_day_31",
                     "value": "p_month_Jun_day_31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9438
                 },
@@ -10480,7 +12822,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9456
                 },
@@ -10489,7 +12833,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9465
                 },
@@ -10498,7 +12844,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9466
                 },
@@ -10507,7 +12855,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9467
                 },
@@ -10516,7 +12866,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9476
                 },
@@ -10525,7 +12877,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9485
                 },
@@ -10534,7 +12888,9 @@
                     "token": "p_month_Jul",
                     "value": "p_month_Jul",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9486
                 },
@@ -10543,7 +12899,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9497
                 },
@@ -10552,7 +12910,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 9502
                 },
@@ -10561,7 +12921,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9508
                 },
@@ -10570,7 +12932,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 9517
                 },
@@ -10579,7 +12943,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9526
                 },
@@ -10588,7 +12954,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9527
                 },
@@ -10597,7 +12965,9 @@
                     "token": "6",
                     "value": 6,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 9528
                 },
@@ -10606,7 +12976,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9529
                 },
@@ -10615,7 +12987,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9530
                 },
@@ -10624,7 +12998,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9531
                 },
@@ -10633,7 +13009,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9532
                 },
@@ -10642,7 +13020,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9545
                 },
@@ -10651,7 +13031,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9557
                 },
@@ -10660,7 +13042,9 @@
                     "token": "p_month_Jul_day_0",
                     "value": "p_month_Jul_day_0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9558
                 },
@@ -10669,7 +13053,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9575
                 },
@@ -10678,7 +13064,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9576
                 },
@@ -10687,7 +13075,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9589
                 },
@@ -10696,7 +13086,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9601
                 },
@@ -10705,7 +13097,9 @@
                     "token": "p_month_Jul_day_1",
                     "value": "p_month_Jul_day_1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9602
                 },
@@ -10714,7 +13108,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9619
                 },
@@ -10723,7 +13119,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9620
                 },
@@ -10732,7 +13130,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9633
                 },
@@ -10741,7 +13141,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9645
                 },
@@ -10750,7 +13152,9 @@
                     "token": "p_month_Jul_day_2",
                     "value": "p_month_Jul_day_2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9646
                 },
@@ -10759,7 +13163,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9663
                 },
@@ -10768,7 +13174,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9664
                 },
@@ -10777,7 +13185,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9677
                 },
@@ -10786,7 +13196,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9689
                 },
@@ -10795,7 +13207,9 @@
                     "token": "p_month_Jul_day_3",
                     "value": "p_month_Jul_day_3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9690
                 },
@@ -10804,7 +13218,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9707
                 },
@@ -10813,7 +13229,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9708
                 },
@@ -10822,7 +13240,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9721
                 },
@@ -10831,7 +13251,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9733
                 },
@@ -10840,7 +13262,9 @@
                     "token": "p_month_Jul_day_4",
                     "value": "p_month_Jul_day_4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9734
                 },
@@ -10849,7 +13273,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9751
                 },
@@ -10858,7 +13284,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9752
                 },
@@ -10867,7 +13295,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9765
                 },
@@ -10876,7 +13306,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9777
                 },
@@ -10885,7 +13317,9 @@
                     "token": "p_month_Jul_day_5",
                     "value": "p_month_Jul_day_5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9778
                 },
@@ -10894,7 +13328,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9795
                 },
@@ -10903,7 +13339,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9796
                 },
@@ -10912,7 +13350,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9809
                 },
@@ -10921,7 +13361,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9821
                 },
@@ -10930,7 +13372,9 @@
                     "token": "p_month_Jul_day_6",
                     "value": "p_month_Jul_day_6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9822
                 },
@@ -10939,7 +13383,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9839
                 },
@@ -10948,7 +13394,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9840
                 },
@@ -10957,7 +13405,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9853
                 },
@@ -10966,7 +13416,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9865
                 },
@@ -10975,7 +13427,9 @@
                     "token": "p_month_Jul_day_7",
                     "value": "p_month_Jul_day_7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9866
                 },
@@ -10984,7 +13438,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9883
                 },
@@ -10993,7 +13449,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9884
                 },
@@ -11002,7 +13460,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9897
                 },
@@ -11011,7 +13471,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9909
                 },
@@ -11020,7 +13482,9 @@
                     "token": "p_month_Jul_day_8",
                     "value": "p_month_Jul_day_8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9910
                 },
@@ -11029,7 +13493,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9927
                 },
@@ -11038,7 +13504,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9928
                 },
@@ -11047,7 +13515,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9941
                 },
@@ -11056,7 +13526,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9953
                 },
@@ -11065,7 +13537,9 @@
                     "token": "p_month_Jul_day_9",
                     "value": "p_month_Jul_day_9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9954
                 },
@@ -11074,7 +13548,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 9971
                 },
@@ -11083,7 +13559,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9972
                 },
@@ -11092,7 +13570,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 9985
                 },
@@ -11101,7 +13581,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9997
                 },
@@ -11110,7 +13592,9 @@
                     "token": "p_month_Jul_day_10",
                     "value": "p_month_Jul_day_10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 9998
                 },
@@ -11119,7 +13603,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10016
                 },
@@ -11128,7 +13614,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10017
                 },
@@ -11137,7 +13625,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10030
                 },
@@ -11146,7 +13636,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10042
                 },
@@ -11155,7 +13647,9 @@
                     "token": "p_month_Jul_day_11",
                     "value": "p_month_Jul_day_11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10043
                 },
@@ -11164,7 +13658,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10061
                 },
@@ -11173,7 +13669,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10062
                 },
@@ -11182,7 +13680,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10075
                 },
@@ -11191,7 +13691,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10087
                 },
@@ -11200,7 +13702,9 @@
                     "token": "p_month_Jul_day_12",
                     "value": "p_month_Jul_day_12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10088
                 },
@@ -11209,7 +13713,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10106
                 },
@@ -11218,7 +13724,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10107
                 },
@@ -11227,7 +13735,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10120
                 },
@@ -11236,7 +13746,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10132
                 },
@@ -11245,7 +13757,9 @@
                     "token": "p_month_Jul_day_13",
                     "value": "p_month_Jul_day_13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10133
                 },
@@ -11254,7 +13768,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10151
                 },
@@ -11263,7 +13779,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10152
                 },
@@ -11272,7 +13790,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10165
                 },
@@ -11281,7 +13801,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10177
                 },
@@ -11290,7 +13812,9 @@
                     "token": "p_month_Jul_day_14",
                     "value": "p_month_Jul_day_14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10178
                 },
@@ -11299,7 +13823,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10196
                 },
@@ -11308,7 +13834,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10197
                 },
@@ -11317,7 +13845,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10210
                 },
@@ -11326,7 +13856,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10222
                 },
@@ -11335,7 +13867,9 @@
                     "token": "p_month_Jul_day_15",
                     "value": "p_month_Jul_day_15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10223
                 },
@@ -11344,7 +13878,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10241
                 },
@@ -11353,7 +13889,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10242
                 },
@@ -11362,7 +13900,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10255
                 },
@@ -11371,7 +13911,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10267
                 },
@@ -11380,7 +13922,9 @@
                     "token": "p_month_Jul_day_16",
                     "value": "p_month_Jul_day_16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10268
                 },
@@ -11389,7 +13933,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10286
                 },
@@ -11398,7 +13944,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10287
                 },
@@ -11407,7 +13955,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10300
                 },
@@ -11416,7 +13966,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10312
                 },
@@ -11425,7 +13977,9 @@
                     "token": "p_month_Jul_day_17",
                     "value": "p_month_Jul_day_17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10313
                 },
@@ -11434,7 +13988,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10331
                 },
@@ -11443,7 +13999,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10332
                 },
@@ -11452,7 +14010,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10345
                 },
@@ -11461,7 +14021,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10357
                 },
@@ -11470,7 +14032,9 @@
                     "token": "p_month_Jul_day_18",
                     "value": "p_month_Jul_day_18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10358
                 },
@@ -11479,7 +14043,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10376
                 },
@@ -11488,7 +14054,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10377
                 },
@@ -11497,7 +14065,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10390
                 },
@@ -11506,7 +14076,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10402
                 },
@@ -11515,7 +14087,9 @@
                     "token": "p_month_Jul_day_19",
                     "value": "p_month_Jul_day_19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10403
                 },
@@ -11524,7 +14098,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10421
                 },
@@ -11533,7 +14109,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10422
                 },
@@ -11542,7 +14120,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10435
                 },
@@ -11551,7 +14131,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10447
                 },
@@ -11560,7 +14142,9 @@
                     "token": "p_month_Jul_day_20",
                     "value": "p_month_Jul_day_20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10448
                 },
@@ -11569,7 +14153,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10466
                 },
@@ -11578,7 +14164,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10467
                 },
@@ -11587,7 +14175,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10480
                 },
@@ -11596,7 +14186,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10492
                 },
@@ -11605,7 +14197,9 @@
                     "token": "p_month_Jul_day_21",
                     "value": "p_month_Jul_day_21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10493
                 },
@@ -11614,7 +14208,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10511
                 },
@@ -11623,7 +14219,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10512
                 },
@@ -11632,7 +14230,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10525
                 },
@@ -11641,7 +14241,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10537
                 },
@@ -11650,7 +14252,9 @@
                     "token": "p_month_Jul_day_22",
                     "value": "p_month_Jul_day_22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10538
                 },
@@ -11659,7 +14263,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10556
                 },
@@ -11668,7 +14274,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10557
                 },
@@ -11677,7 +14285,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10570
                 },
@@ -11686,7 +14296,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10582
                 },
@@ -11695,7 +14307,9 @@
                     "token": "p_month_Jul_day_23",
                     "value": "p_month_Jul_day_23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10583
                 },
@@ -11704,7 +14318,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10601
                 },
@@ -11713,7 +14329,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10602
                 },
@@ -11722,7 +14340,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10615
                 },
@@ -11731,7 +14351,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10627
                 },
@@ -11740,7 +14362,9 @@
                     "token": "p_month_Jul_day_24",
                     "value": "p_month_Jul_day_24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10628
                 },
@@ -11749,7 +14373,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10646
                 },
@@ -11758,7 +14384,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10647
                 },
@@ -11767,7 +14395,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10660
                 },
@@ -11776,7 +14406,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10672
                 },
@@ -11785,7 +14417,9 @@
                     "token": "p_month_Jul_day_25",
                     "value": "p_month_Jul_day_25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10673
                 },
@@ -11794,7 +14428,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10691
                 },
@@ -11803,7 +14439,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10692
                 },
@@ -11812,7 +14450,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10705
                 },
@@ -11821,7 +14461,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10717
                 },
@@ -11830,7 +14472,9 @@
                     "token": "p_month_Jul_day_26",
                     "value": "p_month_Jul_day_26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10718
                 },
@@ -11839,7 +14483,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10736
                 },
@@ -11848,7 +14494,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10737
                 },
@@ -11857,7 +14505,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10750
                 },
@@ -11866,7 +14516,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10762
                 },
@@ -11875,7 +14527,9 @@
                     "token": "p_month_Jul_day_27",
                     "value": "p_month_Jul_day_27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10763
                 },
@@ -11884,7 +14538,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10781
                 },
@@ -11893,7 +14549,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10782
                 },
@@ -11902,7 +14560,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10795
                 },
@@ -11911,7 +14571,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10807
                 },
@@ -11920,7 +14582,9 @@
                     "token": "p_month_Jul_day_28",
                     "value": "p_month_Jul_day_28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10808
                 },
@@ -11929,7 +14593,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10826
                 },
@@ -11938,7 +14604,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10827
                 },
@@ -11947,7 +14615,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10840
                 },
@@ -11956,7 +14626,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10852
                 },
@@ -11965,7 +14637,9 @@
                     "token": "p_month_Jul_day_29",
                     "value": "p_month_Jul_day_29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10853
                 },
@@ -11974,7 +14648,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10871
                 },
@@ -11983,7 +14659,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10872
                 },
@@ -11992,7 +14670,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10885
                 },
@@ -12001,7 +14681,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10897
                 },
@@ -12010,7 +14692,9 @@
                     "token": "p_month_Jul_day_30",
                     "value": "p_month_Jul_day_30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10898
                 },
@@ -12019,7 +14703,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10916
                 },
@@ -12028,7 +14714,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10917
                 },
@@ -12037,7 +14725,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10930
                 },
@@ -12046,7 +14736,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10942
                 },
@@ -12055,7 +14747,9 @@
                     "token": "p_month_Jul_day_31",
                     "value": "p_month_Jul_day_31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10943
                 },
@@ -12064,7 +14758,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10961
                 },
@@ -12073,7 +14769,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10970
                 },
@@ -12082,7 +14780,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 10971
                 },
@@ -12091,7 +14791,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10972
                 },
@@ -12100,7 +14802,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10981
                 },
@@ -12109,7 +14813,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10990
                 },
@@ -12118,7 +14824,9 @@
                     "token": "p_month_Aug",
                     "value": "p_month_Aug",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 10991
                 },
@@ -12127,7 +14835,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11002
                 },
@@ -12136,7 +14846,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 11007
                 },
@@ -12145,7 +14857,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11013
                 },
@@ -12154,7 +14868,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 11022
                 },
@@ -12163,7 +14879,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11031
                 },
@@ -12172,7 +14890,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11032
                 },
@@ -12181,7 +14901,9 @@
                     "token": "7",
                     "value": 7,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 11033
                 },
@@ -12190,7 +14912,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11034
                 },
@@ -12199,7 +14923,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11035
                 },
@@ -12208,7 +14934,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11036
                 },
@@ -12217,7 +14945,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11037
                 },
@@ -12226,7 +14956,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11050
                 },
@@ -12235,7 +14967,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11062
                 },
@@ -12244,7 +14978,9 @@
                     "token": "p_month_Aug_day_0",
                     "value": "p_month_Aug_day_0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11063
                 },
@@ -12253,7 +14989,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11080
                 },
@@ -12262,7 +15000,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11081
                 },
@@ -12271,7 +15011,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11094
                 },
@@ -12280,7 +15022,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11106
                 },
@@ -12289,7 +15033,9 @@
                     "token": "p_month_Aug_day_1",
                     "value": "p_month_Aug_day_1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11107
                 },
@@ -12298,7 +15044,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11124
                 },
@@ -12307,7 +15055,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11125
                 },
@@ -12316,7 +15066,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11138
                 },
@@ -12325,7 +15077,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11150
                 },
@@ -12334,7 +15088,9 @@
                     "token": "p_month_Aug_day_2",
                     "value": "p_month_Aug_day_2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11151
                 },
@@ -12343,7 +15099,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11168
                 },
@@ -12352,7 +15110,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11169
                 },
@@ -12361,7 +15121,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11182
                 },
@@ -12370,7 +15132,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11194
                 },
@@ -12379,7 +15143,9 @@
                     "token": "p_month_Aug_day_3",
                     "value": "p_month_Aug_day_3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11195
                 },
@@ -12388,7 +15154,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11212
                 },
@@ -12397,7 +15165,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11213
                 },
@@ -12406,7 +15176,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11226
                 },
@@ -12415,7 +15187,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11238
                 },
@@ -12424,7 +15198,9 @@
                     "token": "p_month_Aug_day_4",
                     "value": "p_month_Aug_day_4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11239
                 },
@@ -12433,7 +15209,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11256
                 },
@@ -12442,7 +15220,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11257
                 },
@@ -12451,7 +15231,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11270
                 },
@@ -12460,7 +15242,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11282
                 },
@@ -12469,7 +15253,9 @@
                     "token": "p_month_Aug_day_5",
                     "value": "p_month_Aug_day_5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11283
                 },
@@ -12478,7 +15264,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11300
                 },
@@ -12487,7 +15275,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11301
                 },
@@ -12496,7 +15286,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11314
                 },
@@ -12505,7 +15297,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11326
                 },
@@ -12514,7 +15308,9 @@
                     "token": "p_month_Aug_day_6",
                     "value": "p_month_Aug_day_6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11327
                 },
@@ -12523,7 +15319,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11344
                 },
@@ -12532,7 +15330,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11345
                 },
@@ -12541,7 +15341,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11358
                 },
@@ -12550,7 +15352,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11370
                 },
@@ -12559,7 +15363,9 @@
                     "token": "p_month_Aug_day_7",
                     "value": "p_month_Aug_day_7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11371
                 },
@@ -12568,7 +15374,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11388
                 },
@@ -12577,7 +15385,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11389
                 },
@@ -12586,7 +15396,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11402
                 },
@@ -12595,7 +15407,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11414
                 },
@@ -12604,7 +15418,9 @@
                     "token": "p_month_Aug_day_8",
                     "value": "p_month_Aug_day_8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11415
                 },
@@ -12613,7 +15429,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11432
                 },
@@ -12622,7 +15440,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11433
                 },
@@ -12631,7 +15451,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11446
                 },
@@ -12640,7 +15462,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11458
                 },
@@ -12649,7 +15473,9 @@
                     "token": "p_month_Aug_day_9",
                     "value": "p_month_Aug_day_9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11459
                 },
@@ -12658,7 +15484,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11476
                 },
@@ -12667,7 +15495,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11477
                 },
@@ -12676,7 +15506,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11490
                 },
@@ -12685,7 +15517,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11502
                 },
@@ -12694,7 +15528,9 @@
                     "token": "p_month_Aug_day_10",
                     "value": "p_month_Aug_day_10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11503
                 },
@@ -12703,7 +15539,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11521
                 },
@@ -12712,7 +15550,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11522
                 },
@@ -12721,7 +15561,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11535
                 },
@@ -12730,7 +15572,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11547
                 },
@@ -12739,7 +15583,9 @@
                     "token": "p_month_Aug_day_11",
                     "value": "p_month_Aug_day_11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11548
                 },
@@ -12748,7 +15594,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11566
                 },
@@ -12757,7 +15605,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11567
                 },
@@ -12766,7 +15616,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11580
                 },
@@ -12775,7 +15627,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11592
                 },
@@ -12784,7 +15638,9 @@
                     "token": "p_month_Aug_day_12",
                     "value": "p_month_Aug_day_12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11593
                 },
@@ -12793,7 +15649,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11611
                 },
@@ -12802,7 +15660,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11612
                 },
@@ -12811,7 +15671,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11625
                 },
@@ -12820,7 +15682,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11637
                 },
@@ -12829,7 +15693,9 @@
                     "token": "p_month_Aug_day_13",
                     "value": "p_month_Aug_day_13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11638
                 },
@@ -12838,7 +15704,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11656
                 },
@@ -12847,7 +15715,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11657
                 },
@@ -12856,7 +15726,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11670
                 },
@@ -12865,7 +15737,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11682
                 },
@@ -12874,7 +15748,9 @@
                     "token": "p_month_Aug_day_14",
                     "value": "p_month_Aug_day_14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11683
                 },
@@ -12883,7 +15759,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11701
                 },
@@ -12892,7 +15770,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11702
                 },
@@ -12901,7 +15781,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11715
                 },
@@ -12910,7 +15792,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11727
                 },
@@ -12919,7 +15803,9 @@
                     "token": "p_month_Aug_day_15",
                     "value": "p_month_Aug_day_15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11728
                 },
@@ -12928,7 +15814,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11746
                 },
@@ -12937,7 +15825,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11747
                 },
@@ -12946,7 +15836,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11760
                 },
@@ -12955,7 +15847,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11772
                 },
@@ -12964,7 +15858,9 @@
                     "token": "p_month_Aug_day_16",
                     "value": "p_month_Aug_day_16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11773
                 },
@@ -12973,7 +15869,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11791
                 },
@@ -12982,7 +15880,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11792
                 },
@@ -12991,7 +15891,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11805
                 },
@@ -13000,7 +15902,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11817
                 },
@@ -13009,7 +15913,9 @@
                     "token": "p_month_Aug_day_17",
                     "value": "p_month_Aug_day_17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11818
                 },
@@ -13018,7 +15924,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11836
                 },
@@ -13027,7 +15935,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11837
                 },
@@ -13036,7 +15946,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11850
                 },
@@ -13045,7 +15957,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11862
                 },
@@ -13054,7 +15968,9 @@
                     "token": "p_month_Aug_day_18",
                     "value": "p_month_Aug_day_18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11863
                 },
@@ -13063,7 +15979,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11881
                 },
@@ -13072,7 +15990,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11882
                 },
@@ -13081,7 +16001,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11895
                 },
@@ -13090,7 +16012,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11907
                 },
@@ -13099,7 +16023,9 @@
                     "token": "p_month_Aug_day_19",
                     "value": "p_month_Aug_day_19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11908
                 },
@@ -13108,7 +16034,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11926
                 },
@@ -13117,7 +16045,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11927
                 },
@@ -13126,7 +16056,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11940
                 },
@@ -13135,7 +16067,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11952
                 },
@@ -13144,7 +16078,9 @@
                     "token": "p_month_Aug_day_20",
                     "value": "p_month_Aug_day_20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11953
                 },
@@ -13153,7 +16089,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 11971
                 },
@@ -13162,7 +16100,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11972
                 },
@@ -13171,7 +16111,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11985
                 },
@@ -13180,7 +16122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11997
                 },
@@ -13189,7 +16133,9 @@
                     "token": "p_month_Aug_day_21",
                     "value": "p_month_Aug_day_21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 11998
                 },
@@ -13198,7 +16144,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12016
                 },
@@ -13207,7 +16155,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12017
                 },
@@ -13216,7 +16166,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12030
                 },
@@ -13225,7 +16177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12042
                 },
@@ -13234,7 +16188,9 @@
                     "token": "p_month_Aug_day_22",
                     "value": "p_month_Aug_day_22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12043
                 },
@@ -13243,7 +16199,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12061
                 },
@@ -13252,7 +16210,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12062
                 },
@@ -13261,7 +16221,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12075
                 },
@@ -13270,7 +16232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12087
                 },
@@ -13279,7 +16243,9 @@
                     "token": "p_month_Aug_day_23",
                     "value": "p_month_Aug_day_23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12088
                 },
@@ -13288,7 +16254,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12106
                 },
@@ -13297,7 +16265,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12107
                 },
@@ -13306,7 +16276,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12120
                 },
@@ -13315,7 +16287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12132
                 },
@@ -13324,7 +16298,9 @@
                     "token": "p_month_Aug_day_24",
                     "value": "p_month_Aug_day_24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12133
                 },
@@ -13333,7 +16309,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12151
                 },
@@ -13342,7 +16320,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12152
                 },
@@ -13351,7 +16331,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12165
                 },
@@ -13360,7 +16342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12177
                 },
@@ -13369,7 +16353,9 @@
                     "token": "p_month_Aug_day_25",
                     "value": "p_month_Aug_day_25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12178
                 },
@@ -13378,7 +16364,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12196
                 },
@@ -13387,7 +16375,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12197
                 },
@@ -13396,7 +16386,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12210
                 },
@@ -13405,7 +16397,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12222
                 },
@@ -13414,7 +16408,9 @@
                     "token": "p_month_Aug_day_26",
                     "value": "p_month_Aug_day_26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12223
                 },
@@ -13423,7 +16419,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12241
                 },
@@ -13432,7 +16430,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12242
                 },
@@ -13441,7 +16441,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12255
                 },
@@ -13450,7 +16452,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12267
                 },
@@ -13459,7 +16463,9 @@
                     "token": "p_month_Aug_day_27",
                     "value": "p_month_Aug_day_27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12268
                 },
@@ -13468,7 +16474,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12286
                 },
@@ -13477,7 +16485,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12287
                 },
@@ -13486,7 +16496,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12300
                 },
@@ -13495,7 +16507,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12312
                 },
@@ -13504,7 +16518,9 @@
                     "token": "p_month_Aug_day_28",
                     "value": "p_month_Aug_day_28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12313
                 },
@@ -13513,7 +16529,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12331
                 },
@@ -13522,7 +16540,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12332
                 },
@@ -13531,7 +16551,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12345
                 },
@@ -13540,7 +16562,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12357
                 },
@@ -13549,7 +16573,9 @@
                     "token": "p_month_Aug_day_29",
                     "value": "p_month_Aug_day_29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12358
                 },
@@ -13558,7 +16584,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12376
                 },
@@ -13567,7 +16595,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12377
                 },
@@ -13576,7 +16606,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12390
                 },
@@ -13585,7 +16617,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12402
                 },
@@ -13594,7 +16628,9 @@
                     "token": "p_month_Aug_day_30",
                     "value": "p_month_Aug_day_30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12403
                 },
@@ -13603,7 +16639,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12421
                 },
@@ -13612,7 +16650,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12422
                 },
@@ -13621,7 +16661,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12435
                 },
@@ -13630,7 +16672,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12447
                 },
@@ -13639,7 +16683,9 @@
                     "token": "p_month_Aug_day_31",
                     "value": "p_month_Aug_day_31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12448
                 },
@@ -13648,7 +16694,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12466
                 },
@@ -13657,7 +16705,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12475
                 },
@@ -13666,7 +16716,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12476
                 },
@@ -13675,7 +16727,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12477
                 },
@@ -13684,7 +16738,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 12486
                 },
@@ -13693,7 +16749,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12495
                 },
@@ -13702,7 +16760,9 @@
                     "token": "p_month_Sep",
                     "value": "p_month_Sep",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12496
                 },
@@ -13711,7 +16771,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12507
                 },
@@ -13720,7 +16782,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 12512
                 },
@@ -13729,7 +16793,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12518
                 },
@@ -13738,7 +16804,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 12527
                 },
@@ -13747,7 +16815,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12536
                 },
@@ -13756,7 +16826,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12537
                 },
@@ -13765,7 +16837,9 @@
                     "token": "8",
                     "value": 8,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 12538
                 },
@@ -13774,7 +16848,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12539
                 },
@@ -13783,7 +16859,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12540
                 },
@@ -13792,7 +16870,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12541
                 },
@@ -13801,7 +16881,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12542
                 },
@@ -13810,7 +16892,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12555
                 },
@@ -13819,7 +16903,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12567
                 },
@@ -13828,7 +16914,9 @@
                     "token": "p_month_Sep_day_0",
                     "value": "p_month_Sep_day_0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12568
                 },
@@ -13837,7 +16925,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12585
                 },
@@ -13846,7 +16936,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12586
                 },
@@ -13855,7 +16947,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12599
                 },
@@ -13864,7 +16958,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12611
                 },
@@ -13873,7 +16969,9 @@
                     "token": "p_month_Sep_day_1",
                     "value": "p_month_Sep_day_1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12612
                 },
@@ -13882,7 +16980,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12629
                 },
@@ -13891,7 +16991,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12630
                 },
@@ -13900,7 +17002,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12643
                 },
@@ -13909,7 +17013,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12655
                 },
@@ -13918,7 +17024,9 @@
                     "token": "p_month_Sep_day_2",
                     "value": "p_month_Sep_day_2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12656
                 },
@@ -13927,7 +17035,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12673
                 },
@@ -13936,7 +17046,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12674
                 },
@@ -13945,7 +17057,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12687
                 },
@@ -13954,7 +17068,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12699
                 },
@@ -13963,7 +17079,9 @@
                     "token": "p_month_Sep_day_3",
                     "value": "p_month_Sep_day_3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12700
                 },
@@ -13972,7 +17090,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12717
                 },
@@ -13981,7 +17101,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12718
                 },
@@ -13990,7 +17112,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12731
                 },
@@ -13999,7 +17123,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12743
                 },
@@ -14008,7 +17134,9 @@
                     "token": "p_month_Sep_day_4",
                     "value": "p_month_Sep_day_4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12744
                 },
@@ -14017,7 +17145,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12761
                 },
@@ -14026,7 +17156,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12762
                 },
@@ -14035,7 +17167,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12775
                 },
@@ -14044,7 +17178,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12787
                 },
@@ -14053,7 +17189,9 @@
                     "token": "p_month_Sep_day_5",
                     "value": "p_month_Sep_day_5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12788
                 },
@@ -14062,7 +17200,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12805
                 },
@@ -14071,7 +17211,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12806
                 },
@@ -14080,7 +17222,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12819
                 },
@@ -14089,7 +17233,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12831
                 },
@@ -14098,7 +17244,9 @@
                     "token": "p_month_Sep_day_6",
                     "value": "p_month_Sep_day_6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12832
                 },
@@ -14107,7 +17255,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12849
                 },
@@ -14116,7 +17266,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12850
                 },
@@ -14125,7 +17277,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12863
                 },
@@ -14134,7 +17288,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12875
                 },
@@ -14143,7 +17299,9 @@
                     "token": "p_month_Sep_day_7",
                     "value": "p_month_Sep_day_7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12876
                 },
@@ -14152,7 +17310,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12893
                 },
@@ -14161,7 +17321,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12894
                 },
@@ -14170,7 +17332,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12907
                 },
@@ -14179,7 +17343,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12919
                 },
@@ -14188,7 +17354,9 @@
                     "token": "p_month_Sep_day_8",
                     "value": "p_month_Sep_day_8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12920
                 },
@@ -14197,7 +17365,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12937
                 },
@@ -14206,7 +17376,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12938
                 },
@@ -14215,7 +17387,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12951
                 },
@@ -14224,7 +17398,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12963
                 },
@@ -14233,7 +17409,9 @@
                     "token": "p_month_Sep_day_9",
                     "value": "p_month_Sep_day_9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 12964
                 },
@@ -14242,7 +17420,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 12981
                 },
@@ -14251,7 +17431,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12982
                 },
@@ -14260,7 +17442,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12995
                 },
@@ -14269,7 +17453,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13007
                 },
@@ -14278,7 +17464,9 @@
                     "token": "p_month_Sep_day_10",
                     "value": "p_month_Sep_day_10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13008
                 },
@@ -14287,7 +17475,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13026
                 },
@@ -14296,7 +17486,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13027
                 },
@@ -14305,7 +17497,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13040
                 },
@@ -14314,7 +17508,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13052
                 },
@@ -14323,7 +17519,9 @@
                     "token": "p_month_Sep_day_11",
                     "value": "p_month_Sep_day_11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13053
                 },
@@ -14332,7 +17530,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13071
                 },
@@ -14341,7 +17541,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13072
                 },
@@ -14350,7 +17552,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13085
                 },
@@ -14359,7 +17563,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13097
                 },
@@ -14368,7 +17574,9 @@
                     "token": "p_month_Sep_day_12",
                     "value": "p_month_Sep_day_12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13098
                 },
@@ -14377,7 +17585,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13116
                 },
@@ -14386,7 +17596,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13117
                 },
@@ -14395,7 +17607,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13130
                 },
@@ -14404,7 +17618,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13142
                 },
@@ -14413,7 +17629,9 @@
                     "token": "p_month_Sep_day_13",
                     "value": "p_month_Sep_day_13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13143
                 },
@@ -14422,7 +17640,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13161
                 },
@@ -14431,7 +17651,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13162
                 },
@@ -14440,7 +17662,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13175
                 },
@@ -14449,7 +17673,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13187
                 },
@@ -14458,7 +17684,9 @@
                     "token": "p_month_Sep_day_14",
                     "value": "p_month_Sep_day_14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13188
                 },
@@ -14467,7 +17695,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13206
                 },
@@ -14476,7 +17706,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13207
                 },
@@ -14485,7 +17717,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13220
                 },
@@ -14494,7 +17728,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13232
                 },
@@ -14503,7 +17739,9 @@
                     "token": "p_month_Sep_day_15",
                     "value": "p_month_Sep_day_15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13233
                 },
@@ -14512,7 +17750,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13251
                 },
@@ -14521,7 +17761,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13252
                 },
@@ -14530,7 +17772,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13265
                 },
@@ -14539,7 +17783,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13277
                 },
@@ -14548,7 +17794,9 @@
                     "token": "p_month_Sep_day_16",
                     "value": "p_month_Sep_day_16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13278
                 },
@@ -14557,7 +17805,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13296
                 },
@@ -14566,7 +17816,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13297
                 },
@@ -14575,7 +17827,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13310
                 },
@@ -14584,7 +17838,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13322
                 },
@@ -14593,7 +17849,9 @@
                     "token": "p_month_Sep_day_17",
                     "value": "p_month_Sep_day_17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13323
                 },
@@ -14602,7 +17860,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13341
                 },
@@ -14611,7 +17871,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13342
                 },
@@ -14620,7 +17882,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13355
                 },
@@ -14629,7 +17893,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13367
                 },
@@ -14638,7 +17904,9 @@
                     "token": "p_month_Sep_day_18",
                     "value": "p_month_Sep_day_18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13368
                 },
@@ -14647,7 +17915,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13386
                 },
@@ -14656,7 +17926,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13387
                 },
@@ -14665,7 +17937,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13400
                 },
@@ -14674,7 +17948,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13412
                 },
@@ -14683,7 +17959,9 @@
                     "token": "p_month_Sep_day_19",
                     "value": "p_month_Sep_day_19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13413
                 },
@@ -14692,7 +17970,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13431
                 },
@@ -14701,7 +17981,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13432
                 },
@@ -14710,7 +17992,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13445
                 },
@@ -14719,7 +18003,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13457
                 },
@@ -14728,7 +18014,9 @@
                     "token": "p_month_Sep_day_20",
                     "value": "p_month_Sep_day_20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13458
                 },
@@ -14737,7 +18025,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13476
                 },
@@ -14746,7 +18036,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13477
                 },
@@ -14755,7 +18047,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13490
                 },
@@ -14764,7 +18058,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13502
                 },
@@ -14773,7 +18069,9 @@
                     "token": "p_month_Sep_day_21",
                     "value": "p_month_Sep_day_21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13503
                 },
@@ -14782,7 +18080,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13521
                 },
@@ -14791,7 +18091,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13522
                 },
@@ -14800,7 +18102,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13535
                 },
@@ -14809,7 +18113,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13547
                 },
@@ -14818,7 +18124,9 @@
                     "token": "p_month_Sep_day_22",
                     "value": "p_month_Sep_day_22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13548
                 },
@@ -14827,7 +18135,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13566
                 },
@@ -14836,7 +18146,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13567
                 },
@@ -14845,7 +18157,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13580
                 },
@@ -14854,7 +18168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13592
                 },
@@ -14863,7 +18179,9 @@
                     "token": "p_month_Sep_day_23",
                     "value": "p_month_Sep_day_23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13593
                 },
@@ -14872,7 +18190,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13611
                 },
@@ -14881,7 +18201,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13612
                 },
@@ -14890,7 +18212,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13625
                 },
@@ -14899,7 +18223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13637
                 },
@@ -14908,7 +18234,9 @@
                     "token": "p_month_Sep_day_24",
                     "value": "p_month_Sep_day_24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13638
                 },
@@ -14917,7 +18245,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13656
                 },
@@ -14926,7 +18256,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13657
                 },
@@ -14935,7 +18267,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13670
                 },
@@ -14944,7 +18278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13682
                 },
@@ -14953,7 +18289,9 @@
                     "token": "p_month_Sep_day_25",
                     "value": "p_month_Sep_day_25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13683
                 },
@@ -14962,7 +18300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13701
                 },
@@ -14971,7 +18311,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13702
                 },
@@ -14980,7 +18322,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13715
                 },
@@ -14989,7 +18333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13727
                 },
@@ -14998,7 +18344,9 @@
                     "token": "p_month_Sep_day_26",
                     "value": "p_month_Sep_day_26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13728
                 },
@@ -15007,7 +18355,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13746
                 },
@@ -15016,7 +18366,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13747
                 },
@@ -15025,7 +18377,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13760
                 },
@@ -15034,7 +18388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13772
                 },
@@ -15043,7 +18399,9 @@
                     "token": "p_month_Sep_day_27",
                     "value": "p_month_Sep_day_27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13773
                 },
@@ -15052,7 +18410,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13791
                 },
@@ -15061,7 +18421,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13792
                 },
@@ -15070,7 +18432,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13805
                 },
@@ -15079,7 +18443,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13817
                 },
@@ -15088,7 +18454,9 @@
                     "token": "p_month_Sep_day_28",
                     "value": "p_month_Sep_day_28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13818
                 },
@@ -15097,7 +18465,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13836
                 },
@@ -15106,7 +18476,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13837
                 },
@@ -15115,7 +18487,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13850
                 },
@@ -15124,7 +18498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13862
                 },
@@ -15133,7 +18509,9 @@
                     "token": "p_month_Sep_day_29",
                     "value": "p_month_Sep_day_29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13863
                 },
@@ -15142,7 +18520,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13881
                 },
@@ -15151,7 +18531,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13882
                 },
@@ -15160,7 +18542,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13895
                 },
@@ -15169,7 +18553,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13907
                 },
@@ -15178,7 +18564,9 @@
                     "token": "p_month_Sep_day_30",
                     "value": "p_month_Sep_day_30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13908
                 },
@@ -15187,7 +18575,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13926
                 },
@@ -15196,7 +18586,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13927
                 },
@@ -15205,7 +18597,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13940
                 },
@@ -15214,7 +18608,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13952
                 },
@@ -15223,7 +18619,9 @@
                     "token": "p_month_Sep_day_31",
                     "value": "p_month_Sep_day_31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 13953
                 },
@@ -15232,7 +18630,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13971
                 },
@@ -15241,7 +18641,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13980
                 },
@@ -15250,7 +18652,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 13981
                 },
@@ -15259,7 +18663,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13982
                 },
@@ -15268,7 +18674,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13991
                 },
@@ -15277,7 +18685,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14000
                 },
@@ -15286,7 +18696,9 @@
                     "token": "p_month_Oct",
                     "value": "p_month_Oct",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14001
                 },
@@ -15295,7 +18707,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14012
                 },
@@ -15304,7 +18718,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 14017
                 },
@@ -15313,7 +18729,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14023
                 },
@@ -15322,7 +18740,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 14032
                 },
@@ -15331,7 +18751,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14041
                 },
@@ -15340,7 +18762,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14042
                 },
@@ -15349,7 +18773,9 @@
                     "token": "9",
                     "value": 9,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 14043
                 },
@@ -15358,7 +18784,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14044
                 },
@@ -15367,7 +18795,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14045
                 },
@@ -15376,7 +18806,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14046
                 },
@@ -15385,7 +18817,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14047
                 },
@@ -15394,7 +18828,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14060
                 },
@@ -15403,7 +18839,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14072
                 },
@@ -15412,7 +18850,9 @@
                     "token": "p_month_Oct_day_0",
                     "value": "p_month_Oct_day_0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14073
                 },
@@ -15421,7 +18861,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14090
                 },
@@ -15430,7 +18872,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14091
                 },
@@ -15439,7 +18883,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14104
                 },
@@ -15448,7 +18894,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14116
                 },
@@ -15457,7 +18905,9 @@
                     "token": "p_month_Oct_day_1",
                     "value": "p_month_Oct_day_1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14117
                 },
@@ -15466,7 +18916,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14134
                 },
@@ -15475,7 +18927,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14135
                 },
@@ -15484,7 +18938,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14148
                 },
@@ -15493,7 +18949,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14160
                 },
@@ -15502,7 +18960,9 @@
                     "token": "p_month_Oct_day_2",
                     "value": "p_month_Oct_day_2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14161
                 },
@@ -15511,7 +18971,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14178
                 },
@@ -15520,7 +18982,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14179
                 },
@@ -15529,7 +18993,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14192
                 },
@@ -15538,7 +19004,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14204
                 },
@@ -15547,7 +19015,9 @@
                     "token": "p_month_Oct_day_3",
                     "value": "p_month_Oct_day_3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14205
                 },
@@ -15556,7 +19026,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14222
                 },
@@ -15565,7 +19037,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14223
                 },
@@ -15574,7 +19048,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14236
                 },
@@ -15583,7 +19059,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14248
                 },
@@ -15592,7 +19070,9 @@
                     "token": "p_month_Oct_day_4",
                     "value": "p_month_Oct_day_4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14249
                 },
@@ -15601,7 +19081,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14266
                 },
@@ -15610,7 +19092,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14267
                 },
@@ -15619,7 +19103,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14280
                 },
@@ -15628,7 +19114,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14292
                 },
@@ -15637,7 +19125,9 @@
                     "token": "p_month_Oct_day_5",
                     "value": "p_month_Oct_day_5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14293
                 },
@@ -15646,7 +19136,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14310
                 },
@@ -15655,7 +19147,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14311
                 },
@@ -15664,7 +19158,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14324
                 },
@@ -15673,7 +19169,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14336
                 },
@@ -15682,7 +19180,9 @@
                     "token": "p_month_Oct_day_6",
                     "value": "p_month_Oct_day_6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14337
                 },
@@ -15691,7 +19191,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14354
                 },
@@ -15700,7 +19202,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14355
                 },
@@ -15709,7 +19213,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14368
                 },
@@ -15718,7 +19224,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14380
                 },
@@ -15727,7 +19235,9 @@
                     "token": "p_month_Oct_day_7",
                     "value": "p_month_Oct_day_7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14381
                 },
@@ -15736,7 +19246,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14398
                 },
@@ -15745,7 +19257,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14399
                 },
@@ -15754,7 +19268,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14412
                 },
@@ -15763,7 +19279,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14424
                 },
@@ -15772,7 +19290,9 @@
                     "token": "p_month_Oct_day_8",
                     "value": "p_month_Oct_day_8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14425
                 },
@@ -15781,7 +19301,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14442
                 },
@@ -15790,7 +19312,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14443
                 },
@@ -15799,7 +19323,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14456
                 },
@@ -15808,7 +19334,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14468
                 },
@@ -15817,7 +19345,9 @@
                     "token": "p_month_Oct_day_9",
                     "value": "p_month_Oct_day_9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14469
                 },
@@ -15826,7 +19356,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14486
                 },
@@ -15835,7 +19367,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14487
                 },
@@ -15844,7 +19378,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14500
                 },
@@ -15853,7 +19389,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14512
                 },
@@ -15862,7 +19400,9 @@
                     "token": "p_month_Oct_day_10",
                     "value": "p_month_Oct_day_10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14513
                 },
@@ -15871,7 +19411,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14531
                 },
@@ -15880,7 +19422,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14532
                 },
@@ -15889,7 +19433,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14545
                 },
@@ -15898,7 +19444,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14557
                 },
@@ -15907,7 +19455,9 @@
                     "token": "p_month_Oct_day_11",
                     "value": "p_month_Oct_day_11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14558
                 },
@@ -15916,7 +19466,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14576
                 },
@@ -15925,7 +19477,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14577
                 },
@@ -15934,7 +19488,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14590
                 },
@@ -15943,7 +19499,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14602
                 },
@@ -15952,7 +19510,9 @@
                     "token": "p_month_Oct_day_12",
                     "value": "p_month_Oct_day_12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14603
                 },
@@ -15961,7 +19521,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14621
                 },
@@ -15970,7 +19532,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14622
                 },
@@ -15979,7 +19543,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14635
                 },
@@ -15988,7 +19554,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14647
                 },
@@ -15997,7 +19565,9 @@
                     "token": "p_month_Oct_day_13",
                     "value": "p_month_Oct_day_13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14648
                 },
@@ -16006,7 +19576,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14666
                 },
@@ -16015,7 +19587,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14667
                 },
@@ -16024,7 +19598,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14680
                 },
@@ -16033,7 +19609,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14692
                 },
@@ -16042,7 +19620,9 @@
                     "token": "p_month_Oct_day_14",
                     "value": "p_month_Oct_day_14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14693
                 },
@@ -16051,7 +19631,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14711
                 },
@@ -16060,7 +19642,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14712
                 },
@@ -16069,7 +19653,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14725
                 },
@@ -16078,7 +19664,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14737
                 },
@@ -16087,7 +19675,9 @@
                     "token": "p_month_Oct_day_15",
                     "value": "p_month_Oct_day_15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14738
                 },
@@ -16096,7 +19686,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14756
                 },
@@ -16105,7 +19697,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14757
                 },
@@ -16114,7 +19708,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14770
                 },
@@ -16123,7 +19719,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14782
                 },
@@ -16132,7 +19730,9 @@
                     "token": "p_month_Oct_day_16",
                     "value": "p_month_Oct_day_16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14783
                 },
@@ -16141,7 +19741,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14801
                 },
@@ -16150,7 +19752,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14802
                 },
@@ -16159,7 +19763,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14815
                 },
@@ -16168,7 +19774,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14827
                 },
@@ -16177,7 +19785,9 @@
                     "token": "p_month_Oct_day_17",
                     "value": "p_month_Oct_day_17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14828
                 },
@@ -16186,7 +19796,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14846
                 },
@@ -16195,7 +19807,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14847
                 },
@@ -16204,7 +19818,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14860
                 },
@@ -16213,7 +19829,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14872
                 },
@@ -16222,7 +19840,9 @@
                     "token": "p_month_Oct_day_18",
                     "value": "p_month_Oct_day_18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14873
                 },
@@ -16231,7 +19851,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14891
                 },
@@ -16240,7 +19862,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14892
                 },
@@ -16249,7 +19873,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14905
                 },
@@ -16258,7 +19884,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14917
                 },
@@ -16267,7 +19895,9 @@
                     "token": "p_month_Oct_day_19",
                     "value": "p_month_Oct_day_19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14918
                 },
@@ -16276,7 +19906,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14936
                 },
@@ -16285,7 +19917,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14937
                 },
@@ -16294,7 +19928,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14950
                 },
@@ -16303,7 +19939,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14962
                 },
@@ -16312,7 +19950,9 @@
                     "token": "p_month_Oct_day_20",
                     "value": "p_month_Oct_day_20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 14963
                 },
@@ -16321,7 +19961,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 14981
                 },
@@ -16330,7 +19972,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14982
                 },
@@ -16339,7 +19983,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 14995
                 },
@@ -16348,7 +19994,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15007
                 },
@@ -16357,7 +20005,9 @@
                     "token": "p_month_Oct_day_21",
                     "value": "p_month_Oct_day_21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15008
                 },
@@ -16366,7 +20016,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15026
                 },
@@ -16375,7 +20027,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15027
                 },
@@ -16384,7 +20038,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15040
                 },
@@ -16393,7 +20049,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15052
                 },
@@ -16402,7 +20060,9 @@
                     "token": "p_month_Oct_day_22",
                     "value": "p_month_Oct_day_22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15053
                 },
@@ -16411,7 +20071,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15071
                 },
@@ -16420,7 +20082,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15072
                 },
@@ -16429,7 +20093,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15085
                 },
@@ -16438,7 +20104,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15097
                 },
@@ -16447,7 +20115,9 @@
                     "token": "p_month_Oct_day_23",
                     "value": "p_month_Oct_day_23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15098
                 },
@@ -16456,7 +20126,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15116
                 },
@@ -16465,7 +20137,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15117
                 },
@@ -16474,7 +20148,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15130
                 },
@@ -16483,7 +20159,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15142
                 },
@@ -16492,7 +20170,9 @@
                     "token": "p_month_Oct_day_24",
                     "value": "p_month_Oct_day_24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15143
                 },
@@ -16501,7 +20181,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15161
                 },
@@ -16510,7 +20192,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15162
                 },
@@ -16519,7 +20203,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15175
                 },
@@ -16528,7 +20214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15187
                 },
@@ -16537,7 +20225,9 @@
                     "token": "p_month_Oct_day_25",
                     "value": "p_month_Oct_day_25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15188
                 },
@@ -16546,7 +20236,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15206
                 },
@@ -16555,7 +20247,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15207
                 },
@@ -16564,7 +20258,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15220
                 },
@@ -16573,7 +20269,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15232
                 },
@@ -16582,7 +20280,9 @@
                     "token": "p_month_Oct_day_26",
                     "value": "p_month_Oct_day_26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15233
                 },
@@ -16591,7 +20291,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15251
                 },
@@ -16600,7 +20302,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15252
                 },
@@ -16609,7 +20313,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15265
                 },
@@ -16618,7 +20324,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15277
                 },
@@ -16627,7 +20335,9 @@
                     "token": "p_month_Oct_day_27",
                     "value": "p_month_Oct_day_27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15278
                 },
@@ -16636,7 +20346,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15296
                 },
@@ -16645,7 +20357,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15297
                 },
@@ -16654,7 +20368,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15310
                 },
@@ -16663,7 +20379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15322
                 },
@@ -16672,7 +20390,9 @@
                     "token": "p_month_Oct_day_28",
                     "value": "p_month_Oct_day_28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15323
                 },
@@ -16681,7 +20401,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15341
                 },
@@ -16690,7 +20412,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15342
                 },
@@ -16699,7 +20423,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15355
                 },
@@ -16708,7 +20434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15367
                 },
@@ -16717,7 +20445,9 @@
                     "token": "p_month_Oct_day_29",
                     "value": "p_month_Oct_day_29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15368
                 },
@@ -16726,7 +20456,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15386
                 },
@@ -16735,7 +20467,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15387
                 },
@@ -16744,7 +20478,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15400
                 },
@@ -16753,7 +20489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15412
                 },
@@ -16762,7 +20500,9 @@
                     "token": "p_month_Oct_day_30",
                     "value": "p_month_Oct_day_30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15413
                 },
@@ -16771,7 +20511,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15431
                 },
@@ -16780,7 +20522,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15432
                 },
@@ -16789,7 +20533,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15445
                 },
@@ -16798,7 +20544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15457
                 },
@@ -16807,7 +20555,9 @@
                     "token": "p_month_Oct_day_31",
                     "value": "p_month_Oct_day_31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15458
                 },
@@ -16816,7 +20566,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15476
                 },
@@ -16825,7 +20577,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15485
                 },
@@ -16834,7 +20588,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15486
                 },
@@ -16843,7 +20599,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15487
                 },
@@ -16852,7 +20610,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 15496
                 },
@@ -16861,7 +20621,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15505
                 },
@@ -16870,7 +20632,9 @@
                     "token": "p_month_Nov",
                     "value": "p_month_Nov",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15506
                 },
@@ -16879,7 +20643,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15517
                 },
@@ -16888,7 +20654,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 15522
                 },
@@ -16897,7 +20665,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15528
                 },
@@ -16906,7 +20676,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 15537
                 },
@@ -16915,7 +20687,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15546
                 },
@@ -16924,7 +20698,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15547
                 },
@@ -16933,7 +20709,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 15548
                 },
@@ -16942,7 +20720,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15550
                 },
@@ -16951,7 +20731,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15551
                 },
@@ -16960,7 +20742,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15552
                 },
@@ -16969,7 +20753,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15553
                 },
@@ -16978,7 +20764,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15566
                 },
@@ -16987,7 +20775,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15578
                 },
@@ -16996,7 +20786,9 @@
                     "token": "p_month_Nov_day_0",
                     "value": "p_month_Nov_day_0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15579
                 },
@@ -17005,7 +20797,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15596
                 },
@@ -17014,7 +20808,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15597
                 },
@@ -17023,7 +20819,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15610
                 },
@@ -17032,7 +20830,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15622
                 },
@@ -17041,7 +20841,9 @@
                     "token": "p_month_Nov_day_1",
                     "value": "p_month_Nov_day_1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15623
                 },
@@ -17050,7 +20852,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15640
                 },
@@ -17059,7 +20863,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15641
                 },
@@ -17068,7 +20874,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15654
                 },
@@ -17077,7 +20885,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15666
                 },
@@ -17086,7 +20896,9 @@
                     "token": "p_month_Nov_day_2",
                     "value": "p_month_Nov_day_2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15667
                 },
@@ -17095,7 +20907,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15684
                 },
@@ -17104,7 +20918,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15685
                 },
@@ -17113,7 +20929,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15698
                 },
@@ -17122,7 +20940,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15710
                 },
@@ -17131,7 +20951,9 @@
                     "token": "p_month_Nov_day_3",
                     "value": "p_month_Nov_day_3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15711
                 },
@@ -17140,7 +20962,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15728
                 },
@@ -17149,7 +20973,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15729
                 },
@@ -17158,7 +20984,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15742
                 },
@@ -17167,7 +20995,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15754
                 },
@@ -17176,7 +21006,9 @@
                     "token": "p_month_Nov_day_4",
                     "value": "p_month_Nov_day_4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15755
                 },
@@ -17185,7 +21017,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15772
                 },
@@ -17194,7 +21028,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15773
                 },
@@ -17203,7 +21039,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15786
                 },
@@ -17212,7 +21050,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15798
                 },
@@ -17221,7 +21061,9 @@
                     "token": "p_month_Nov_day_5",
                     "value": "p_month_Nov_day_5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15799
                 },
@@ -17230,7 +21072,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15816
                 },
@@ -17239,7 +21083,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15817
                 },
@@ -17248,7 +21094,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15830
                 },
@@ -17257,7 +21105,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15842
                 },
@@ -17266,7 +21116,9 @@
                     "token": "p_month_Nov_day_6",
                     "value": "p_month_Nov_day_6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15843
                 },
@@ -17275,7 +21127,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15860
                 },
@@ -17284,7 +21138,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15861
                 },
@@ -17293,7 +21149,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15874
                 },
@@ -17302,7 +21160,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15886
                 },
@@ -17311,7 +21171,9 @@
                     "token": "p_month_Nov_day_7",
                     "value": "p_month_Nov_day_7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15887
                 },
@@ -17320,7 +21182,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15904
                 },
@@ -17329,7 +21193,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15905
                 },
@@ -17338,7 +21204,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15918
                 },
@@ -17347,7 +21215,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15930
                 },
@@ -17356,7 +21226,9 @@
                     "token": "p_month_Nov_day_8",
                     "value": "p_month_Nov_day_8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15931
                 },
@@ -17365,7 +21237,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15948
                 },
@@ -17374,7 +21248,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15949
                 },
@@ -17383,7 +21259,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15962
                 },
@@ -17392,7 +21270,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15974
                 },
@@ -17401,7 +21281,9 @@
                     "token": "p_month_Nov_day_9",
                     "value": "p_month_Nov_day_9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 15975
                 },
@@ -17410,7 +21292,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 15992
                 },
@@ -17419,7 +21303,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15993
                 },
@@ -17428,7 +21314,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16006
                 },
@@ -17437,7 +21325,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16018
                 },
@@ -17446,7 +21336,9 @@
                     "token": "p_month_Nov_day_10",
                     "value": "p_month_Nov_day_10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16019
                 },
@@ -17455,7 +21347,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16037
                 },
@@ -17464,7 +21358,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16038
                 },
@@ -17473,7 +21369,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16051
                 },
@@ -17482,7 +21380,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16063
                 },
@@ -17491,7 +21391,9 @@
                     "token": "p_month_Nov_day_11",
                     "value": "p_month_Nov_day_11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16064
                 },
@@ -17500,7 +21402,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16082
                 },
@@ -17509,7 +21413,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16083
                 },
@@ -17518,7 +21424,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16096
                 },
@@ -17527,7 +21435,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16108
                 },
@@ -17536,7 +21446,9 @@
                     "token": "p_month_Nov_day_12",
                     "value": "p_month_Nov_day_12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16109
                 },
@@ -17545,7 +21457,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16127
                 },
@@ -17554,7 +21468,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16128
                 },
@@ -17563,7 +21479,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16141
                 },
@@ -17572,7 +21490,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16153
                 },
@@ -17581,7 +21501,9 @@
                     "token": "p_month_Nov_day_13",
                     "value": "p_month_Nov_day_13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16154
                 },
@@ -17590,7 +21512,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16172
                 },
@@ -17599,7 +21523,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16173
                 },
@@ -17608,7 +21534,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16186
                 },
@@ -17617,7 +21545,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16198
                 },
@@ -17626,7 +21556,9 @@
                     "token": "p_month_Nov_day_14",
                     "value": "p_month_Nov_day_14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16199
                 },
@@ -17635,7 +21567,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16217
                 },
@@ -17644,7 +21578,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16218
                 },
@@ -17653,7 +21589,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16231
                 },
@@ -17662,7 +21600,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16243
                 },
@@ -17671,7 +21611,9 @@
                     "token": "p_month_Nov_day_15",
                     "value": "p_month_Nov_day_15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16244
                 },
@@ -17680,7 +21622,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16262
                 },
@@ -17689,7 +21633,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16263
                 },
@@ -17698,7 +21644,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16276
                 },
@@ -17707,7 +21655,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16288
                 },
@@ -17716,7 +21666,9 @@
                     "token": "p_month_Nov_day_16",
                     "value": "p_month_Nov_day_16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16289
                 },
@@ -17725,7 +21677,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16307
                 },
@@ -17734,7 +21688,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16308
                 },
@@ -17743,7 +21699,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16321
                 },
@@ -17752,7 +21710,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16333
                 },
@@ -17761,7 +21721,9 @@
                     "token": "p_month_Nov_day_17",
                     "value": "p_month_Nov_day_17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16334
                 },
@@ -17770,7 +21732,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16352
                 },
@@ -17779,7 +21743,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16353
                 },
@@ -17788,7 +21754,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16366
                 },
@@ -17797,7 +21765,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16378
                 },
@@ -17806,7 +21776,9 @@
                     "token": "p_month_Nov_day_18",
                     "value": "p_month_Nov_day_18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16379
                 },
@@ -17815,7 +21787,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16397
                 },
@@ -17824,7 +21798,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16398
                 },
@@ -17833,7 +21809,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16411
                 },
@@ -17842,7 +21820,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16423
                 },
@@ -17851,7 +21831,9 @@
                     "token": "p_month_Nov_day_19",
                     "value": "p_month_Nov_day_19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16424
                 },
@@ -17860,7 +21842,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16442
                 },
@@ -17869,7 +21853,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16443
                 },
@@ -17878,7 +21864,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16456
                 },
@@ -17887,7 +21875,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16468
                 },
@@ -17896,7 +21886,9 @@
                     "token": "p_month_Nov_day_20",
                     "value": "p_month_Nov_day_20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16469
                 },
@@ -17905,7 +21897,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16487
                 },
@@ -17914,7 +21908,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16488
                 },
@@ -17923,7 +21919,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16501
                 },
@@ -17932,7 +21930,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16513
                 },
@@ -17941,7 +21941,9 @@
                     "token": "p_month_Nov_day_21",
                     "value": "p_month_Nov_day_21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16514
                 },
@@ -17950,7 +21952,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16532
                 },
@@ -17959,7 +21963,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16533
                 },
@@ -17968,7 +21974,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16546
                 },
@@ -17977,7 +21985,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16558
                 },
@@ -17986,7 +21996,9 @@
                     "token": "p_month_Nov_day_22",
                     "value": "p_month_Nov_day_22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16559
                 },
@@ -17995,7 +22007,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16577
                 },
@@ -18004,7 +22018,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16578
                 },
@@ -18013,7 +22029,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16591
                 },
@@ -18022,7 +22040,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16603
                 },
@@ -18031,7 +22051,9 @@
                     "token": "p_month_Nov_day_23",
                     "value": "p_month_Nov_day_23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16604
                 },
@@ -18040,7 +22062,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16622
                 },
@@ -18049,7 +22073,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16623
                 },
@@ -18058,7 +22084,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16636
                 },
@@ -18067,7 +22095,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16648
                 },
@@ -18076,7 +22106,9 @@
                     "token": "p_month_Nov_day_24",
                     "value": "p_month_Nov_day_24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16649
                 },
@@ -18085,7 +22117,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16667
                 },
@@ -18094,7 +22128,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16668
                 },
@@ -18103,7 +22139,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16681
                 },
@@ -18112,7 +22150,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16693
                 },
@@ -18121,7 +22161,9 @@
                     "token": "p_month_Nov_day_25",
                     "value": "p_month_Nov_day_25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16694
                 },
@@ -18130,7 +22172,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16712
                 },
@@ -18139,7 +22183,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16713
                 },
@@ -18148,7 +22194,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16726
                 },
@@ -18157,7 +22205,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16738
                 },
@@ -18166,7 +22216,9 @@
                     "token": "p_month_Nov_day_26",
                     "value": "p_month_Nov_day_26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16739
                 },
@@ -18175,7 +22227,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16757
                 },
@@ -18184,7 +22238,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16758
                 },
@@ -18193,7 +22249,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16771
                 },
@@ -18202,7 +22260,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16783
                 },
@@ -18211,7 +22271,9 @@
                     "token": "p_month_Nov_day_27",
                     "value": "p_month_Nov_day_27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16784
                 },
@@ -18220,7 +22282,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16802
                 },
@@ -18229,7 +22293,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16803
                 },
@@ -18238,7 +22304,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16816
                 },
@@ -18247,7 +22315,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16828
                 },
@@ -18256,7 +22326,9 @@
                     "token": "p_month_Nov_day_28",
                     "value": "p_month_Nov_day_28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16829
                 },
@@ -18265,7 +22337,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16847
                 },
@@ -18274,7 +22348,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16848
                 },
@@ -18283,7 +22359,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16861
                 },
@@ -18292,7 +22370,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16873
                 },
@@ -18301,7 +22381,9 @@
                     "token": "p_month_Nov_day_29",
                     "value": "p_month_Nov_day_29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16874
                 },
@@ -18310,7 +22392,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16892
                 },
@@ -18319,7 +22403,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16893
                 },
@@ -18328,7 +22414,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16906
                 },
@@ -18337,7 +22425,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16918
                 },
@@ -18346,7 +22436,9 @@
                     "token": "p_month_Nov_day_30",
                     "value": "p_month_Nov_day_30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16919
                 },
@@ -18355,7 +22447,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16937
                 },
@@ -18364,7 +22458,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16938
                 },
@@ -18373,7 +22469,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 16951
                 },
@@ -18382,7 +22480,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16963
                 },
@@ -18391,7 +22491,9 @@
                     "token": "p_month_Nov_day_31",
                     "value": "p_month_Nov_day_31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 16964
                 },
@@ -18400,7 +22502,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16982
                 },
@@ -18409,7 +22513,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16991
                 },
@@ -18418,7 +22524,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 16992
                 },
@@ -18427,7 +22535,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16993
                 },
@@ -18436,7 +22546,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17002
                 },
@@ -18445,7 +22557,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17011
                 },
@@ -18454,7 +22568,9 @@
                     "token": "p_month_Dec",
                     "value": "p_month_Dec",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17012
                 },
@@ -18463,7 +22579,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17023
                 },
@@ -18472,7 +22590,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 17028
                 },
@@ -18481,7 +22601,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17034
                 },
@@ -18490,7 +22612,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 17043
                 },
@@ -18499,7 +22623,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17052
                 },
@@ -18508,7 +22634,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17053
                 },
@@ -18517,7 +22645,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 17054
                 },
@@ -18526,7 +22656,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17056
                 },
@@ -18535,7 +22667,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17057
                 },
@@ -18544,7 +22678,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17058
                 },
@@ -18553,7 +22689,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17059
                 },
@@ -18562,7 +22700,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17072
                 },
@@ -18571,7 +22711,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17084
                 },
@@ -18580,7 +22722,9 @@
                     "token": "p_month_Dec_day_0",
                     "value": "p_month_Dec_day_0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17085
                 },
@@ -18589,7 +22733,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17102
                 },
@@ -18598,7 +22744,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17103
                 },
@@ -18607,7 +22755,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17116
                 },
@@ -18616,7 +22766,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17128
                 },
@@ -18625,7 +22777,9 @@
                     "token": "p_month_Dec_day_1",
                     "value": "p_month_Dec_day_1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17129
                 },
@@ -18634,7 +22788,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17146
                 },
@@ -18643,7 +22799,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17147
                 },
@@ -18652,7 +22810,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17160
                 },
@@ -18661,7 +22821,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17172
                 },
@@ -18670,7 +22832,9 @@
                     "token": "p_month_Dec_day_2",
                     "value": "p_month_Dec_day_2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17173
                 },
@@ -18679,7 +22843,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17190
                 },
@@ -18688,7 +22854,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17191
                 },
@@ -18697,7 +22865,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17204
                 },
@@ -18706,7 +22876,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17216
                 },
@@ -18715,7 +22887,9 @@
                     "token": "p_month_Dec_day_3",
                     "value": "p_month_Dec_day_3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17217
                 },
@@ -18724,7 +22898,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17234
                 },
@@ -18733,7 +22909,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17235
                 },
@@ -18742,7 +22920,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17248
                 },
@@ -18751,7 +22931,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17260
                 },
@@ -18760,7 +22942,9 @@
                     "token": "p_month_Dec_day_4",
                     "value": "p_month_Dec_day_4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17261
                 },
@@ -18769,7 +22953,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17278
                 },
@@ -18778,7 +22964,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17279
                 },
@@ -18787,7 +22975,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17292
                 },
@@ -18796,7 +22986,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17304
                 },
@@ -18805,7 +22997,9 @@
                     "token": "p_month_Dec_day_5",
                     "value": "p_month_Dec_day_5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17305
                 },
@@ -18814,7 +23008,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17322
                 },
@@ -18823,7 +23019,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17323
                 },
@@ -18832,7 +23030,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17336
                 },
@@ -18841,7 +23041,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17348
                 },
@@ -18850,7 +23052,9 @@
                     "token": "p_month_Dec_day_6",
                     "value": "p_month_Dec_day_6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17349
                 },
@@ -18859,7 +23063,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17366
                 },
@@ -18868,7 +23074,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17367
                 },
@@ -18877,7 +23085,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17380
                 },
@@ -18886,7 +23096,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17392
                 },
@@ -18895,7 +23107,9 @@
                     "token": "p_month_Dec_day_7",
                     "value": "p_month_Dec_day_7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17393
                 },
@@ -18904,7 +23118,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17410
                 },
@@ -18913,7 +23129,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17411
                 },
@@ -18922,7 +23140,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17424
                 },
@@ -18931,7 +23151,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17436
                 },
@@ -18940,7 +23162,9 @@
                     "token": "p_month_Dec_day_8",
                     "value": "p_month_Dec_day_8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17437
                 },
@@ -18949,7 +23173,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17454
                 },
@@ -18958,7 +23184,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17455
                 },
@@ -18967,7 +23195,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17468
                 },
@@ -18976,7 +23206,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17480
                 },
@@ -18985,7 +23217,9 @@
                     "token": "p_month_Dec_day_9",
                     "value": "p_month_Dec_day_9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17481
                 },
@@ -18994,7 +23228,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17498
                 },
@@ -19003,7 +23239,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17499
                 },
@@ -19012,7 +23250,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17512
                 },
@@ -19021,7 +23261,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17524
                 },
@@ -19030,7 +23272,9 @@
                     "token": "p_month_Dec_day_10",
                     "value": "p_month_Dec_day_10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17525
                 },
@@ -19039,7 +23283,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17543
                 },
@@ -19048,7 +23294,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17544
                 },
@@ -19057,7 +23305,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17557
                 },
@@ -19066,7 +23316,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17569
                 },
@@ -19075,7 +23327,9 @@
                     "token": "p_month_Dec_day_11",
                     "value": "p_month_Dec_day_11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17570
                 },
@@ -19084,7 +23338,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17588
                 },
@@ -19093,7 +23349,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17589
                 },
@@ -19102,7 +23360,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17602
                 },
@@ -19111,7 +23371,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17614
                 },
@@ -19120,7 +23382,9 @@
                     "token": "p_month_Dec_day_12",
                     "value": "p_month_Dec_day_12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17615
                 },
@@ -19129,7 +23393,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17633
                 },
@@ -19138,7 +23404,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17634
                 },
@@ -19147,7 +23415,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17647
                 },
@@ -19156,7 +23426,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17659
                 },
@@ -19165,7 +23437,9 @@
                     "token": "p_month_Dec_day_13",
                     "value": "p_month_Dec_day_13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17660
                 },
@@ -19174,7 +23448,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17678
                 },
@@ -19183,7 +23459,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17679
                 },
@@ -19192,7 +23470,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17692
                 },
@@ -19201,7 +23481,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17704
                 },
@@ -19210,7 +23492,9 @@
                     "token": "p_month_Dec_day_14",
                     "value": "p_month_Dec_day_14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17705
                 },
@@ -19219,7 +23503,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17723
                 },
@@ -19228,7 +23514,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17724
                 },
@@ -19237,7 +23525,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17737
                 },
@@ -19246,7 +23536,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17749
                 },
@@ -19255,7 +23547,9 @@
                     "token": "p_month_Dec_day_15",
                     "value": "p_month_Dec_day_15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17750
                 },
@@ -19264,7 +23558,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17768
                 },
@@ -19273,7 +23569,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17769
                 },
@@ -19282,7 +23580,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17782
                 },
@@ -19291,7 +23591,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17794
                 },
@@ -19300,7 +23602,9 @@
                     "token": "p_month_Dec_day_16",
                     "value": "p_month_Dec_day_16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17795
                 },
@@ -19309,7 +23613,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17813
                 },
@@ -19318,7 +23624,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17814
                 },
@@ -19327,7 +23635,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17827
                 },
@@ -19336,7 +23646,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17839
                 },
@@ -19345,7 +23657,9 @@
                     "token": "p_month_Dec_day_17",
                     "value": "p_month_Dec_day_17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17840
                 },
@@ -19354,7 +23668,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17858
                 },
@@ -19363,7 +23679,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17859
                 },
@@ -19372,7 +23690,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17872
                 },
@@ -19381,7 +23701,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17884
                 },
@@ -19390,7 +23712,9 @@
                     "token": "p_month_Dec_day_18",
                     "value": "p_month_Dec_day_18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17885
                 },
@@ -19399,7 +23723,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17903
                 },
@@ -19408,7 +23734,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17904
                 },
@@ -19417,7 +23745,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17917
                 },
@@ -19426,7 +23756,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17929
                 },
@@ -19435,7 +23767,9 @@
                     "token": "p_month_Dec_day_19",
                     "value": "p_month_Dec_day_19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17930
                 },
@@ -19444,7 +23778,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17948
                 },
@@ -19453,7 +23789,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17949
                 },
@@ -19462,7 +23800,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17962
                 },
@@ -19471,7 +23811,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17974
                 },
@@ -19480,7 +23822,9 @@
                     "token": "p_month_Dec_day_20",
                     "value": "p_month_Dec_day_20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 17975
                 },
@@ -19489,7 +23833,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 17993
                 },
@@ -19498,7 +23844,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17994
                 },
@@ -19507,7 +23855,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18007
                 },
@@ -19516,7 +23866,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18019
                 },
@@ -19525,7 +23877,9 @@
                     "token": "p_month_Dec_day_21",
                     "value": "p_month_Dec_day_21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 18020
                 },
@@ -19534,7 +23888,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 18038
                 },
@@ -19543,7 +23899,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18039
                 },
@@ -19552,7 +23910,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18052
                 },
@@ -19561,7 +23921,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18064
                 },
@@ -19570,7 +23932,9 @@
                     "token": "p_month_Dec_day_22",
                     "value": "p_month_Dec_day_22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 18065
                 },
@@ -19579,7 +23943,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 18083
                 },
@@ -19588,7 +23954,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18084
                 },
@@ -19597,7 +23965,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18097
                 },
@@ -19606,7 +23976,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18109
                 },
@@ -19615,7 +23987,9 @@
                     "token": "p_month_Dec_day_23",
                     "value": "p_month_Dec_day_23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 18110
                 },
@@ -19624,7 +23998,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 18128
                 },
@@ -19633,7 +24009,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18129
                 },
@@ -19642,7 +24020,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18142
                 },
@@ -19651,7 +24031,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18154
                 },
@@ -19660,7 +24042,9 @@
                     "token": "p_month_Dec_day_24",
                     "value": "p_month_Dec_day_24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 18155
                 },
@@ -19669,7 +24053,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 18173
                 },
@@ -19678,7 +24064,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18174
                 },
@@ -19687,7 +24075,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18187
                 },
@@ -19696,7 +24086,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18199
                 },
@@ -19705,7 +24097,9 @@
                     "token": "p_month_Dec_day_25",
                     "value": "p_month_Dec_day_25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 18200
                 },
@@ -19714,7 +24108,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 18218
                 },
@@ -19723,7 +24119,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18219
                 },
@@ -19732,7 +24130,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18232
                 },
@@ -19741,7 +24141,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18244
                 },
@@ -19750,7 +24152,9 @@
                     "token": "p_month_Dec_day_26",
                     "value": "p_month_Dec_day_26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 18245
                 },
@@ -19759,7 +24163,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 18263
                 },
@@ -19768,7 +24174,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18264
                 },
@@ -19777,7 +24185,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18277
                 },
@@ -19786,7 +24196,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18289
                 },
@@ -19795,7 +24207,9 @@
                     "token": "p_month_Dec_day_27",
                     "value": "p_month_Dec_day_27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 18290
                 },
@@ -19804,7 +24218,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 18308
                 },
@@ -19813,7 +24229,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18309
                 },
@@ -19822,7 +24240,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18322
                 },
@@ -19831,7 +24251,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18334
                 },
@@ -19840,7 +24262,9 @@
                     "token": "p_month_Dec_day_28",
                     "value": "p_month_Dec_day_28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 18335
                 },
@@ -19849,7 +24273,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 18353
                 },
@@ -19858,7 +24284,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18354
                 },
@@ -19867,7 +24295,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18367
                 },
@@ -19876,7 +24306,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18379
                 },
@@ -19885,7 +24317,9 @@
                     "token": "p_month_Dec_day_29",
                     "value": "p_month_Dec_day_29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 18380
                 },
@@ -19894,7 +24328,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 18398
                 },
@@ -19903,7 +24339,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18399
                 },
@@ -19912,7 +24350,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18412
                 },
@@ -19921,7 +24361,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18424
                 },
@@ -19930,7 +24372,9 @@
                     "token": "p_month_Dec_day_30",
                     "value": "p_month_Dec_day_30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 18425
                 },
@@ -19939,7 +24383,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 18443
                 },
@@ -19948,7 +24394,9 @@
                     "token": "\n            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18444
                 },
@@ -19957,7 +24405,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 18457
                 },
@@ -19966,7 +24416,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18469
                 },
@@ -19975,7 +24427,9 @@
                     "token": "p_month_Dec_day_31",
                     "value": "p_month_Dec_day_31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 18470
                 },
@@ -19984,7 +24438,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18488
                 },
@@ -19993,7 +24449,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 18497
                 },
@@ -20002,7 +24460,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18498
                 },
@@ -20011,7 +24471,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 18499
                 },
@@ -20020,13 +24482,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 2224,
-            "idx": 2224
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable12.out
+++ b/tests/data/parser/parseCreateTable12.out
@@ -7,13 +7,19 @@
         "last": 75,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 27,
+            "idx": 27,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "OR REPLACE",
                     "value": "OR REPLACE",
                     "keyword": "OR REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -49,7 +63,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +85,11 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,7 +109,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 27
                 },
@@ -94,7 +122,9 @@
                     "token": "v1",
                     "value": "v1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -139,7 +177,9 @@
                     "token": "PARTITION BY",
                     "value": "PARTITION BY",
                     "keyword": "PARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 38
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -157,7 +199,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 51
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -175,7 +221,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 55
                 },
@@ -184,7 +232,9 @@
                     "token": "v1",
                     "value": "v1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -193,7 +243,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 58
                 },
@@ -202,7 +254,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -211,7 +265,9 @@
                     "token": "PARTITIONS",
                     "value": "PARTITIONS",
                     "keyword": "PARTITIONS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 62
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -229,7 +287,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -238,7 +300,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -247,13 +313,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 27,
-            "idx": 27
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable13.out
+++ b/tests/data/parser/parseCreateTable13.out
@@ -7,13 +7,19 @@
         "last": 138,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 41,
+            "idx": 41,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "autos",
                     "value": "autos",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -76,7 +100,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +111,9 @@
                     "token": "auto_id",
                     "value": "auto_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +133,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -121,7 +155,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 37
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 46
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -157,7 +199,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 55
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -175,7 +221,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 70
                 },
@@ -184,7 +232,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 73
                 },
@@ -193,7 +243,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -202,7 +254,9 @@
                     "token": "make",
                     "value": "make",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -220,7 +276,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 84
                 },
@@ -229,7 +287,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 91
                 },
@@ -238,7 +298,11 @@
                     "token": "128",
                     "value": 128,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -247,7 +311,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 95
                 },
@@ -256,7 +322,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 96
                 },
@@ -265,7 +333,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -274,7 +344,9 @@
                     "token": "year",
                     "value": "year",
                     "keyword": "YEAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 102
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -292,7 +366,9 @@
                     "token": "INTEGER",
                     "value": "INTEGER",
                     "keyword": "INTEGER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 107
                 },
@@ -301,7 +377,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 114
                 },
@@ -310,7 +388,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -319,7 +399,9 @@
                     "token": "mileage",
                     "value": "mileage",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -337,7 +421,9 @@
                     "token": "INTEGER",
                     "value": "INTEGER",
                     "keyword": "INTEGER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 128
                 },
@@ -346,7 +432,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -355,7 +443,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 136
                 },
@@ -364,7 +454,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 137
                 },
@@ -373,13 +467,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@47"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 41,
-            "idx": 41
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable14.out
+++ b/tests/data/parser/parseCreateTable14.out
@@ -7,13 +7,19 @@
         "last": 123,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 39,
+            "idx": 39,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "autos",
                     "value": "autos",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -76,7 +100,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +111,9 @@
                     "token": "auto_id",
                     "value": "auto_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +133,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -121,7 +155,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 37
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 46
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -157,7 +199,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 55
                 },
@@ -166,7 +210,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 58
                 },
@@ -175,7 +221,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -184,7 +232,9 @@
                     "token": "make",
                     "value": "make",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -202,7 +254,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 69
                 },
@@ -211,7 +265,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 76
                 },
@@ -220,7 +276,11 @@
                     "token": "128",
                     "value": 128,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -229,7 +289,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 81
                 },
@@ -247,7 +311,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -256,7 +322,9 @@
                     "token": "year",
                     "value": "year",
                     "keyword": "YEAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 87
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -274,7 +344,9 @@
                     "token": "INTEGER",
                     "value": "INTEGER",
                     "keyword": "INTEGER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 92
                 },
@@ -283,7 +355,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 99
                 },
@@ -292,7 +366,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -301,7 +377,9 @@
                     "token": "mileage",
                     "value": "mileage",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -319,7 +399,9 @@
                     "token": "INTEGER",
                     "value": "INTEGER",
                     "keyword": "INTEGER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 113
                 },
@@ -328,7 +410,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -337,7 +421,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 121
                 },
@@ -346,7 +432,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -355,13 +445,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 39,
-            "idx": 39
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable15.out
+++ b/tests/data/parser/parseCreateTable15.out
@@ -7,13 +7,19 @@
         "last": 132,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 41,
+            "idx": 41,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "autos",
                     "value": "autos",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -76,7 +100,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +111,9 @@
                     "token": "auto_id",
                     "value": "auto_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +133,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -121,7 +155,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 37
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": "ZEROFILL",
                     "value": "ZEROFILL",
                     "keyword": "ZEROFILL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 46
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -157,7 +199,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 55
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -175,7 +221,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 64
                 },
@@ -184,7 +232,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 67
                 },
@@ -193,7 +243,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -202,7 +254,9 @@
                     "token": "make",
                     "value": "make",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -220,7 +276,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 78
                 },
@@ -229,7 +287,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 85
                 },
@@ -238,7 +298,11 @@
                     "token": "128",
                     "value": 128,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -247,7 +311,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 89
                 },
@@ -256,7 +322,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 90
                 },
@@ -265,7 +333,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -274,7 +344,9 @@
                     "token": "year",
                     "value": "year",
                     "keyword": "YEAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 96
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -292,7 +366,9 @@
                     "token": "INTEGER",
                     "value": "INTEGER",
                     "keyword": "INTEGER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 101
                 },
@@ -301,7 +377,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 108
                 },
@@ -310,7 +388,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -319,7 +399,9 @@
                     "token": "mileage",
                     "value": "mileage",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -337,7 +421,9 @@
                     "token": "INTEGER",
                     "value": "INTEGER",
                     "keyword": "INTEGER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 122
                 },
@@ -346,7 +432,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -355,7 +443,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 130
                 },
@@ -364,7 +454,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -373,13 +467,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@47"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 41,
-            "idx": 41
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable16.out
+++ b/tests/data/parser/parseCreateTable16.out
@@ -7,13 +7,19 @@
         "last": 65,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 25,
+            "idx": 25,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 18
                 },
@@ -76,7 +100,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +111,9 @@
                     "token": "user_id",
                     "value": "user_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -103,7 +133,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": "INDEX",
                     "value": "INDEX",
                     "keyword": "INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 37
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -148,7 +188,11 @@
                     "token": "`test`",
                     "value": "test",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 43
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -166,7 +212,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 50
                 },
@@ -175,7 +223,9 @@
                     "token": "user_id",
                     "value": "user_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -193,7 +245,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 59
                 },
@@ -202,7 +256,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 62
                 },
@@ -211,7 +267,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -220,7 +278,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 64
                 },
@@ -229,13 +289,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 25,
-            "idx": 25
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable17.out
+++ b/tests/data/parser/parseCreateTable17.out
@@ -7,13 +7,19 @@
         "last": 323,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 94,
+            "idx": 94,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`autos8`",
                     "value": "autos8",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 22
                 },
@@ -76,7 +100,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +111,9 @@
                     "token": "`auto_id`",
                     "value": "auto_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 28
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -103,7 +133,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 38
                 },
@@ -112,7 +144,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -121,7 +155,11 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 44
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -148,7 +190,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 46
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -166,7 +212,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 55
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -184,7 +234,9 @@
                     "token": "UNIQUE KEY",
                     "value": "UNIQUE KEY",
                     "keyword": "UNIQUE KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 64
                 },
@@ -193,7 +245,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 74
                 },
@@ -202,7 +256,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -211,7 +267,9 @@
                     "token": "`make`",
                     "value": "make",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 80
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -229,7 +289,9 @@
                     "token": "varchar",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 87
                 },
@@ -238,7 +300,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 94
                 },
@@ -247,7 +311,9 @@
                     "token": "128",
                     "value": 128,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -256,7 +322,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 98
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -274,7 +344,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 100
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -292,7 +366,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -301,7 +377,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 112
                 },
@@ -310,7 +388,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -319,7 +399,9 @@
                     "token": "`year`",
                     "value": "year",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 118
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -337,7 +421,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 125
                 },
@@ -346,7 +432,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 128
                 },
@@ -355,7 +443,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -364,7 +454,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 131
                 },
@@ -373,7 +465,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -382,7 +476,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 133
                 },
@@ -391,7 +487,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -400,7 +498,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 141
                 },
@@ -409,7 +509,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 145
                 },
@@ -418,7 +520,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 146
                 },
@@ -427,7 +531,9 @@
                     "token": "`mileage`",
                     "value": "mileage",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 151
                 },
@@ -436,7 +542,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -445,7 +553,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 161
                 },
@@ -454,7 +564,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 164
                 },
@@ -463,7 +575,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 165
                 },
@@ -472,7 +586,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 167
                 },
@@ -481,7 +597,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 168
                 },
@@ -490,7 +608,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 169
                 },
@@ -499,7 +619,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -508,7 +630,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 177
                 },
@@ -517,7 +641,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 181
                 },
@@ -526,7 +652,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 182
                 },
@@ -535,7 +663,9 @@
                     "token": "`city`",
                     "value": "city",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 187
                 },
@@ -544,7 +674,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 193
                 },
@@ -553,7 +685,9 @@
                     "token": "point",
                     "value": "point",
                     "keyword": "POINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 194
                 },
@@ -562,7 +696,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 199
                 },
@@ -571,7 +707,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 200
                 },
@@ -580,7 +718,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 208
                 },
@@ -589,7 +729,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 209
                 },
@@ -598,7 +740,9 @@
                     "token": "SPATIAL INDEX",
                     "value": "SPATIAL INDEX",
                     "keyword": "SPATIAL INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 214
                 },
@@ -607,7 +751,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 227
                 },
@@ -616,7 +762,9 @@
                     "token": "`city_index`",
                     "value": "city_index",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 228
                 },
@@ -625,7 +773,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 240
                 },
@@ -634,7 +784,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 241
                 },
@@ -643,7 +795,9 @@
                     "token": "`city`",
                     "value": "city",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 242
                 },
@@ -652,7 +806,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 248
                 },
@@ -661,7 +817,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 249
                 },
@@ -670,7 +828,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 250
                 },
@@ -679,7 +839,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 251
                 },
@@ -688,7 +850,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 252
                 },
@@ -697,7 +861,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 258
                 },
@@ -706,7 +872,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 259
                 },
@@ -715,7 +883,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 260
                 },
@@ -724,7 +894,11 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 261
                 },
@@ -733,7 +907,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 267
                 },
@@ -742,7 +918,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 268
                 },
@@ -751,7 +929,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 283
                 },
@@ -760,7 +940,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 284
                 },
@@ -769,7 +951,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 285
                 },
@@ -778,7 +962,9 @@
                     "token": "utf8mb4",
                     "value": "utf8mb4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@87"
+                    },
                     "flags": 0,
                     "position": 286
                 },
@@ -787,7 +973,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 293
                 },
@@ -796,7 +984,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 294
                 },
@@ -805,7 +995,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 301
                 },
@@ -814,7 +1006,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 302
                 },
@@ -823,7 +1017,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 303
                 },
@@ -832,7 +1028,9 @@
                     "token": "utf8mb4_general_ci",
                     "value": "utf8mb4_general_ci",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@87"
+                    },
                     "flags": 0,
                     "position": 304
                 },
@@ -841,7 +1039,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 322
                 },
@@ -850,13 +1052,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@101"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 94,
-            "idx": 94
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable18.out
+++ b/tests/data/parser/parseCreateTable18.out
@@ -7,13 +7,19 @@
         "last": 196,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 55,
+            "idx": 55,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 18
                 },
@@ -76,7 +100,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +111,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -103,7 +133,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 25
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -121,7 +155,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -139,7 +177,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 38
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -157,7 +199,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 47
                 },
@@ -166,7 +210,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 61
                 },
@@ -175,7 +221,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -184,7 +232,9 @@
                     "token": "data",
                     "value": "data",
                     "keyword": "DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 65
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -202,7 +254,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 70
                 },
@@ -211,7 +265,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -220,7 +276,11 @@
                     "token": "64",
                     "value": 64,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -229,7 +289,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -247,7 +311,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 82
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -265,7 +333,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 90
                 },
@@ -274,7 +344,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 94
                 },
@@ -283,7 +355,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -292,7 +366,9 @@
                     "token": "ts",
                     "value": "ts",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -310,7 +388,9 @@
                     "token": "TIMESTAMP",
                     "value": "TIMESTAMP",
                     "keyword": "TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 101
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -328,7 +410,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 111
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -346,7 +432,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 120
                 },
@@ -355,7 +443,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -364,7 +454,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 128
                 },
@@ -373,7 +465,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 145
                 },
@@ -382,7 +476,9 @@
                     "token": "ON UPDATE",
                     "value": "ON UPDATE",
                     "keyword": "ON UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 146
                 },
@@ -391,7 +487,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 155
                 },
@@ -400,7 +498,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 156
                 },
@@ -409,7 +509,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 173
                 },
@@ -418,7 +520,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 174
                 },
@@ -427,7 +531,9 @@
                     "token": "PRIMARY KEY",
                     "value": "PRIMARY KEY",
                     "keyword": "PRIMARY KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 177
                 },
@@ -436,7 +542,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 188
                 },
@@ -445,7 +553,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 189
                 },
@@ -454,7 +564,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 190
                 },
@@ -463,7 +575,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 192
                 },
@@ -472,7 +586,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 193
                 },
@@ -481,7 +597,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 194
                 },
@@ -490,7 +608,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 195
                 },
@@ -499,13 +621,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@61"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 55,
-            "idx": 55
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable2.out
+++ b/tests/data/parser/parseCreateTable2.out
@@ -7,13 +7,19 @@
         "last": 940,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 212,
+            "idx": 212,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`payment`",
                     "value": "payment",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 23
                 },
@@ -76,7 +100,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": "`payment_id`",
                     "value": "payment_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -103,7 +133,9 @@
                     "token": "smallint",
                     "value": "SMALLINT",
                     "keyword": "SMALLINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 40
                 },
@@ -112,7 +144,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 48
                 },
@@ -121,7 +155,11 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 50
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -148,7 +190,9 @@
                     "token": "unsigned",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 52
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -166,7 +212,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 61
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +234,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 84
                 },
@@ -202,7 +256,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -211,7 +267,9 @@
                     "token": "`customer_id`",
                     "value": "customer_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 88
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -229,7 +289,9 @@
                     "token": "smallint",
                     "value": "SMALLINT",
                     "keyword": "SMALLINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 102
                 },
@@ -238,7 +300,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 110
                 },
@@ -247,7 +311,9 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -256,7 +322,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 112
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -274,7 +344,9 @@
                     "token": "unsigned",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 114
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -292,7 +366,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 123
                 },
@@ -301,7 +377,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 131
                 },
@@ -310,7 +388,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -319,7 +399,9 @@
                     "token": "`staff_id`",
                     "value": "staff_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 135
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 145
                 },
@@ -337,7 +421,9 @@
                     "token": "tinyint",
                     "value": "TINYINT",
                     "keyword": "TINYINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 146
                 },
@@ -346,7 +432,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 153
                 },
@@ -355,7 +443,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -364,7 +454,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 155
                 },
@@ -373,7 +465,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 156
                 },
@@ -382,7 +476,9 @@
                     "token": "unsigned",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 157
                 },
@@ -391,7 +487,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 165
                 },
@@ -400,7 +498,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 166
                 },
@@ -409,7 +509,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 174
                 },
@@ -418,7 +520,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 175
                 },
@@ -427,7 +531,9 @@
                     "token": "`rental_id`",
                     "value": "rental_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 178
                 },
@@ -436,7 +542,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 189
                 },
@@ -445,7 +553,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 190
                 },
@@ -454,7 +564,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 193
                 },
@@ -463,7 +575,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 194
                 },
@@ -472,7 +586,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 196
                 },
@@ -481,7 +597,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 197
                 },
@@ -490,7 +608,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 198
                 },
@@ -499,7 +619,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 205
                 },
@@ -508,7 +630,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 206
                 },
@@ -517,7 +641,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 210
                 },
@@ -526,7 +652,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 211
                 },
@@ -535,7 +663,9 @@
                     "token": "`amount`",
                     "value": "amount",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 214
                 },
@@ -544,7 +674,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 222
                 },
@@ -553,7 +685,9 @@
                     "token": "decimal",
                     "value": "DECIMAL",
                     "keyword": "DECIMAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 223
                 },
@@ -562,7 +696,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 230
                 },
@@ -571,7 +707,9 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 231
                 },
@@ -580,7 +718,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 232
                 },
@@ -589,7 +729,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 233
                 },
@@ -598,7 +740,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 234
                 },
@@ -607,7 +751,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 235
                 },
@@ -616,7 +762,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 236
                 },
@@ -625,7 +773,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 244
                 },
@@ -634,7 +784,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 245
                 },
@@ -643,7 +795,9 @@
                     "token": "`payment_date`",
                     "value": "payment_date",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 248
                 },
@@ -652,7 +806,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 262
                 },
@@ -661,7 +817,9 @@
                     "token": "datetime",
                     "value": "datetime",
                     "keyword": "DATETIME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 9,
                     "position": 263
                 },
@@ -670,7 +828,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 271
                 },
@@ -679,7 +839,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 272
                 },
@@ -688,7 +850,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 280
                 },
@@ -697,7 +861,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 281
                 },
@@ -706,7 +872,9 @@
                     "token": "`last_update`",
                     "value": "last_update",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 284
                 },
@@ -715,7 +883,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 297
                 },
@@ -724,7 +894,9 @@
                     "token": "timestamp",
                     "value": "timestamp",
                     "keyword": "TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 298
                 },
@@ -733,7 +905,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 307
                 },
@@ -742,7 +916,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 308
                 },
@@ -751,7 +927,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 316
                 },
@@ -760,7 +938,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 317
                 },
@@ -769,7 +949,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 324
                 },
@@ -778,7 +960,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 325
                 },
@@ -787,7 +971,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 342
                 },
@@ -796,7 +982,9 @@
                     "token": "ON UPDATE",
                     "value": "ON UPDATE",
                     "keyword": "ON UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 343
                 },
@@ -805,7 +993,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 352
                 },
@@ -814,7 +1004,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 353
                 },
@@ -823,7 +1015,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 370
                 },
@@ -832,7 +1026,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 371
                 },
@@ -841,7 +1037,9 @@
                     "token": "PRIMARY KEY",
                     "value": "PRIMARY KEY",
                     "keyword": "PRIMARY KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 374
                 },
@@ -850,7 +1048,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 385
                 },
@@ -859,7 +1059,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 386
                 },
@@ -868,7 +1070,9 @@
                     "token": "`payment_id`",
                     "value": "payment_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 387
                 },
@@ -877,7 +1081,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 399
                 },
@@ -886,7 +1092,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 400
                 },
@@ -895,7 +1103,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 401
                 },
@@ -904,7 +1114,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 404
                 },
@@ -913,7 +1125,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 407
                 },
@@ -922,7 +1136,9 @@
                     "token": "`idx_fk_staff_id`",
                     "value": "idx_fk_staff_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 408
                 },
@@ -931,7 +1147,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 425
                 },
@@ -940,7 +1158,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 426
                 },
@@ -949,7 +1169,9 @@
                     "token": "`staff_id`",
                     "value": "staff_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 427
                 },
@@ -958,7 +1180,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 437
                 },
@@ -967,7 +1191,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 438
                 },
@@ -976,7 +1202,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 439
                 },
@@ -985,7 +1213,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 442
                 },
@@ -994,7 +1224,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 445
                 },
@@ -1003,7 +1235,9 @@
                     "token": "`idx_fk_customer_id`",
                     "value": "idx_fk_customer_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 446
                 },
@@ -1012,7 +1246,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 466
                 },
@@ -1021,7 +1257,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 467
                 },
@@ -1030,7 +1268,9 @@
                     "token": "`customer_id`",
                     "value": "customer_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 468
                 },
@@ -1039,7 +1279,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 481
                 },
@@ -1048,7 +1290,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 482
                 },
@@ -1057,7 +1301,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 483
                 },
@@ -1066,7 +1312,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 486
                 },
@@ -1075,7 +1323,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 489
                 },
@@ -1084,7 +1334,9 @@
                     "token": "`fk_payment_rental`",
                     "value": "fk_payment_rental",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 490
                 },
@@ -1093,7 +1345,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 509
                 },
@@ -1102,7 +1356,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 510
                 },
@@ -1111,7 +1367,9 @@
                     "token": "`rental_id`",
                     "value": "rental_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 511
                 },
@@ -1120,7 +1378,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 522
                 },
@@ -1129,7 +1389,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 523
                 },
@@ -1138,7 +1400,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 524
                 },
@@ -1147,7 +1411,9 @@
                     "token": "CONSTRAINT",
                     "value": "CONSTRAINT",
                     "keyword": "CONSTRAINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 527
                 },
@@ -1156,7 +1422,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 537
                 },
@@ -1165,7 +1433,9 @@
                     "token": "`fk_payment_customer`",
                     "value": "fk_payment_customer",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 538
                 },
@@ -1174,7 +1444,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 559
                 },
@@ -1183,7 +1455,9 @@
                     "token": "FOREIGN KEY",
                     "value": "FOREIGN KEY",
                     "keyword": "FOREIGN KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 560
                 },
@@ -1192,7 +1466,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 571
                 },
@@ -1201,7 +1477,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 572
                 },
@@ -1210,7 +1488,9 @@
                     "token": "`customer_id`",
                     "value": "customer_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 573
                 },
@@ -1219,7 +1499,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 586
                 },
@@ -1228,7 +1510,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 587
                 },
@@ -1237,7 +1521,9 @@
                     "token": "REFERENCES",
                     "value": "REFERENCES",
                     "keyword": "REFERENCES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 588
                 },
@@ -1246,7 +1532,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 598
                 },
@@ -1255,7 +1543,9 @@
                     "token": "`customer`",
                     "value": "customer",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 599
                 },
@@ -1264,7 +1554,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 609
                 },
@@ -1273,7 +1565,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 610
                 },
@@ -1282,7 +1576,9 @@
                     "token": "`customer_id`",
                     "value": "customer_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 611
                 },
@@ -1291,7 +1587,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 624
                 },
@@ -1300,7 +1598,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 625
                 },
@@ -1309,7 +1609,9 @@
                     "token": "ON UPDATE",
                     "value": "ON UPDATE",
                     "keyword": "ON UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 626
                 },
@@ -1318,7 +1620,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 635
                 },
@@ -1327,7 +1631,9 @@
                     "token": "CASCADE",
                     "value": "CASCADE",
                     "keyword": "CASCADE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 636
                 },
@@ -1336,7 +1642,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 643
                 },
@@ -1345,7 +1653,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 644
                 },
@@ -1354,7 +1664,9 @@
                     "token": "CONSTRAINT",
                     "value": "CONSTRAINT",
                     "keyword": "CONSTRAINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 647
                 },
@@ -1363,7 +1675,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 657
                 },
@@ -1372,7 +1686,9 @@
                     "token": "`fk_payment_rental`",
                     "value": "fk_payment_rental",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 658
                 },
@@ -1381,7 +1697,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 677
                 },
@@ -1390,7 +1708,9 @@
                     "token": "FOREIGN KEY",
                     "value": "FOREIGN KEY",
                     "keyword": "FOREIGN KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 678
                 },
@@ -1399,7 +1719,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 689
                 },
@@ -1408,7 +1730,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 690
                 },
@@ -1417,7 +1741,9 @@
                     "token": "`rental_id`",
                     "value": "rental_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 691
                 },
@@ -1426,7 +1752,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 702
                 },
@@ -1435,7 +1763,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 703
                 },
@@ -1444,7 +1774,9 @@
                     "token": "REFERENCES",
                     "value": "REFERENCES",
                     "keyword": "REFERENCES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 704
                 },
@@ -1453,7 +1785,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 714
                 },
@@ -1462,7 +1796,9 @@
                     "token": "`rental`",
                     "value": "rental",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 715
                 },
@@ -1471,7 +1807,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 723
                 },
@@ -1480,7 +1818,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 724
                 },
@@ -1489,7 +1829,9 @@
                     "token": "`rental_id`",
                     "value": "rental_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 725
                 },
@@ -1498,7 +1840,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 736
                 },
@@ -1507,7 +1851,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 737
                 },
@@ -1516,7 +1862,9 @@
                     "token": "ON DELETE",
                     "value": "ON DELETE",
                     "keyword": "ON DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 738
                 },
@@ -1525,7 +1873,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 747
                 },
@@ -1534,7 +1884,9 @@
                     "token": "SET NULL",
                     "value": "SET NULL",
                     "keyword": "SET NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 748
                 },
@@ -1543,7 +1895,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 756
                 },
@@ -1552,7 +1906,9 @@
                     "token": "ON UPDATE",
                     "value": "ON UPDATE",
                     "keyword": "ON UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 757
                 },
@@ -1561,7 +1917,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 766
                 },
@@ -1570,7 +1928,9 @@
                     "token": "CASCADE",
                     "value": "CASCADE",
                     "keyword": "CASCADE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 767
                 },
@@ -1579,7 +1939,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 774
                 },
@@ -1588,7 +1950,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 775
                 },
@@ -1597,7 +1961,9 @@
                     "token": "CONSTRAINT",
                     "value": "CONSTRAINT",
                     "keyword": "CONSTRAINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 778
                 },
@@ -1606,7 +1972,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 788
                 },
@@ -1615,7 +1983,9 @@
                     "token": "`fk_payment_staff`",
                     "value": "fk_payment_staff",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 789
                 },
@@ -1624,7 +1994,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 807
                 },
@@ -1633,7 +2005,9 @@
                     "token": "FOREIGN KEY",
                     "value": "FOREIGN KEY",
                     "keyword": "FOREIGN KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 808
                 },
@@ -1642,7 +2016,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 819
                 },
@@ -1651,7 +2027,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 820
                 },
@@ -1660,7 +2038,9 @@
                     "token": "`staff_id`",
                     "value": "staff_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 821
                 },
@@ -1669,7 +2049,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 831
                 },
@@ -1678,7 +2060,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 832
                 },
@@ -1687,7 +2071,9 @@
                     "token": "REFERENCES",
                     "value": "REFERENCES",
                     "keyword": "REFERENCES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 833
                 },
@@ -1696,7 +2082,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 843
                 },
@@ -1705,7 +2093,9 @@
                     "token": "`staff`",
                     "value": "staff",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 844
                 },
@@ -1714,7 +2104,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 851
                 },
@@ -1723,7 +2115,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 852
                 },
@@ -1732,7 +2126,9 @@
                     "token": "`staff_id`",
                     "value": "staff_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 853
                 },
@@ -1741,7 +2137,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 863
                 },
@@ -1750,7 +2148,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 864
                 },
@@ -1759,7 +2159,9 @@
                     "token": "ON UPDATE",
                     "value": "ON UPDATE",
                     "keyword": "ON UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 865
                 },
@@ -1768,7 +2170,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 874
                 },
@@ -1777,7 +2181,9 @@
                     "token": "CASCADE",
                     "value": "CASCADE",
                     "keyword": "CASCADE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 875
                 },
@@ -1786,7 +2192,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 882
                 },
@@ -1795,7 +2203,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 883
                 },
@@ -1804,7 +2214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 884
                 },
@@ -1813,7 +2225,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 885
                 },
@@ -1822,7 +2236,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 891
                 },
@@ -1831,7 +2247,11 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 892
                 },
@@ -1840,7 +2260,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 898
                 },
@@ -1849,7 +2271,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 899
                 },
@@ -1858,7 +2282,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 913
                 },
@@ -1867,7 +2293,9 @@
                     "token": "16050",
                     "value": 16050,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 914
                 },
@@ -1876,7 +2304,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 919
                 },
@@ -1885,7 +2315,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 920
                 },
@@ -1894,7 +2326,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 935
                 },
@@ -1903,7 +2337,9 @@
                     "token": "utf8",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@210"
+                    },
                     "flags": 0,
                     "position": 936
                 },
@@ -1912,13 +2348,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 212,
-            "idx": 212
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable3.out
+++ b/tests/data/parser/parseCreateTable3.out
@@ -7,13 +7,19 @@
         "last": 139,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 63,
+            "idx": 63,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +133,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 28
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 32
                 },
@@ -130,7 +166,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -139,7 +177,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +188,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -166,7 +210,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 48
                 },
@@ -175,7 +221,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 55
                 },
@@ -184,7 +232,11 @@
                     "token": "32",
                     "value": 32,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 58
                 },
@@ -202,7 +256,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 59
                 },
@@ -211,7 +267,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -220,7 +278,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -238,7 +300,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 67
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -256,7 +322,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 71
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -274,7 +344,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 74
                 },
@@ -283,7 +355,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -301,7 +377,9 @@
                     "token": "mod",
                     "value": "MOD",
                     "keyword": "MOD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 77
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -319,7 +399,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -328,7 +410,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 83
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -346,7 +432,9 @@
                     "token": "VIRTUAL",
                     "value": "VIRTUAL",
                     "keyword": "VIRTUAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 85
                 },
@@ -355,7 +443,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 92
                 },
@@ -364,7 +454,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -373,7 +465,9 @@
                     "token": "d",
                     "value": "d",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -382,7 +476,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -391,7 +487,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 100
                 },
@@ -400,7 +498,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 107
                 },
@@ -409,7 +509,9 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -418,7 +520,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 109
                 },
@@ -427,7 +531,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -436,7 +542,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 111
                 },
@@ -445,7 +553,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -454,7 +564,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 114
                 },
@@ -463,7 +575,9 @@
                     "token": "left",
                     "value": "LEFT",
                     "keyword": "LEFT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 115
                 },
@@ -472,7 +586,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 119
                 },
@@ -481,7 +597,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -490,7 +608,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 121
                 },
@@ -499,7 +619,9 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -508,7 +630,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 123
                 },
@@ -517,7 +641,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 124
                 },
@@ -526,7 +652,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -535,7 +663,9 @@
                     "token": "PERSISTENT",
                     "value": "PERSISTENT",
                     "keyword": "PERSISTENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 126
                 },
@@ -544,7 +674,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 136
                 },
@@ -553,7 +685,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 137
                 },
@@ -562,7 +696,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -571,13 +709,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@69"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 63,
-            "idx": 63
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable4.out
+++ b/tests/data/parser/parseCreateTable4.out
@@ -7,13 +7,19 @@
         "last": 408,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 120,
+            "idx": 120,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "ts",
                     "value": "ts",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 15
                 },
@@ -67,7 +89,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -85,7 +111,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 19
                 },
@@ -94,7 +122,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 22
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -112,7 +144,9 @@
                     "token": "purchased",
                     "value": "purchased",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -130,7 +166,9 @@
                     "token": "DATE",
                     "value": "DATE",
                     "keyword": "DATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 34
                 },
@@ -139,7 +177,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -148,7 +188,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -157,7 +199,9 @@
                     "token": "PARTITION BY",
                     "value": "PARTITION BY",
                     "keyword": "PARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 40
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -175,7 +221,11 @@
                     "token": "/* comment */",
                     "value": "/* comment */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 53
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -193,7 +245,9 @@
                     "token": "RANGE",
                     "value": "RANGE",
                     "keyword": "RANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 67
                 },
@@ -202,7 +256,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "YEAR",
                     "value": "YEAR",
                     "keyword": "YEAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -229,7 +289,9 @@
                     "token": "purchased",
                     "value": "purchased",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -238,7 +300,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 87
                 },
@@ -247,7 +311,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 88
                 },
@@ -256,7 +322,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -265,7 +333,9 @@
                     "token": "PARTITIONS",
                     "value": "PARTITIONS",
                     "keyword": "PARTITIONS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 90
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -283,7 +355,11 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -292,7 +368,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -301,7 +379,9 @@
                     "token": "SUBPARTITION BY",
                     "value": "SUBPARTITION BY",
                     "keyword": "SUBPARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 103
                 },
@@ -310,7 +390,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -319,7 +401,9 @@
                     "token": "HASH",
                     "value": "HASH",
                     "keyword": "HASH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 119
                 },
@@ -328,7 +412,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 123
                 },
@@ -337,7 +423,9 @@
                     "token": "TO_DAYS",
                     "value": "TO_DAYS",
                     "keyword": "TO_DAYS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 124
                 },
@@ -346,7 +434,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 131
                 },
@@ -355,7 +445,9 @@
                     "token": "purchased",
                     "value": "purchased",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -364,7 +456,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 141
                 },
@@ -373,7 +467,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 142
                 },
@@ -382,7 +478,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -391,7 +489,9 @@
                     "token": "SUBPARTITIONS",
                     "value": "SUBPARTITIONS",
                     "keyword": "SUBPARTITIONS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 144
                 },
@@ -400,7 +500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -409,7 +511,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@38"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -418,7 +522,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 159
                 },
@@ -427,7 +533,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -436,7 +544,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 161
                 },
@@ -445,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 170
                 },
@@ -454,7 +566,9 @@
                     "token": "p0",
                     "value": "p0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 171
                 },
@@ -463,7 +577,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 173
                 },
@@ -472,7 +588,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 174
                 },
@@ -481,7 +599,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 180
                 },
@@ -490,7 +610,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 181
                 },
@@ -499,7 +621,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 190
                 },
@@ -508,7 +632,9 @@
                     "token": "1990",
                     "value": 1990,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@38"
+                    },
                     "flags": 0,
                     "position": 191
                 },
@@ -517,7 +643,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 195
                 },
@@ -526,7 +654,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 196
                 },
@@ -535,7 +665,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 197
                 },
@@ -544,7 +676,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 202
                 },
@@ -553,7 +687,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 214
                 },
@@ -562,7 +698,9 @@
                     "token": "s0",
                     "value": "s0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 215
                 },
@@ -571,7 +709,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 217
                 },
@@ -580,7 +720,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 218
                 },
@@ -589,7 +731,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 223
                 },
@@ -598,7 +742,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 235
                 },
@@ -607,7 +753,9 @@
                     "token": "s1",
                     "value": "s1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 236
                 },
@@ -616,7 +764,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 238
                 },
@@ -625,7 +775,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 239
                 },
@@ -634,7 +786,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 240
                 },
@@ -643,7 +797,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 241
                 },
@@ -652,7 +808,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 242
                 },
@@ -661,7 +819,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 251
                 },
@@ -670,7 +830,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 252
                 },
@@ -679,7 +841,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 254
                 },
@@ -688,7 +852,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 255
                 },
@@ -697,7 +863,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 261
                 },
@@ -706,7 +874,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 262
                 },
@@ -715,7 +885,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 271
                 },
@@ -724,7 +896,9 @@
                     "token": "2000",
                     "value": 2000,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@38"
+                    },
                     "flags": 0,
                     "position": 272
                 },
@@ -733,7 +907,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 276
                 },
@@ -742,7 +918,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 277
                 },
@@ -751,7 +929,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 278
                 },
@@ -760,7 +940,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 283
                 },
@@ -769,7 +951,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 295
                 },
@@ -778,7 +962,9 @@
                     "token": "s2",
                     "value": "s2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 296
                 },
@@ -787,7 +973,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 298
                 },
@@ -796,7 +984,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 299
                 },
@@ -805,7 +995,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 304
                 },
@@ -814,7 +1006,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 316
                 },
@@ -823,7 +1017,9 @@
                     "token": "s3",
                     "value": "s3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 317
                 },
@@ -832,7 +1028,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 319
                 },
@@ -841,7 +1039,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 320
                 },
@@ -850,7 +1050,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 321
                 },
@@ -859,7 +1061,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 322
                 },
@@ -868,7 +1072,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 323
                 },
@@ -877,7 +1083,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 332
                 },
@@ -886,7 +1094,9 @@
                     "token": "p2",
                     "value": "p2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 333
                 },
@@ -895,7 +1105,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 335
                 },
@@ -904,7 +1116,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 336
                 },
@@ -913,7 +1127,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 342
                 },
@@ -922,7 +1138,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 343
                 },
@@ -931,7 +1149,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 352
                 },
@@ -940,7 +1160,9 @@
                     "token": "MAXVALUE",
                     "value": "MAXVALUE",
                     "keyword": "MAXVALUE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 353
                 },
@@ -949,7 +1171,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 361
                 },
@@ -958,7 +1182,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 362
                 },
@@ -967,7 +1193,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 367
                 },
@@ -976,7 +1204,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 379
                 },
@@ -985,7 +1215,9 @@
                     "token": "s4",
                     "value": "s4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 380
                 },
@@ -994,7 +1226,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 382
                 },
@@ -1003,7 +1237,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 383
                 },
@@ -1012,7 +1248,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 388
                 },
@@ -1021,7 +1259,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 400
                 },
@@ -1030,7 +1270,9 @@
                     "token": "s5",
                     "value": "s5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 401
                 },
@@ -1039,7 +1281,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 403
                 },
@@ -1048,7 +1292,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 404
                 },
@@ -1057,7 +1303,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 405
                 },
@@ -1066,7 +1314,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 406
                 },
@@ -1075,7 +1325,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 407
                 },
@@ -1084,13 +1338,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@127"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 120,
-            "idx": 120
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable5.out
+++ b/tests/data/parser/parseCreateTable5.out
@@ -7,13 +7,19 @@
         "last": 56,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 20,
+            "idx": 20,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "new_table",
                     "value": "new_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 23
                 },
@@ -76,7 +100,11 @@
                     "token": "`INT`",
                     "value": "INT",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 24
                 },
@@ -85,7 +113,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -94,7 +124,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 30
                 },
@@ -103,7 +135,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 37
                 },
@@ -112,7 +146,11 @@
                     "token": "50",
                     "value": 50,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -121,7 +159,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -130,7 +170,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -139,7 +181,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 42
                 },
@@ -148,7 +192,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -157,7 +203,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 50
                 },
@@ -166,7 +214,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 54
                 },
@@ -175,7 +225,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -184,13 +238,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 20,
-            "idx": 20
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable6.out
+++ b/tests/data/parser/parseCreateTable6.out
@@ -7,13 +7,19 @@
         "last": 58,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "new_table",
                     "value": "new_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 23
                 },
@@ -76,7 +100,9 @@
                     "token": "ACTION",
                     "value": "ACTION",
                     "keyword": "ACTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -94,7 +122,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 31
                 },
@@ -103,7 +133,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -112,7 +144,11 @@
                     "token": "50",
                     "value": 50,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -121,7 +157,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -139,7 +179,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 43
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -157,7 +201,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 51
                 },
@@ -166,7 +212,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 55
                 },
@@ -175,7 +223,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -184,7 +236,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -193,13 +247,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable7.out
+++ b/tests/data/parser/parseCreateTable7.out
@@ -7,13 +7,19 @@
         "last": 518,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 165,
+            "idx": 165,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`ts`",
                     "value": "ts",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 18
                 },
@@ -76,7 +100,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +111,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -121,7 +155,11 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -148,7 +190,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 35
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -166,7 +212,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 43
                 },
@@ -175,7 +223,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 47
                 },
@@ -184,7 +234,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -193,7 +245,9 @@
                     "token": "`purchased`",
                     "value": "purchased",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 51
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -211,7 +267,9 @@
                     "token": "date",
                     "value": "date",
                     "keyword": "DATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 63
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -229,7 +289,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 68
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -247,7 +311,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 76
                 },
@@ -256,7 +322,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -265,7 +333,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 81
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -283,7 +355,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 83
                 },
@@ -292,7 +366,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 89
                 },
@@ -301,7 +377,11 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -310,7 +390,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -319,7 +401,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 97
                 },
@@ -328,7 +412,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 112
                 },
@@ -337,7 +423,9 @@
                     "token": "utf8mb4",
                     "value": "utf8mb4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -346,7 +434,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -355,7 +445,9 @@
                     "token": "PARTITION BY",
                     "value": "PARTITION BY",
                     "keyword": "PARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 121
                 },
@@ -364,7 +456,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -373,7 +467,9 @@
                     "token": "RANGE",
                     "value": "RANGE",
                     "keyword": "RANGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 134
                 },
@@ -382,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -391,7 +489,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 140
                 },
@@ -400,7 +500,9 @@
                     "token": "YEAR",
                     "value": "YEAR",
                     "keyword": "YEAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 141
                 },
@@ -409,7 +511,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 145
                 },
@@ -418,7 +522,9 @@
                     "token": "purchased",
                     "value": "purchased",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 146
                 },
@@ -427,7 +533,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 155
                 },
@@ -436,7 +544,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 156
                 },
@@ -445,7 +555,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -454,7 +566,9 @@
                     "token": "SUBPARTITION BY",
                     "value": "SUBPARTITION BY",
                     "keyword": "SUBPARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 158
                 },
@@ -463,7 +577,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 173
                 },
@@ -472,7 +588,9 @@
                     "token": "HASH",
                     "value": "HASH",
                     "keyword": "HASH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 174
                 },
@@ -481,7 +599,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 178
                 },
@@ -490,7 +610,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 179
                 },
@@ -499,7 +621,9 @@
                     "token": "TO_DAYS",
                     "value": "TO_DAYS",
                     "keyword": "TO_DAYS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 180
                 },
@@ -508,7 +632,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 187
                 },
@@ -517,7 +643,9 @@
                     "token": "purchased",
                     "value": "purchased",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 188
                 },
@@ -526,7 +654,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 197
                 },
@@ -535,7 +665,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 198
                 },
@@ -544,7 +676,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 199
                 },
@@ -553,7 +687,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 200
                 },
@@ -562,7 +698,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 201
                 },
@@ -571,7 +709,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 202
                 },
@@ -580,7 +720,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 211
                 },
@@ -589,7 +731,9 @@
                     "token": "p0",
                     "value": "p0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 212
                 },
@@ -598,7 +742,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 214
                 },
@@ -607,7 +753,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 215
                 },
@@ -616,7 +764,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 221
                 },
@@ -625,7 +775,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 222
                 },
@@ -634,7 +786,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 231
                 },
@@ -643,7 +797,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 232
                 },
@@ -652,7 +808,9 @@
                     "token": "1990",
                     "value": 1990,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 233
                 },
@@ -661,7 +819,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 237
                 },
@@ -670,7 +830,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 238
                 },
@@ -679,7 +841,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 240
                 },
@@ -688,7 +852,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 241
                 },
@@ -697,7 +863,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 242
                 },
@@ -706,7 +874,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 254
                 },
@@ -715,7 +885,9 @@
                     "token": "s0",
                     "value": "s0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 255
                 },
@@ -724,7 +896,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 257
                 },
@@ -733,7 +907,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 258
                 },
@@ -742,7 +918,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 264
                 },
@@ -751,7 +929,9 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 265
                 },
@@ -760,7 +940,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 271
                 },
@@ -769,7 +951,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 272
                 },
@@ -778,7 +962,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 273
                 },
@@ -787,7 +973,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 285
                 },
@@ -796,7 +984,9 @@
                     "token": "s1",
                     "value": "s1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 286
                 },
@@ -805,7 +995,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 288
                 },
@@ -814,7 +1006,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 289
                 },
@@ -823,7 +1017,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 295
                 },
@@ -832,7 +1028,9 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 296
                 },
@@ -841,7 +1039,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 302
                 },
@@ -850,7 +1050,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 303
                 },
@@ -859,7 +1061,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 304
                 },
@@ -868,7 +1072,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 305
                 },
@@ -877,7 +1083,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 306
                 },
@@ -886,7 +1094,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 315
                 },
@@ -895,7 +1105,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 316
                 },
@@ -904,7 +1116,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 318
                 },
@@ -913,7 +1127,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 319
                 },
@@ -922,7 +1138,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 325
                 },
@@ -931,7 +1149,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 326
                 },
@@ -940,7 +1160,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 335
                 },
@@ -949,7 +1171,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 336
                 },
@@ -958,7 +1182,9 @@
                     "token": "2000",
                     "value": 2000,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 337
                 },
@@ -967,7 +1193,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 341
                 },
@@ -976,7 +1204,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 342
                 },
@@ -985,7 +1215,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 344
                 },
@@ -994,7 +1226,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 345
                 },
@@ -1003,7 +1237,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 346
                 },
@@ -1012,7 +1248,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 358
                 },
@@ -1021,7 +1259,9 @@
                     "token": "s2",
                     "value": "s2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 359
                 },
@@ -1030,7 +1270,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 361
                 },
@@ -1039,7 +1281,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 362
                 },
@@ -1048,7 +1292,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 368
                 },
@@ -1057,7 +1303,9 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 369
                 },
@@ -1066,7 +1314,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 375
                 },
@@ -1075,7 +1325,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 376
                 },
@@ -1084,7 +1336,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 377
                 },
@@ -1093,7 +1347,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 389
                 },
@@ -1102,7 +1358,9 @@
                     "token": "s3",
                     "value": "s3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 390
                 },
@@ -1111,7 +1369,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 392
                 },
@@ -1120,7 +1380,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 393
                 },
@@ -1129,7 +1391,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 399
                 },
@@ -1138,7 +1402,9 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 400
                 },
@@ -1147,7 +1413,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 406
                 },
@@ -1156,7 +1424,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 407
                 },
@@ -1165,7 +1435,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 408
                 },
@@ -1174,7 +1446,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 409
                 },
@@ -1183,7 +1457,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 410
                 },
@@ -1192,7 +1468,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 419
                 },
@@ -1201,7 +1479,9 @@
                     "token": "p2",
                     "value": "p2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 420
                 },
@@ -1210,7 +1490,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 422
                 },
@@ -1219,7 +1501,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 423
                 },
@@ -1228,7 +1512,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 429
                 },
@@ -1237,7 +1523,9 @@
                     "token": "LESS THAN",
                     "value": "LESS THAN",
                     "keyword": "LESS THAN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 430
                 },
@@ -1246,7 +1534,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 439
                 },
@@ -1255,7 +1545,9 @@
                     "token": "MAXVALUE",
                     "value": "MAXVALUE",
                     "keyword": "MAXVALUE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 440
                 },
@@ -1264,7 +1556,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 448
                 },
@@ -1273,7 +1567,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 450
                 },
@@ -1282,7 +1578,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 451
                 },
@@ -1291,7 +1589,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 452
                 },
@@ -1300,7 +1600,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 464
                 },
@@ -1309,7 +1611,9 @@
                     "token": "s4",
                     "value": "s4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 465
                 },
@@ -1318,7 +1622,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 467
                 },
@@ -1327,7 +1633,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 468
                 },
@@ -1336,7 +1644,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 474
                 },
@@ -1345,7 +1655,9 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 475
                 },
@@ -1354,7 +1666,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 481
                 },
@@ -1363,7 +1677,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 482
                 },
@@ -1372,7 +1688,9 @@
                     "token": "SUBPARTITION",
                     "value": "SUBPARTITION",
                     "keyword": "SUBPARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 483
                 },
@@ -1381,7 +1699,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 495
                 },
@@ -1390,7 +1710,9 @@
                     "token": "s5",
                     "value": "s5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 496
                 },
@@ -1399,7 +1721,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 498
                 },
@@ -1408,7 +1732,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 499
                 },
@@ -1417,7 +1743,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 505
                 },
@@ -1426,7 +1754,9 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 506
                 },
@@ -1435,7 +1765,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 512
                 },
@@ -1444,7 +1776,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 513
                 },
@@ -1453,7 +1787,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 514
                 },
@@ -1462,7 +1798,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 515
                 },
@@ -1471,7 +1809,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 516
                 },
@@ -1480,7 +1822,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 517
                 },
@@ -1489,13 +1833,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@171"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 165,
-            "idx": 165
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable8.out
+++ b/tests/data/parser/parseCreateTable8.out
@@ -7,13 +7,19 @@
         "last": 145,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 35,
+            "idx": 35,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`test1`",
                     "value": "test1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 21
                 },
@@ -76,7 +100,9 @@
                     "token": "\n ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,7 +111,9 @@
                     "token": "`amultipoint`",
                     "value": "amultipoint",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 24
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -103,7 +133,9 @@
                     "token": "multipoint",
                     "value": "multipoint",
                     "keyword": "MULTIPOINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 38
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -121,7 +155,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 49
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -139,7 +177,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 57
                 },
@@ -148,7 +188,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 61
                 },
@@ -157,7 +199,9 @@
                     "token": "\n ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -166,7 +210,9 @@
                     "token": "`amultipolygon`",
                     "value": "amultipolygon",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 64
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -184,7 +232,9 @@
                     "token": "multipolygon",
                     "value": "multipolygon",
                     "keyword": "MULTIPOLYGON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 80
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -202,7 +254,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 93
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -220,7 +276,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 101
                 },
@@ -229,7 +287,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -238,7 +298,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 106
                 },
@@ -247,7 +309,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -256,7 +320,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 108
                 },
@@ -265,7 +331,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 114
                 },
@@ -274,7 +342,11 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -292,7 +366,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 122
                 },
@@ -301,7 +377,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 137
                 },
@@ -310,7 +388,9 @@
                     "token": "utf8mb4",
                     "value": "utf8mb4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@36"
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -319,13 +399,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 35,
-            "idx": 35
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTable9.out
+++ b/tests/data/parser/parseCreateTable9.out
@@ -7,13 +7,19 @@
         "last": 1957,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 489,
+            "idx": 489,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`trips`",
                     "value": "trips",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 21
                 },
@@ -76,7 +100,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,7 +111,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +133,9 @@
                     "token": "bigint",
                     "value": "BIGINT",
                     "keyword": "BIGINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -121,7 +155,11 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -148,7 +190,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 43
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -166,7 +212,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 52
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -184,7 +234,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 61
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -202,7 +256,11 @@
                     "token": "'Unique trip Id'",
                     "value": "Unique trip Id",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 69
                 },
@@ -211,7 +269,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 85
                 },
@@ -220,7 +280,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -229,7 +291,9 @@
                     "token": "`trip_code`",
                     "value": "trip_code",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 91
                 },
@@ -238,7 +302,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -247,7 +313,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 103
                 },
@@ -256,7 +324,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 106
                 },
@@ -265,7 +335,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -274,7 +346,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 109
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -292,7 +368,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 111
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -310,7 +390,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 120
                 },
@@ -319,7 +401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 128
                 },
@@ -328,7 +412,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 129
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 136
                 },
@@ -346,7 +434,9 @@
                     "token": "'Trip code'",
                     "value": "Trip code",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 137
                 },
@@ -355,7 +445,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 148
                 },
@@ -364,7 +456,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -373,7 +467,9 @@
                     "token": "`trip_category`",
                     "value": "trip_category",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 154
                 },
@@ -382,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 169
                 },
@@ -391,7 +489,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 170
                 },
@@ -400,7 +500,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 173
                 },
@@ -409,7 +511,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 174
                 },
@@ -418,7 +522,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 176
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 177
                 },
@@ -436,7 +544,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 178
                 },
@@ -445,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 186
                 },
@@ -454,7 +566,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 187
                 },
@@ -463,7 +577,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 195
                 },
@@ -472,7 +588,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 196
                 },
@@ -481,7 +599,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 203
                 },
@@ -490,7 +610,9 @@
                     "token": "'Trip category'",
                     "value": "Trip category",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 204
                 },
@@ -499,7 +621,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 219
                 },
@@ -508,7 +632,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 220
                 },
@@ -517,7 +643,9 @@
                     "token": "`trip_date`",
                     "value": "trip_date",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 225
                 },
@@ -526,7 +654,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 236
                 },
@@ -535,7 +665,9 @@
                     "token": "date",
                     "value": "date",
                     "keyword": "DATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 237
                 },
@@ -544,7 +676,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 241
                 },
@@ -553,7 +687,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 242
                 },
@@ -562,7 +698,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 250
                 },
@@ -571,7 +709,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 251
                 },
@@ -580,7 +720,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 258
                 },
@@ -589,7 +731,9 @@
                     "token": "'The trip date'",
                     "value": "The trip date",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 259
                 },
@@ -598,7 +742,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 274
                 },
@@ -607,7 +753,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 275
                 },
@@ -616,7 +764,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 276
                 },
@@ -625,7 +775,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 277
                 },
@@ -634,7 +786,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 283
                 },
@@ -643,7 +797,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 284
                 },
@@ -652,7 +808,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 285
                 },
@@ -661,7 +819,11 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 286
                 },
@@ -670,7 +832,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 292
                 },
@@ -679,7 +843,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 293
                 },
@@ -688,7 +854,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 308
                 },
@@ -697,7 +865,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 309
                 },
@@ -706,7 +876,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 310
                 },
@@ -715,7 +887,9 @@
                     "token": "utf8mb4",
                     "value": "utf8mb4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 311
                 },
@@ -724,7 +898,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 318
                 },
@@ -733,7 +909,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 319
                 },
@@ -742,7 +920,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 326
                 },
@@ -751,7 +931,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 327
                 },
@@ -760,7 +942,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 328
                 },
@@ -769,7 +953,9 @@
                     "token": "utf8mb4_unicode_ci",
                     "value": "utf8mb4_unicode_ci",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 329
                 },
@@ -778,7 +964,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 347
                 },
@@ -787,7 +975,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 348
                 },
@@ -796,7 +986,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 355
                 },
@@ -805,7 +997,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 356
                 },
@@ -814,7 +1008,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 357
                 },
@@ -823,7 +1019,9 @@
                     "token": "'The trips'",
                     "value": "The trips",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 358
                 },
@@ -832,7 +1030,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 369
                 },
@@ -841,7 +1041,9 @@
                     "token": "PARTITION BY",
                     "value": "PARTITION BY",
                     "keyword": "PARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 370
                 },
@@ -850,7 +1052,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 382
                 },
@@ -859,7 +1063,9 @@
                     "token": "LIST",
                     "value": "LIST",
                     "keyword": "LIST",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 383
                 },
@@ -868,7 +1074,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 387
                 },
@@ -877,7 +1085,9 @@
                     "token": "trip_category",
                     "value": "trip_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 388
                 },
@@ -886,7 +1096,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 401
                 },
@@ -895,7 +1107,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 402
                 },
@@ -904,7 +1118,9 @@
                     "token": "SUBPARTITION BY",
                     "value": "SUBPARTITION BY",
                     "keyword": "SUBPARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 403
                 },
@@ -913,7 +1129,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 418
                 },
@@ -922,7 +1140,9 @@
                     "token": "HASH",
                     "value": "HASH",
                     "keyword": "HASH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 419
                 },
@@ -931,7 +1151,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 423
                 },
@@ -940,7 +1162,9 @@
                     "token": "DAY",
                     "value": "DAY",
                     "keyword": "DAY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 424
                 },
@@ -949,7 +1173,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 427
                 },
@@ -958,7 +1184,9 @@
                     "token": "trip_date",
                     "value": "trip_date",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 428
                 },
@@ -967,7 +1195,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 437
                 },
@@ -976,7 +1206,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 438
                 },
@@ -985,7 +1217,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 439
                 },
@@ -994,7 +1228,9 @@
                     "token": "SUBPARTITIONS",
                     "value": "SUBPARTITIONS",
                     "keyword": "SUBPARTITIONS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 440
                 },
@@ -1003,7 +1239,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 453
                 },
@@ -1012,7 +1250,9 @@
                     "token": "31",
                     "value": 31,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 454
                 },
@@ -1021,7 +1261,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 456
                 },
@@ -1030,7 +1272,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 457
                 },
@@ -1039,7 +1283,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 458
                 },
@@ -1048,7 +1294,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 463
                 },
@@ -1057,7 +1305,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 472
                 },
@@ -1066,7 +1316,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 473
                 },
@@ -1075,7 +1327,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 475
                 },
@@ -1084,7 +1338,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 480
                 },
@@ -1093,7 +1349,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 486
                 },
@@ -1102,7 +1360,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 495
                 },
@@ -1111,7 +1371,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 497
                 },
@@ -1120,7 +1382,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 498
                 },
@@ -1129,7 +1393,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 499
                 },
@@ -1138,7 +1404,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 500
                 },
@@ -1147,7 +1415,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 501
                 },
@@ -1156,7 +1426,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 510
                 },
@@ -1165,7 +1437,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 519
                 },
@@ -1174,7 +1448,9 @@
                     "token": "p2",
                     "value": "p2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 520
                 },
@@ -1183,7 +1459,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 522
                 },
@@ -1192,7 +1470,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 527
                 },
@@ -1201,7 +1481,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 533
                 },
@@ -1210,7 +1492,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 542
                 },
@@ -1219,7 +1503,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 544
                 },
@@ -1228,7 +1514,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 545
                 },
@@ -1237,7 +1525,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 546
                 },
@@ -1246,7 +1536,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 547
                 },
@@ -1255,7 +1547,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 548
                 },
@@ -1264,7 +1558,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 557
                 },
@@ -1273,7 +1569,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 566
                 },
@@ -1282,7 +1580,9 @@
                     "token": "p3",
                     "value": "p3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 567
                 },
@@ -1291,7 +1591,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 569
                 },
@@ -1300,7 +1602,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 574
                 },
@@ -1309,7 +1613,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 580
                 },
@@ -1318,7 +1624,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 589
                 },
@@ -1327,7 +1635,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 591
                 },
@@ -1336,7 +1646,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 592
                 },
@@ -1345,7 +1657,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 593
                 },
@@ -1354,7 +1668,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 594
                 },
@@ -1363,7 +1679,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 595
                 },
@@ -1372,7 +1690,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 604
                 },
@@ -1381,7 +1701,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 613
                 },
@@ -1390,7 +1712,9 @@
                     "token": "p4",
                     "value": "p4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 614
                 },
@@ -1399,7 +1723,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 616
                 },
@@ -1408,7 +1734,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 621
                 },
@@ -1417,7 +1745,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 627
                 },
@@ -1426,7 +1756,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 636
                 },
@@ -1435,7 +1767,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 638
                 },
@@ -1444,7 +1778,9 @@
                     "token": "4",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 639
                 },
@@ -1453,7 +1789,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 640
                 },
@@ -1462,7 +1800,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 641
                 },
@@ -1471,7 +1811,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 642
                 },
@@ -1480,7 +1822,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 651
                 },
@@ -1489,7 +1833,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 660
                 },
@@ -1498,7 +1844,9 @@
                     "token": "p5",
                     "value": "p5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 661
                 },
@@ -1507,7 +1855,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 663
                 },
@@ -1516,7 +1866,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 668
                 },
@@ -1525,7 +1877,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 674
                 },
@@ -1534,7 +1888,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 683
                 },
@@ -1543,7 +1899,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 685
                 },
@@ -1552,7 +1910,9 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 686
                 },
@@ -1561,7 +1921,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 687
                 },
@@ -1570,7 +1932,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 688
                 },
@@ -1579,7 +1943,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 689
                 },
@@ -1588,7 +1954,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 698
                 },
@@ -1597,7 +1965,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 707
                 },
@@ -1606,7 +1976,9 @@
                     "token": "p6",
                     "value": "p6",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 708
                 },
@@ -1615,7 +1987,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 710
                 },
@@ -1624,7 +1998,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 715
                 },
@@ -1633,7 +2009,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 721
                 },
@@ -1642,7 +2020,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 730
                 },
@@ -1651,7 +2031,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 732
                 },
@@ -1660,7 +2042,9 @@
                     "token": "6",
                     "value": 6,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 733
                 },
@@ -1669,7 +2053,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 734
                 },
@@ -1678,7 +2064,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 735
                 },
@@ -1687,7 +2075,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 736
                 },
@@ -1696,7 +2086,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 745
                 },
@@ -1705,7 +2097,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 754
                 },
@@ -1714,7 +2108,9 @@
                     "token": "p7",
                     "value": "p7",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 755
                 },
@@ -1723,7 +2119,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 757
                 },
@@ -1732,7 +2130,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 762
                 },
@@ -1741,7 +2141,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 768
                 },
@@ -1750,7 +2152,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 777
                 },
@@ -1759,7 +2163,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 779
                 },
@@ -1768,7 +2174,9 @@
                     "token": "7",
                     "value": 7,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 780
                 },
@@ -1777,7 +2185,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 781
                 },
@@ -1786,7 +2196,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 782
                 },
@@ -1795,7 +2207,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 783
                 },
@@ -1804,7 +2218,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 792
                 },
@@ -1813,7 +2229,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 801
                 },
@@ -1822,7 +2240,9 @@
                     "token": "p8",
                     "value": "p8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 802
                 },
@@ -1831,7 +2251,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 804
                 },
@@ -1840,7 +2262,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 809
                 },
@@ -1849,7 +2273,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 815
                 },
@@ -1858,7 +2284,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 824
                 },
@@ -1867,7 +2295,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 826
                 },
@@ -1876,7 +2306,9 @@
                     "token": "8",
                     "value": 8,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 827
                 },
@@ -1885,7 +2317,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 828
                 },
@@ -1894,7 +2328,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 829
                 },
@@ -1903,7 +2339,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 830
                 },
@@ -1912,7 +2350,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 839
                 },
@@ -1921,7 +2361,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 848
                 },
@@ -1930,7 +2372,9 @@
                     "token": "p9",
                     "value": "p9",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 849
                 },
@@ -1939,7 +2383,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 851
                 },
@@ -1948,7 +2394,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 856
                 },
@@ -1957,7 +2405,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 862
                 },
@@ -1966,7 +2416,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 871
                 },
@@ -1975,7 +2427,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 873
                 },
@@ -1984,7 +2438,9 @@
                     "token": "9",
                     "value": 9,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 874
                 },
@@ -1993,7 +2449,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 875
                 },
@@ -2002,7 +2460,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 876
                 },
@@ -2011,7 +2471,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 877
                 },
@@ -2020,7 +2482,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 886
                 },
@@ -2029,7 +2493,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 895
                 },
@@ -2038,7 +2504,9 @@
                     "token": "p10",
                     "value": "p10",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 896
                 },
@@ -2047,7 +2515,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 899
                 },
@@ -2056,7 +2526,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 904
                 },
@@ -2065,7 +2537,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 910
                 },
@@ -2074,7 +2548,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 919
                 },
@@ -2083,7 +2559,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 921
                 },
@@ -2092,7 +2570,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 922
                 },
@@ -2101,7 +2581,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 924
                 },
@@ -2110,7 +2592,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 925
                 },
@@ -2119,7 +2603,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 926
                 },
@@ -2128,7 +2614,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 935
                 },
@@ -2137,7 +2625,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 944
                 },
@@ -2146,7 +2636,9 @@
                     "token": "p11",
                     "value": "p11",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 945
                 },
@@ -2155,7 +2647,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 948
                 },
@@ -2164,7 +2658,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 953
                 },
@@ -2173,7 +2669,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 959
                 },
@@ -2182,7 +2680,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 968
                 },
@@ -2191,7 +2691,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 970
                 },
@@ -2200,7 +2702,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 971
                 },
@@ -2209,7 +2713,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 973
                 },
@@ -2218,7 +2724,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 974
                 },
@@ -2227,7 +2735,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 975
                 },
@@ -2236,7 +2746,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 984
                 },
@@ -2245,7 +2757,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 993
                 },
@@ -2254,7 +2768,9 @@
                     "token": "p12",
                     "value": "p12",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 994
                 },
@@ -2263,7 +2779,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 997
                 },
@@ -2272,7 +2790,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1002
                 },
@@ -2281,7 +2801,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1008
                 },
@@ -2290,7 +2812,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1017
                 },
@@ -2299,7 +2823,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1019
                 },
@@ -2308,7 +2834,9 @@
                     "token": "12",
                     "value": 12,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1020
                 },
@@ -2317,7 +2845,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1022
                 },
@@ -2326,7 +2856,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1023
                 },
@@ -2335,7 +2867,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1024
                 },
@@ -2344,7 +2878,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1033
                 },
@@ -2353,7 +2889,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1042
                 },
@@ -2362,7 +2900,9 @@
                     "token": "p13",
                     "value": "p13",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1043
                 },
@@ -2371,7 +2911,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1046
                 },
@@ -2380,7 +2922,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1051
                 },
@@ -2389,7 +2933,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1057
                 },
@@ -2398,7 +2944,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1066
                 },
@@ -2407,7 +2955,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1068
                 },
@@ -2416,7 +2966,9 @@
                     "token": "13",
                     "value": 13,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1069
                 },
@@ -2425,7 +2977,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1071
                 },
@@ -2434,7 +2988,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1072
                 },
@@ -2443,7 +2999,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1073
                 },
@@ -2452,7 +3010,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1082
                 },
@@ -2461,7 +3021,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1091
                 },
@@ -2470,7 +3032,9 @@
                     "token": "p14",
                     "value": "p14",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1092
                 },
@@ -2479,7 +3043,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1095
                 },
@@ -2488,7 +3054,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1100
                 },
@@ -2497,7 +3065,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1106
                 },
@@ -2506,7 +3076,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1115
                 },
@@ -2515,7 +3087,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1117
                 },
@@ -2524,7 +3098,9 @@
                     "token": "14",
                     "value": 14,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1118
                 },
@@ -2533,7 +3109,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1120
                 },
@@ -2542,7 +3120,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1121
                 },
@@ -2551,7 +3131,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1122
                 },
@@ -2560,7 +3142,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1131
                 },
@@ -2569,7 +3153,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1140
                 },
@@ -2578,7 +3164,9 @@
                     "token": "p15",
                     "value": "p15",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1141
                 },
@@ -2587,7 +3175,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1144
                 },
@@ -2596,7 +3186,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1149
                 },
@@ -2605,7 +3197,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1155
                 },
@@ -2614,7 +3208,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1164
                 },
@@ -2623,7 +3219,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1166
                 },
@@ -2632,7 +3230,9 @@
                     "token": "15",
                     "value": 15,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1167
                 },
@@ -2641,7 +3241,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1169
                 },
@@ -2650,7 +3252,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1170
                 },
@@ -2659,7 +3263,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1171
                 },
@@ -2668,7 +3274,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1180
                 },
@@ -2677,7 +3285,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1189
                 },
@@ -2686,7 +3296,9 @@
                     "token": "p16",
                     "value": "p16",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1190
                 },
@@ -2695,7 +3307,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1193
                 },
@@ -2704,7 +3318,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1198
                 },
@@ -2713,7 +3329,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1204
                 },
@@ -2722,7 +3340,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1213
                 },
@@ -2731,7 +3351,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1215
                 },
@@ -2740,7 +3362,9 @@
                     "token": "16",
                     "value": 16,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1216
                 },
@@ -2749,7 +3373,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1218
                 },
@@ -2758,7 +3384,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1219
                 },
@@ -2767,7 +3395,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1220
                 },
@@ -2776,7 +3406,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1229
                 },
@@ -2785,7 +3417,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1238
                 },
@@ -2794,7 +3428,9 @@
                     "token": "p17",
                     "value": "p17",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1239
                 },
@@ -2803,7 +3439,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1242
                 },
@@ -2812,7 +3450,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1247
                 },
@@ -2821,7 +3461,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1253
                 },
@@ -2830,7 +3472,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1262
                 },
@@ -2839,7 +3483,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1264
                 },
@@ -2848,7 +3494,9 @@
                     "token": "17",
                     "value": 17,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1265
                 },
@@ -2857,7 +3505,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1267
                 },
@@ -2866,7 +3516,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1268
                 },
@@ -2875,7 +3527,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1269
                 },
@@ -2884,7 +3538,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1278
                 },
@@ -2893,7 +3549,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1287
                 },
@@ -2902,7 +3560,9 @@
                     "token": "p18",
                     "value": "p18",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1288
                 },
@@ -2911,7 +3571,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1291
                 },
@@ -2920,7 +3582,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1296
                 },
@@ -2929,7 +3593,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1302
                 },
@@ -2938,7 +3604,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1311
                 },
@@ -2947,7 +3615,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1313
                 },
@@ -2956,7 +3626,9 @@
                     "token": "18",
                     "value": 18,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1314
                 },
@@ -2965,7 +3637,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1316
                 },
@@ -2974,7 +3648,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1317
                 },
@@ -2983,7 +3659,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1318
                 },
@@ -2992,7 +3670,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1327
                 },
@@ -3001,7 +3681,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1336
                 },
@@ -3010,7 +3692,9 @@
                     "token": "p19",
                     "value": "p19",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1337
                 },
@@ -3019,7 +3703,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1340
                 },
@@ -3028,7 +3714,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1345
                 },
@@ -3037,7 +3725,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1351
                 },
@@ -3046,7 +3736,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1360
                 },
@@ -3055,7 +3747,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1362
                 },
@@ -3064,7 +3758,9 @@
                     "token": "19",
                     "value": 19,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1363
                 },
@@ -3073,7 +3769,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1365
                 },
@@ -3082,7 +3780,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1366
                 },
@@ -3091,7 +3791,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1367
                 },
@@ -3100,7 +3802,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1376
                 },
@@ -3109,7 +3813,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1385
                 },
@@ -3118,7 +3824,9 @@
                     "token": "p20",
                     "value": "p20",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1386
                 },
@@ -3127,7 +3835,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1389
                 },
@@ -3136,7 +3846,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1394
                 },
@@ -3145,7 +3857,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1400
                 },
@@ -3154,7 +3868,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1409
                 },
@@ -3163,7 +3879,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1411
                 },
@@ -3172,7 +3890,9 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1412
                 },
@@ -3181,7 +3901,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1414
                 },
@@ -3190,7 +3912,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1415
                 },
@@ -3199,7 +3923,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1416
                 },
@@ -3208,7 +3934,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1425
                 },
@@ -3217,7 +3945,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1434
                 },
@@ -3226,7 +3956,9 @@
                     "token": "p21",
                     "value": "p21",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1435
                 },
@@ -3235,7 +3967,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1438
                 },
@@ -3244,7 +3978,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1443
                 },
@@ -3253,7 +3989,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1449
                 },
@@ -3262,7 +4000,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1458
                 },
@@ -3271,7 +4011,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1460
                 },
@@ -3280,7 +4022,9 @@
                     "token": "21",
                     "value": 21,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1461
                 },
@@ -3289,7 +4033,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1463
                 },
@@ -3298,7 +4044,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1464
                 },
@@ -3307,7 +4055,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1465
                 },
@@ -3316,7 +4066,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1474
                 },
@@ -3325,7 +4077,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1483
                 },
@@ -3334,7 +4088,9 @@
                     "token": "p22",
                     "value": "p22",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1484
                 },
@@ -3343,7 +4099,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1487
                 },
@@ -3352,7 +4110,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1492
                 },
@@ -3361,7 +4121,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1498
                 },
@@ -3370,7 +4132,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1507
                 },
@@ -3379,7 +4143,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1509
                 },
@@ -3388,7 +4154,9 @@
                     "token": "22",
                     "value": 22,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1510
                 },
@@ -3397,7 +4165,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1512
                 },
@@ -3406,7 +4176,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1513
                 },
@@ -3415,7 +4187,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1514
                 },
@@ -3424,7 +4198,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1523
                 },
@@ -3433,7 +4209,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1532
                 },
@@ -3442,7 +4220,9 @@
                     "token": "p23",
                     "value": "p23",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1533
                 },
@@ -3451,7 +4231,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1536
                 },
@@ -3460,7 +4242,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1541
                 },
@@ -3469,7 +4253,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1547
                 },
@@ -3478,7 +4264,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1556
                 },
@@ -3487,7 +4275,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1558
                 },
@@ -3496,7 +4286,9 @@
                     "token": "23",
                     "value": 23,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1559
                 },
@@ -3505,7 +4297,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1561
                 },
@@ -3514,7 +4308,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1562
                 },
@@ -3523,7 +4319,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1563
                 },
@@ -3532,7 +4330,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1572
                 },
@@ -3541,7 +4341,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1581
                 },
@@ -3550,7 +4352,9 @@
                     "token": "p24",
                     "value": "p24",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1582
                 },
@@ -3559,7 +4363,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1585
                 },
@@ -3568,7 +4374,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1590
                 },
@@ -3577,7 +4385,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1596
                 },
@@ -3586,7 +4396,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1605
                 },
@@ -3595,7 +4407,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1607
                 },
@@ -3604,7 +4418,9 @@
                     "token": "24",
                     "value": 24,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1608
                 },
@@ -3613,7 +4429,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1610
                 },
@@ -3622,7 +4440,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1611
                 },
@@ -3631,7 +4451,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1612
                 },
@@ -3640,7 +4462,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1621
                 },
@@ -3649,7 +4473,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1630
                 },
@@ -3658,7 +4484,9 @@
                     "token": "p25",
                     "value": "p25",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1631
                 },
@@ -3667,7 +4495,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1634
                 },
@@ -3676,7 +4506,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1639
                 },
@@ -3685,7 +4517,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1645
                 },
@@ -3694,7 +4528,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1654
                 },
@@ -3703,7 +4539,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1656
                 },
@@ -3712,7 +4550,9 @@
                     "token": "25",
                     "value": 25,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1657
                 },
@@ -3721,7 +4561,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1659
                 },
@@ -3730,7 +4572,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1660
                 },
@@ -3739,7 +4583,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1661
                 },
@@ -3748,7 +4594,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1670
                 },
@@ -3757,7 +4605,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1679
                 },
@@ -3766,7 +4616,9 @@
                     "token": "p26",
                     "value": "p26",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1680
                 },
@@ -3775,7 +4627,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1683
                 },
@@ -3784,7 +4638,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1688
                 },
@@ -3793,7 +4649,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1694
                 },
@@ -3802,7 +4660,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1703
                 },
@@ -3811,7 +4671,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1705
                 },
@@ -3820,7 +4682,9 @@
                     "token": "26",
                     "value": 26,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1706
                 },
@@ -3829,7 +4693,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1708
                 },
@@ -3838,7 +4704,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1709
                 },
@@ -3847,7 +4715,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1710
                 },
@@ -3856,7 +4726,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1719
                 },
@@ -3865,7 +4737,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1728
                 },
@@ -3874,7 +4748,9 @@
                     "token": "p27",
                     "value": "p27",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1729
                 },
@@ -3883,7 +4759,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1732
                 },
@@ -3892,7 +4770,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1737
                 },
@@ -3901,7 +4781,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1743
                 },
@@ -3910,7 +4792,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1752
                 },
@@ -3919,7 +4803,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1754
                 },
@@ -3928,7 +4814,9 @@
                     "token": "27",
                     "value": 27,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1755
                 },
@@ -3937,7 +4825,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1757
                 },
@@ -3946,7 +4836,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1758
                 },
@@ -3955,7 +4847,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1759
                 },
@@ -3964,7 +4858,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1768
                 },
@@ -3973,7 +4869,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1777
                 },
@@ -3982,7 +4880,9 @@
                     "token": "p28",
                     "value": "p28",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1778
                 },
@@ -3991,7 +4891,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1781
                 },
@@ -4000,7 +4902,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1786
                 },
@@ -4009,7 +4913,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1792
                 },
@@ -4018,7 +4924,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1801
                 },
@@ -4027,7 +4935,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1803
                 },
@@ -4036,7 +4946,9 @@
                     "token": "28",
                     "value": 28,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1804
                 },
@@ -4045,7 +4957,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1806
                 },
@@ -4054,7 +4968,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1807
                 },
@@ -4063,7 +4979,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1808
                 },
@@ -4072,7 +4990,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1817
                 },
@@ -4081,7 +5001,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1826
                 },
@@ -4090,7 +5012,9 @@
                     "token": "p29",
                     "value": "p29",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1827
                 },
@@ -4099,7 +5023,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1830
                 },
@@ -4108,7 +5034,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1835
                 },
@@ -4117,7 +5045,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1841
                 },
@@ -4126,7 +5056,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1850
                 },
@@ -4135,7 +5067,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1852
                 },
@@ -4144,7 +5078,9 @@
                     "token": "29",
                     "value": 29,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1853
                 },
@@ -4153,7 +5089,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1855
                 },
@@ -4162,7 +5100,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1856
                 },
@@ -4171,7 +5111,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1857
                 },
@@ -4180,7 +5122,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1866
                 },
@@ -4189,7 +5133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1875
                 },
@@ -4198,7 +5144,9 @@
                     "token": "p30",
                     "value": "p30",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1876
                 },
@@ -4207,7 +5155,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1879
                 },
@@ -4216,7 +5166,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1884
                 },
@@ -4225,7 +5177,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1890
                 },
@@ -4234,7 +5188,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1899
                 },
@@ -4243,7 +5199,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1901
                 },
@@ -4252,7 +5210,9 @@
                     "token": "30",
                     "value": 30,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1902
                 },
@@ -4261,7 +5221,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1904
                 },
@@ -4270,7 +5232,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1905
                 },
@@ -4279,7 +5243,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1906
                 },
@@ -4288,7 +5254,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1915
                 },
@@ -4297,7 +5265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1924
                 },
@@ -4306,7 +5276,9 @@
                     "token": "p31",
                     "value": "p31",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@81"
+                    },
                     "flags": 0,
                     "position": 1925
                 },
@@ -4315,7 +5287,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1928
                 },
@@ -4324,7 +5298,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1933
                 },
@@ -4333,7 +5309,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1939
                 },
@@ -4342,7 +5320,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1948
                 },
@@ -4351,7 +5331,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1950
                 },
@@ -4360,7 +5342,9 @@
                     "token": "31",
                     "value": 31,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 1951
                 },
@@ -4369,7 +5353,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1953
                 },
@@ -4378,7 +5364,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1954
                 },
@@ -4387,7 +5375,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 1955
                 },
@@ -4396,7 +5386,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 1956
                 },
@@ -4405,13 +5399,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@497"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 489,
-            "idx": 489
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTableAsSelect.out
+++ b/tests/data/parser/parseCreateTableAsSelect.out
@@ -7,13 +7,19 @@
         "last": 47,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "new_tbl",
                     "value": "new_tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +109,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +131,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 31
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -121,7 +155,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -139,7 +177,9 @@
                     "token": "orig_tbl",
                     "value": "orig_tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -148,7 +188,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -157,13 +199,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTableEnforcedCheck.out
+++ b/tests/data/parser/parseCreateTableEnforcedCheck.out
@@ -7,13 +7,19 @@
         "last": 132,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 38,
+            "idx": 38,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "IF NOT EXISTS",
                     "value": "IF NOT EXISTS",
                     "keyword": "IF NOT EXISTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -67,7 +85,11 @@
                     "token": "employees_check",
                     "value": "employees_check",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -85,7 +109,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -94,7 +122,9 @@
                     "token": "FirstName",
                     "value": "FirstName",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -112,7 +144,9 @@
                     "token": "varchar",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 54
                 },
@@ -121,7 +155,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 61
                 },
@@ -130,7 +166,11 @@
                     "token": "30",
                     "value": 30,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -139,7 +179,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 64
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -157,7 +201,9 @@
                     "token": "CHECK",
                     "value": "CHECK",
                     "keyword": "CHECK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 66
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -175,7 +223,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 72
                 },
@@ -184,7 +234,9 @@
                     "token": "FirstName",
                     "value": "FirstName",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -202,7 +256,9 @@
                     "token": "REGEXP",
                     "value": "REGEXP",
                     "keyword": "REGEXP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 83
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -220,7 +278,11 @@
                     "token": "'^T'",
                     "value": "^T",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 90
                 },
@@ -229,7 +291,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -238,7 +302,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 95
                 },
@@ -247,7 +313,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -256,7 +324,9 @@
                     "token": "FirstName",
                     "value": "FirstName",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -265,7 +335,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -274,7 +346,9 @@
                     "token": "REGEXP",
                     "value": "REGEXP",
                     "keyword": "REGEXP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 109
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -292,7 +368,9 @@
                     "token": "'r$'",
                     "value": "r$",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 1,
                     "position": 116
                 },
@@ -301,7 +379,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 120
                 },
@@ -310,7 +390,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -319,7 +401,9 @@
                     "token": "ENFORCED",
                     "value": "ENFORCED",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -328,7 +412,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 130
                 },
@@ -337,7 +423,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -346,13 +436,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 38,
-            "idx": 38
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTableErr1.out
+++ b/tests/data/parser/parseCreateTableErr1.out
@@ -7,13 +7,19 @@
         "last": 68,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "IF NOT EXISTS",
                     "value": "IF NOT EXISTS",
                     "keyword": "IF NOT EXISTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -67,7 +85,11 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +109,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -94,7 +122,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -103,7 +133,11 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 39
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -121,7 +157,9 @@
                     "token": "UNKNOWN",
                     "value": "UNKNOWN",
                     "keyword": "UNKNOWN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 44
                 },
@@ -130,7 +168,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -139,7 +179,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 52
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -157,7 +201,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 54
                 },
@@ -166,7 +212,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 60
                 },
@@ -175,7 +223,9 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -184,7 +234,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -193,13 +247,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -291,7 +345,7 @@
             [
                 "Unrecognized data type.",
                 {
-                    "@type": "@14"
+                    "@type": "@19"
                 },
                 0
             ]

--- a/tests/data/parser/parseCreateTableErr2.out
+++ b/tests/data/parser/parseCreateTableErr2.out
@@ -7,13 +7,19 @@
         "last": 12,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 4,
+            "idx": 4,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,13 +52,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 4,
-            "idx": 4
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -99,14 +113,14 @@
             [
                 "The name of the entity was expected.",
                 {
-                    "@type": "@5"
+                    "@type": "@7"
                 },
                 0
             ],
             [
                 "At least one column definition was expected.",
                 {
-                    "@type": "@4"
+                    "@type": "@6"
                 },
                 0
             ]

--- a/tests/data/parser/parseCreateTableErr3.out
+++ b/tests/data/parser/parseCreateTableErr3.out
@@ -7,13 +7,19 @@
         "last": 32,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`table_copy`",
                     "value": "table_copy",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -67,7 +87,9 @@
                     "token": "LIKE",
                     "value": "LIKE",
                     "keyword": "LIKE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 26
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -85,7 +109,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -94,13 +122,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -159,7 +187,7 @@
             [
                 "A table name was expected.",
                 {
-                    "@type": "@10"
+                    "@type": "@13"
                 },
                 0
             ]

--- a/tests/data/parser/parseCreateTableErr4.out
+++ b/tests/data/parser/parseCreateTableErr4.out
@@ -7,13 +7,19 @@
         "last": 54,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 20,
+            "idx": 20,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "new_table",
                     "value": "new_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 23
                 },
@@ -76,7 +100,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -94,7 +122,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 28
                 },
@@ -103,7 +133,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -112,7 +144,11 @@
                     "token": "50",
                     "value": 50,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -121,7 +157,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +179,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 40
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -157,7 +201,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 48
                 },
@@ -166,7 +212,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 52
                 },
@@ -175,7 +223,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -184,13 +236,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 20,
-            "idx": 20
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -252,28 +304,28 @@
             [
                 "A symbol name was expected! A reserved keyword can not be used as a column name without backquotes.",
                 {
-                    "@type": "@9"
+                    "@type": "@13"
                 },
                 0
             ],
             [
                 "At least one column definition was expected.",
                 {
-                    "@type": "@9"
+                    "@type": "@13"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@13"
+                    "@type": "@17"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@16"
+                    "@type": "@21"
                 },
                 0
             ]

--- a/tests/data/parser/parseCreateTableErr5.out
+++ b/tests/data/parser/parseCreateTableErr5.out
@@ -7,13 +7,19 @@
         "last": 55,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "new_table",
                     "value": "new_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 23
                 },
@@ -76,7 +100,11 @@
                     "token": "666",
                     "value": 666,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +113,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -94,7 +124,9 @@
                     "token": "VARCHAR",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 28
                 },
@@ -103,7 +135,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -112,7 +146,9 @@
                     "token": "50",
                     "value": 50,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -121,7 +157,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +179,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 40
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -157,7 +201,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 48
                 },
@@ -166,7 +212,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 52
                 },
@@ -175,7 +223,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -184,7 +236,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -193,13 +247,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -261,28 +315,28 @@
             [
                 "A symbol name was expected!",
                 {
-                    "@type": "@9"
+                    "@type": "@13"
                 },
                 0
             ],
             [
                 "At least one column definition was expected.",
                 {
-                    "@type": "@9"
+                    "@type": "@13"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@13"
+                    "@type": "@18"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@16"
+                    "@type": "@21"
                 },
                 0
             ]

--- a/tests/data/parser/parseCreateTableLike.out
+++ b/tests/data/parser/parseCreateTableLike.out
@@ -7,13 +7,19 @@
         "last": 43,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`table_copy`",
                     "value": "table_copy",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -67,7 +87,9 @@
                     "token": "LIKE",
                     "value": "LIKE",
                     "keyword": "LIKE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 26
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -85,7 +109,9 @@
                     "token": "`old_table`",
                     "value": "old_table",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 31
                 },
@@ -94,7 +120,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -103,13 +133,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTableNotEnforcedCheck.out
+++ b/tests/data/parser/parseCreateTableNotEnforcedCheck.out
@@ -7,13 +7,19 @@
         "last": 136,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 40,
+            "idx": 40,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "IF NOT EXISTS",
                     "value": "IF NOT EXISTS",
                     "keyword": "IF NOT EXISTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -67,7 +85,11 @@
                     "token": "employees_check",
                     "value": "employees_check",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -85,7 +109,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -94,7 +122,9 @@
                     "token": "FirstName",
                     "value": "FirstName",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -112,7 +144,9 @@
                     "token": "varchar",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 54
                 },
@@ -121,7 +155,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 61
                 },
@@ -130,7 +166,11 @@
                     "token": "30",
                     "value": 30,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -139,7 +179,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 64
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -157,7 +201,9 @@
                     "token": "CHECK",
                     "value": "CHECK",
                     "keyword": "CHECK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 66
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -175,7 +223,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 72
                 },
@@ -184,7 +234,9 @@
                     "token": "FirstName",
                     "value": "FirstName",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -202,7 +256,9 @@
                     "token": "REGEXP",
                     "value": "REGEXP",
                     "keyword": "REGEXP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 83
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -220,7 +278,11 @@
                     "token": "'^T'",
                     "value": "^T",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 90
                 },
@@ -229,7 +291,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -238,7 +302,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 95
                 },
@@ -247,7 +313,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -256,7 +324,9 @@
                     "token": "FirstName",
                     "value": "FirstName",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -265,7 +335,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -274,7 +346,9 @@
                     "token": "REGEXP",
                     "value": "REGEXP",
                     "keyword": "REGEXP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 109
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -292,7 +368,9 @@
                     "token": "'r$'",
                     "value": "r$",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 1,
                     "position": 116
                 },
@@ -301,7 +379,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 120
                 },
@@ -310,7 +390,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -319,7 +401,9 @@
                     "token": "NOT",
                     "value": "NOT",
                     "keyword": "NOT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 122
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -337,7 +423,9 @@
                     "token": "ENFORCED",
                     "value": "ENFORCED",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -346,7 +434,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 134
                 },
@@ -355,7 +445,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -364,13 +458,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@47"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 40,
-            "idx": 40
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTableSelect.out
+++ b/tests/data/parser/parseCreateTableSelect.out
@@ -7,13 +7,19 @@
         "last": 44,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 15,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "new_tbl",
                     "value": "new_tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -85,7 +109,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 28
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -103,7 +133,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -121,7 +155,9 @@
                     "token": "orig_tbl",
                     "value": "orig_tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -130,7 +166,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -139,13 +177,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 15
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTableSpatial.out
+++ b/tests/data/parser/parseCreateTableSpatial.out
@@ -7,13 +7,19 @@
         "last": 64,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 25,
+            "idx": 25,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`xss`",
                     "value": "xss",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 18
                 },
@@ -67,7 +89,9 @@
                     "token": "`gis`",
                     "value": "gis",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 19
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "`x`",
                     "value": "x",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -121,7 +155,9 @@
                     "token": "POINT",
                     "value": "POINT",
                     "keyword": "POINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 31
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -139,7 +177,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 37
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -157,7 +199,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 46
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -175,7 +221,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 48
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -193,7 +243,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 55
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -211,7 +265,11 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -220,7 +278,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -229,13 +291,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 25,
-            "idx": 25
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTableTimestampWithPrecision.out
+++ b/tests/data/parser/parseCreateTableTimestampWithPrecision.out
@@ -7,13 +7,19 @@
         "last": 203,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 56,
+            "idx": 56,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`aa`",
                     "value": "aa",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 18
                 },
@@ -76,7 +100,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +111,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -121,7 +155,11 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -148,7 +190,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 35
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -166,7 +212,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -175,7 +223,9 @@
                     "token": "`rTime`",
                     "value": "rTime",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 47
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -193,7 +245,9 @@
                     "token": "timestamp",
                     "value": "timestamp",
                     "keyword": "TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 55
                 },
@@ -202,7 +256,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 64
                 },
@@ -211,7 +267,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -220,7 +278,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 66
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -238,7 +300,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 68
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -256,7 +322,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 77
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -274,7 +344,11 @@
                     "token": "'0000-00-00 00:00:00.000'",
                     "value": "0000-00-00 00:00:00.000",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 85
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -292,7 +368,9 @@
                     "token": "ON UPDATE",
                     "value": "ON UPDATE",
                     "keyword": "ON UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 111
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -310,7 +390,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 121
                 },
@@ -319,7 +401,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 138
                 },
@@ -328,7 +412,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -337,7 +423,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 140
                 },
@@ -346,7 +434,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 141
                 },
@@ -355,7 +445,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -364,7 +456,9 @@
                     "token": "PRIMARY KEY",
                     "value": "PRIMARY KEY",
                     "keyword": "PRIMARY KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 145
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 156
                 },
@@ -382,7 +478,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 157
                 },
@@ -391,7 +489,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 158
                 },
@@ -400,7 +500,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 162
                 },
@@ -409,7 +511,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 163
                 },
@@ -418,7 +522,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 164
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 165
                 },
@@ -436,7 +544,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 166
                 },
@@ -445,7 +555,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 172
                 },
@@ -454,7 +566,11 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 173
                 },
@@ -463,7 +579,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 179
                 },
@@ -472,7 +590,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 180
                 },
@@ -481,7 +601,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 195
                 },
@@ -490,7 +612,9 @@
                     "token": "latin1",
                     "value": "latin1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@58"
+                    },
                     "flags": 0,
                     "position": 196
                 },
@@ -499,7 +623,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 202
                 },
@@ -508,13 +636,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@64"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 56,
-            "idx": 56
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTableWithInvisibleKey.out
+++ b/tests/data/parser/parseCreateTableWithInvisibleKey.out
@@ -7,13 +7,19 @@
         "last": 730,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 153,
+            "idx": 153,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`animes_comments`",
                     "value": "animes_comments",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 31
                 },
@@ -76,7 +100,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +111,9 @@
                     "token": "`anime_comment_id`",
                     "value": "anime_comment_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 35
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -103,7 +133,9 @@
                     "token": "bigint",
                     "value": "BIGINT",
                     "keyword": "BIGINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 54
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -121,7 +155,9 @@
                     "token": "unsigned",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 61
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -139,7 +177,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 70
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -157,7 +199,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 79
                 },
@@ -166,7 +210,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 93
                 },
@@ -175,7 +221,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -184,7 +232,9 @@
                     "token": "`anime_id`",
                     "value": "anime_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 97
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -202,7 +254,9 @@
                     "token": "bigint",
                     "value": "BIGINT",
                     "keyword": "BIGINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 108
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -220,7 +276,9 @@
                     "token": "unsigned",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 115
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -238,7 +298,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 124
                 },
@@ -247,7 +309,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 132
                 },
@@ -256,7 +320,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -265,7 +331,9 @@
                     "token": "`user_id`",
                     "value": "user_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 136
                 },
@@ -274,7 +342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 145
                 },
@@ -283,7 +353,9 @@
                     "token": "bigint",
                     "value": "BIGINT",
                     "keyword": "BIGINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 146
                 },
@@ -292,7 +364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -301,7 +375,9 @@
                     "token": "unsigned",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 153
                 },
@@ -310,7 +386,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 161
                 },
@@ -319,7 +397,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 162
                 },
@@ -328,7 +408,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 170
                 },
@@ -337,7 +419,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 171
                 },
@@ -346,7 +430,9 @@
                     "token": "`comment_text`",
                     "value": "comment_text",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 174
                 },
@@ -355,7 +441,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 188
                 },
@@ -364,7 +452,9 @@
                     "token": "varchar",
                     "value": "VARCHAR",
                     "keyword": "VARCHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 189
                 },
@@ -373,7 +463,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 196
                 },
@@ -382,7 +474,11 @@
                     "token": "500",
                     "value": 500,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 197
                 },
@@ -391,7 +487,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 200
                 },
@@ -400,7 +498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 201
                 },
@@ -409,7 +509,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 202
                 },
@@ -418,7 +520,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 209
                 },
@@ -427,7 +531,11 @@
                     "token": "utf8mb4_general_ci",
                     "value": "utf8mb4_general_ci",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 210
                 },
@@ -436,7 +544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 228
                 },
@@ -445,7 +555,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 229
                 },
@@ -454,7 +566,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 236
                 },
@@ -463,7 +577,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 237
                 },
@@ -472,7 +588,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 241
                 },
@@ -481,7 +599,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 242
                 },
@@ -490,7 +610,9 @@
                     "token": "`comment_at`",
                     "value": "comment_at",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 245
                 },
@@ -499,7 +621,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 257
                 },
@@ -508,7 +632,9 @@
                     "token": "datetime",
                     "value": "datetime",
                     "keyword": "DATETIME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 9,
                     "position": 258
                 },
@@ -517,7 +643,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 266
                 },
@@ -526,7 +654,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 267
                 },
@@ -535,7 +665,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 274
                 },
@@ -544,7 +676,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 275
                 },
@@ -553,7 +687,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 279
                 },
@@ -562,7 +698,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 280
                 },
@@ -571,7 +709,9 @@
                     "token": "PRIMARY KEY",
                     "value": "PRIMARY KEY",
                     "keyword": "PRIMARY KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 283
                 },
@@ -580,7 +720,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 294
                 },
@@ -589,7 +731,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 295
                 },
@@ -598,7 +742,9 @@
                     "token": "`anime_comment_id`",
                     "value": "anime_comment_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 296
                 },
@@ -607,7 +753,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 314
                 },
@@ -616,7 +764,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 315
                 },
@@ -625,7 +775,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 316
                 },
@@ -634,7 +786,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 319
                 },
@@ -643,7 +797,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 322
                 },
@@ -652,7 +808,9 @@
                     "token": "`animes_comments_animes_fk`",
                     "value": "animes_comments_animes_fk",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 323
                 },
@@ -661,7 +819,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 350
                 },
@@ -670,7 +830,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 351
                 },
@@ -679,7 +841,9 @@
                     "token": "`anime_id`",
                     "value": "anime_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 352
                 },
@@ -688,7 +852,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 362
                 },
@@ -697,7 +863,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 363
                 },
@@ -706,7 +874,9 @@
                     "token": "invisible",
                     "value": "invisible",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@54"
+                    },
                     "flags": 0,
                     "position": 364
                 },
@@ -715,7 +885,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 373
                 },
@@ -724,7 +896,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 374
                 },
@@ -733,7 +907,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 377
                 },
@@ -742,7 +918,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 380
                 },
@@ -751,7 +929,9 @@
                     "token": "`animes_comments_users_fk`",
                     "value": "animes_comments_users_fk",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 381
                 },
@@ -760,7 +940,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 407
                 },
@@ -769,7 +951,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 408
                 },
@@ -778,7 +962,9 @@
                     "token": "`user_id`",
                     "value": "user_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 409
                 },
@@ -787,7 +973,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 418
                 },
@@ -796,7 +984,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 419
                 },
@@ -805,7 +995,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 420
                 },
@@ -814,7 +1006,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 423
                 },
@@ -823,7 +1017,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 426
                 },
@@ -832,7 +1028,9 @@
                     "token": "`comment_at_idx`",
                     "value": "comment_at_idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 427
                 },
@@ -841,7 +1039,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 443
                 },
@@ -850,7 +1050,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 444
                 },
@@ -859,7 +1061,9 @@
                     "token": "`comment_at`",
                     "value": "comment_at",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 445
                 },
@@ -868,7 +1072,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 457
                 },
@@ -877,7 +1083,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 458
                 },
@@ -886,7 +1094,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 459
                 },
@@ -895,7 +1105,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 460
                 },
@@ -904,7 +1116,9 @@
                     "token": "CONSTRAINT",
                     "value": "CONSTRAINT",
                     "keyword": "CONSTRAINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 463
                 },
@@ -913,7 +1127,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 473
                 },
@@ -922,7 +1138,9 @@
                     "token": "`animes_comments_animes_fk`",
                     "value": "animes_comments_animes_fk",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 474
                 },
@@ -931,7 +1149,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 501
                 },
@@ -940,7 +1160,9 @@
                     "token": "FOREIGN KEY",
                     "value": "FOREIGN KEY",
                     "keyword": "FOREIGN KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 502
                 },
@@ -949,7 +1171,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 513
                 },
@@ -958,7 +1182,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 514
                 },
@@ -967,7 +1193,9 @@
                     "token": "`anime_id`",
                     "value": "anime_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 515
                 },
@@ -976,7 +1204,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 525
                 },
@@ -985,7 +1215,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 526
                 },
@@ -994,7 +1226,9 @@
                     "token": "REFERENCES",
                     "value": "REFERENCES",
                     "keyword": "REFERENCES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 527
                 },
@@ -1003,7 +1237,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 537
                 },
@@ -1012,7 +1248,9 @@
                     "token": "`animes`",
                     "value": "animes",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 538
                 },
@@ -1021,7 +1259,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 546
                 },
@@ -1030,7 +1270,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 547
                 },
@@ -1039,7 +1281,9 @@
                     "token": "`anime_id`",
                     "value": "anime_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 548
                 },
@@ -1048,7 +1292,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 558
                 },
@@ -1057,7 +1303,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 559
                 },
@@ -1066,7 +1314,9 @@
                     "token": "ON DELETE",
                     "value": "ON DELETE",
                     "keyword": "ON DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 560
                 },
@@ -1075,7 +1325,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 569
                 },
@@ -1084,7 +1336,9 @@
                     "token": "CASCADE",
                     "value": "CASCADE",
                     "keyword": "CASCADE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 570
                 },
@@ -1093,7 +1347,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 577
                 },
@@ -1102,7 +1358,9 @@
                     "token": "ON UPDATE",
                     "value": "ON UPDATE",
                     "keyword": "ON UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 578
                 },
@@ -1111,7 +1369,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 587
                 },
@@ -1120,7 +1380,9 @@
                     "token": "RESTRICT",
                     "value": "RESTRICT",
                     "keyword": "RESTRICT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 588
                 },
@@ -1129,7 +1391,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 596
                 },
@@ -1138,7 +1402,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 597
                 },
@@ -1147,7 +1413,9 @@
                     "token": "CONSTRAINT",
                     "value": "CONSTRAINT",
                     "keyword": "CONSTRAINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 600
                 },
@@ -1156,7 +1424,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 610
                 },
@@ -1165,7 +1435,9 @@
                     "token": "`animes_comments_users_fk`",
                     "value": "animes_comments_users_fk",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 611
                 },
@@ -1174,7 +1446,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 637
                 },
@@ -1183,7 +1457,9 @@
                     "token": "FOREIGN KEY",
                     "value": "FOREIGN KEY",
                     "keyword": "FOREIGN KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 23,
                     "position": 638
                 },
@@ -1192,7 +1468,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 649
                 },
@@ -1201,7 +1479,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 650
                 },
@@ -1210,7 +1490,9 @@
                     "token": "`user_id`",
                     "value": "user_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 651
                 },
@@ -1219,7 +1501,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 660
                 },
@@ -1228,7 +1512,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 661
                 },
@@ -1237,7 +1523,9 @@
                     "token": "REFERENCES",
                     "value": "REFERENCES",
                     "keyword": "REFERENCES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 662
                 },
@@ -1246,7 +1534,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 672
                 },
@@ -1255,7 +1545,9 @@
                     "token": "`users`",
                     "value": "users",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 673
                 },
@@ -1264,7 +1556,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 680
                 },
@@ -1273,7 +1567,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 681
                 },
@@ -1282,7 +1578,9 @@
                     "token": "`user_id`",
                     "value": "user_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 682
                 },
@@ -1291,7 +1589,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 691
                 },
@@ -1300,7 +1600,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 692
                 },
@@ -1309,7 +1611,9 @@
                     "token": "ON DELETE",
                     "value": "ON DELETE",
                     "keyword": "ON DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 693
                 },
@@ -1318,7 +1622,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 702
                 },
@@ -1327,7 +1633,9 @@
                     "token": "CASCADE",
                     "value": "CASCADE",
                     "keyword": "CASCADE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 703
                 },
@@ -1336,7 +1644,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 710
                 },
@@ -1345,7 +1655,9 @@
                     "token": "ON UPDATE",
                     "value": "ON UPDATE",
                     "keyword": "ON UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 711
                 },
@@ -1354,7 +1666,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 720
                 },
@@ -1363,7 +1677,9 @@
                     "token": "RESTRICT",
                     "value": "RESTRICT",
                     "keyword": "RESTRICT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 721
                 },
@@ -1372,7 +1688,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 729
                 },
@@ -1381,13 +1699,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 153,
-            "idx": 153
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateTrigger.out
+++ b/tests/data/parser/parseCreateTrigger.out
@@ -7,13 +7,19 @@
         "last": 99,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 34,
+            "idx": 34,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TRIGGER",
                     "value": "TRIGGER",
                     "keyword": "TRIGGER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -49,7 +63,11 @@
                     "token": "ins_sum",
                     "value": "ins_sum",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +87,9 @@
                     "token": "BEFORE",
                     "value": "BEFORE",
                     "keyword": "BEFORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 23
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -85,7 +109,9 @@
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 30
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -103,7 +131,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 37
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -121,7 +153,9 @@
                     "token": "account",
                     "value": "account",
                     "keyword": "ACCOUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 40
                 },
@@ -130,7 +164,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -139,7 +175,9 @@
                     "token": "FOR EACH ROW",
                     "value": "FOR EACH ROW",
                     "keyword": "FOR EACH ROW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 48
                 },
@@ -148,7 +186,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -157,7 +197,9 @@
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 61
                 },
@@ -166,7 +208,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -175,7 +219,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 67
                 },
@@ -184,7 +230,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +241,11 @@
                     "token": "@sum",
                     "value": "sum",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 71
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -211,7 +265,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 76
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -229,7 +289,9 @@
                     "token": "@sum",
                     "value": "sum",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 1,
                     "position": 78
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -247,7 +311,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 83
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -265,7 +333,9 @@
                     "token": "NEW",
                     "value": "NEW",
                     "keyword": "NEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 85
                 },
@@ -274,7 +344,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 16,
                     "position": 88
                 },
@@ -283,7 +355,9 @@
                     "token": "amount",
                     "value": "amount",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -301,7 +377,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 96
                 },
@@ -310,13 +388,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 34,
-            "idx": 34
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -371,15 +451,6 @@
                 "parameters": null,
                 "body": [
                     {
-                        "@type": "@18"
-                    },
-                    {
-                        "@type": "@19"
-                    },
-                    {
-                        "@type": "@20"
-                    },
-                    {
                         "@type": "@21"
                     },
                     {
@@ -395,16 +466,10 @@
                         "@type": "@25"
                     },
                     {
-                        "@type": "@26"
-                    },
-                    {
                         "@type": "@27"
                     },
                     {
                         "@type": "@28"
-                    },
-                    {
-                        "@type": "@29"
                     },
                     {
                         "@type": "@30"
@@ -420,6 +485,21 @@
                     },
                     {
                         "@type": "@34"
+                    },
+                    {
+                        "@type": "@35"
+                    },
+                    {
+                        "@type": "@36"
+                    },
+                    {
+                        "@type": "@37"
+                    },
+                    {
+                        "@type": "@38"
+                    },
+                    {
+                        "@type": "@39"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseCreateUser1.out
+++ b/tests/data/parser/parseCreateUser1.out
@@ -7,13 +7,19 @@
         "last": 16,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 6,
+            "idx": 6,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,13 +76,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 6,
-            "idx": 6
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateUser2.out
+++ b/tests/data/parser/parseCreateUser2.out
@@ -7,13 +7,19 @@
         "last": 141,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 25,
+            "idx": 25,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "'bob'@'localhost'",
                     "value": "bob@localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " \n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -67,7 +87,9 @@
                     "token": "IDENTIFIED",
                     "value": "IDENTIFIED",
                     "keyword": "IDENTIFIED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 33
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -85,7 +109,11 @@
                     "token": "VIA",
                     "value": "VIA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -103,7 +133,9 @@
                     "token": "mysql_native_password",
                     "value": "mysql_native_password",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -121,7 +155,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 70
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -139,7 +177,9 @@
                     "token": "PASSWORD",
                     "value": "PASSWORD",
                     "keyword": "PASSWORD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 76
                 },
@@ -148,7 +188,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 84
                 },
@@ -157,7 +201,11 @@
                     "token": "'vp8LAf4#wu2V&Wi*iJWC#3KPotsHzx3u'",
                     "value": "vp8LAf4#wu2V&Wi*iJWC#3KPotsHzx3u",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 85
                 },
@@ -166,7 +214,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 16,
                     "position": 119
                 },
@@ -175,7 +225,9 @@
                     "token": " \n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -184,7 +236,9 @@
                     "token": "OR",
                     "value": "OR",
                     "keyword": "OR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 124
                 },
@@ -193,7 +247,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -202,7 +258,9 @@
                     "token": "unix_socket",
                     "value": "unix_socket",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -211,7 +269,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -220,7 +282,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -229,13 +293,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 25,
-            "idx": 25
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -275,15 +339,6 @@
                 "parameters": null,
                 "body": [
                     {
-                        "@type": "@8"
-                    },
-                    {
-                        "@type": "@9"
-                    },
-                    {
-                        "@type": "@10"
-                    },
-                    {
                         "@type": "@11"
                     },
                     {
@@ -291,9 +346,6 @@
                     },
                     {
                         "@type": "@13"
-                    },
-                    {
-                        "@type": "@14"
                     },
                     {
                         "@type": "@15"
@@ -317,10 +369,22 @@
                         "@type": "@21"
                     },
                     {
-                        "@type": "@22"
+                        "@type": "@23"
                     },
                     {
-                        "@type": "@23"
+                        "@type": "@25"
+                    },
+                    {
+                        "@type": "@26"
+                    },
+                    {
+                        "@type": "@27"
+                    },
+                    {
+                        "@type": "@28"
+                    },
+                    {
+                        "@type": "@29"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseCreateView.out
+++ b/tests/data/parser/parseCreateView.out
@@ -7,13 +7,19 @@
         "last": 960,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 286,
+            "idx": 286,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "ALGORITHM",
                     "value": "ALGORITHM",
                     "keyword": "ALGORITHM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 16
                 },
@@ -49,7 +65,9 @@
                     "token": "UNDEFINED",
                     "value": "UNDEFINED",
                     "keyword": "UNDEFINED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -67,7 +87,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 27
                 },
@@ -76,7 +98,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 2,
                     "position": 34
                 },
@@ -85,7 +109,11 @@
                     "token": "`root`@`localhost`",
                     "value": "root@localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 35
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -103,7 +133,9 @@
                     "token": "SQL SECURITY",
                     "value": "SQL SECURITY",
                     "keyword": "SQL SECURITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 54
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -121,7 +155,9 @@
                     "token": "INVOKER",
                     "value": "INVOKER",
                     "keyword": "INVOKER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 67
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -139,7 +177,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 75
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -157,7 +199,9 @@
                     "token": "`sakila`",
                     "value": "sakila",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 80
                 },
@@ -166,7 +210,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 88
                 },
@@ -175,7 +221,9 @@
                     "token": "`actor_info`",
                     "value": "actor_info",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 89
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -193,7 +243,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 102
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -211,7 +265,9 @@
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 105
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -229,7 +287,9 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 112
                 },
@@ -238,7 +298,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 115
                 },
@@ -247,7 +309,9 @@
                     "token": "`actor_id`",
                     "value": "actor_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 116
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -265,7 +331,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 127
                 },
@@ -274,7 +342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -283,7 +353,9 @@
                     "token": "`actor_id`",
                     "value": "actor_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 130
                 },
@@ -292,7 +364,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 140
                 },
@@ -301,7 +375,9 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 141
                 },
@@ -310,7 +386,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 144
                 },
@@ -319,7 +397,9 @@
                     "token": "`first_name`",
                     "value": "first_name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 145
                 },
@@ -328,7 +408,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -337,7 +419,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 158
                 },
@@ -346,7 +430,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -355,7 +441,9 @@
                     "token": "`first_name`",
                     "value": "first_name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 161
                 },
@@ -364,7 +452,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 173
                 },
@@ -373,7 +463,9 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 174
                 },
@@ -382,7 +474,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 177
                 },
@@ -391,7 +485,9 @@
                     "token": "`last_name`",
                     "value": "last_name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 178
                 },
@@ -400,7 +496,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 189
                 },
@@ -409,7 +507,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 190
                 },
@@ -418,7 +518,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 192
                 },
@@ -427,7 +529,9 @@
                     "token": "`last_name`",
                     "value": "last_name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 193
                 },
@@ -436,7 +540,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 204
                 },
@@ -445,7 +551,9 @@
                     "token": "group_concat",
                     "value": "group_concat",
                     "keyword": "GROUP_CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 205
                 },
@@ -454,7 +562,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 217
                 },
@@ -463,7 +573,9 @@
                     "token": "distinct",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 218
                 },
@@ -472,7 +584,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 226
                 },
@@ -481,7 +595,9 @@
                     "token": "concat",
                     "value": "concat",
                     "keyword": "CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 227
                 },
@@ -490,7 +606,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 233
                 },
@@ -499,7 +617,9 @@
                     "token": "`c`",
                     "value": "c",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 234
                 },
@@ -508,7 +628,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 237
                 },
@@ -517,7 +639,9 @@
                     "token": "`name`",
                     "value": "name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 238
                 },
@@ -526,7 +650,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 244
                 },
@@ -535,7 +661,11 @@
                     "token": "': '",
                     "value": ": ",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 245
                 },
@@ -544,7 +674,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 249
                 },
@@ -553,7 +685,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 250
                 },
@@ -562,7 +696,9 @@
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 251
                 },
@@ -571,7 +707,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 257
                 },
@@ -580,7 +718,9 @@
                     "token": "group_concat",
                     "value": "group_concat",
                     "keyword": "GROUP_CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 258
                 },
@@ -589,7 +729,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 270
                 },
@@ -598,7 +740,9 @@
                     "token": "`f`",
                     "value": "f",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 271
                 },
@@ -607,7 +751,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 274
                 },
@@ -616,7 +762,9 @@
                     "token": "`title`",
                     "value": "title",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 275
                 },
@@ -625,7 +773,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 282
                 },
@@ -634,7 +784,9 @@
                     "token": "order by",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 283
                 },
@@ -643,7 +795,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 291
                 },
@@ -652,7 +806,9 @@
                     "token": "`f`",
                     "value": "f",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 292
                 },
@@ -661,7 +817,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 295
                 },
@@ -670,7 +828,9 @@
                     "token": "`title`",
                     "value": "title",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 296
                 },
@@ -679,7 +839,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 303
                 },
@@ -688,7 +850,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 304
                 },
@@ -697,7 +861,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 307
                 },
@@ -706,7 +872,9 @@
                     "token": "separator",
                     "value": "SEPARATOR",
                     "keyword": "SEPARATOR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 308
                 },
@@ -715,7 +883,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 317
                 },
@@ -724,7 +894,9 @@
                     "token": "', '",
                     "value": ", ",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@65"
+                    },
                     "flags": 1,
                     "position": 318
                 },
@@ -733,7 +905,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 322
                 },
@@ -742,7 +916,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 323
                 },
@@ -751,7 +927,9 @@
                     "token": "from",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 324
                 },
@@ -760,7 +938,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 328
                 },
@@ -769,7 +949,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 329
                 },
@@ -778,7 +960,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 330
                 },
@@ -787,7 +971,9 @@
                     "token": "`sakila`",
                     "value": "sakila",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 331
                 },
@@ -796,7 +982,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 339
                 },
@@ -805,7 +993,9 @@
                     "token": "`film`",
                     "value": "film",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 340
                 },
@@ -814,7 +1004,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 346
                 },
@@ -823,7 +1015,9 @@
                     "token": "`f`",
                     "value": "f",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 347
                 },
@@ -832,7 +1026,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 350
                 },
@@ -841,7 +1037,9 @@
                     "token": "join",
                     "value": "JOIN",
                     "keyword": "JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 351
                 },
@@ -850,7 +1048,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 355
                 },
@@ -859,7 +1059,9 @@
                     "token": "`sakila`",
                     "value": "sakila",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 356
                 },
@@ -868,7 +1070,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 364
                 },
@@ -877,7 +1081,9 @@
                     "token": "`film_category`",
                     "value": "film_category",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 365
                 },
@@ -886,7 +1092,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 380
                 },
@@ -895,7 +1103,9 @@
                     "token": "`fc`",
                     "value": "fc",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 381
                 },
@@ -904,7 +1114,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 385
                 },
@@ -913,7 +1125,9 @@
                     "token": "on",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 386
                 },
@@ -922,7 +1136,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 388
                 },
@@ -931,7 +1147,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 389
                 },
@@ -940,7 +1158,9 @@
                     "token": "`f`",
                     "value": "f",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 390
                 },
@@ -949,7 +1169,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 393
                 },
@@ -958,7 +1180,9 @@
                     "token": "`film_id`",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 394
                 },
@@ -967,7 +1191,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 403
                 },
@@ -976,7 +1202,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 2,
                     "position": 404
                 },
@@ -985,7 +1213,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 405
                 },
@@ -994,7 +1224,9 @@
                     "token": "`fc`",
                     "value": "fc",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 406
                 },
@@ -1003,7 +1235,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 410
                 },
@@ -1012,7 +1246,9 @@
                     "token": "`film_id`",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 411
                 },
@@ -1021,7 +1257,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 420
                 },
@@ -1030,7 +1268,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 421
                 },
@@ -1039,7 +1279,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 422
                 },
@@ -1048,7 +1290,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 423
                 },
@@ -1057,7 +1301,9 @@
                     "token": "join",
                     "value": "JOIN",
                     "keyword": "JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 424
                 },
@@ -1066,7 +1312,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 428
                 },
@@ -1075,7 +1323,9 @@
                     "token": "`sakila`",
                     "value": "sakila",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 429
                 },
@@ -1084,7 +1334,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 437
                 },
@@ -1093,7 +1345,9 @@
                     "token": "`film_actor`",
                     "value": "film_actor",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 438
                 },
@@ -1102,7 +1356,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 450
                 },
@@ -1111,7 +1367,9 @@
                     "token": "`fa`",
                     "value": "fa",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 451
                 },
@@ -1120,7 +1378,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 455
                 },
@@ -1129,7 +1389,9 @@
                     "token": "on",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 456
                 },
@@ -1138,7 +1400,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 458
                 },
@@ -1147,7 +1411,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 459
                 },
@@ -1156,7 +1422,9 @@
                     "token": "`f`",
                     "value": "f",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 460
                 },
@@ -1165,7 +1433,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 463
                 },
@@ -1174,7 +1444,9 @@
                     "token": "`film_id`",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 464
                 },
@@ -1183,7 +1455,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 473
                 },
@@ -1192,7 +1466,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 2,
                     "position": 474
                 },
@@ -1201,7 +1477,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 475
                 },
@@ -1210,7 +1488,9 @@
                     "token": "`fa`",
                     "value": "fa",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 476
                 },
@@ -1219,7 +1499,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 480
                 },
@@ -1228,7 +1510,9 @@
                     "token": "`film_id`",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 481
                 },
@@ -1237,7 +1521,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 490
                 },
@@ -1246,7 +1532,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 491
                 },
@@ -1255,7 +1543,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 492
                 },
@@ -1264,7 +1554,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 493
                 },
@@ -1273,7 +1565,9 @@
                     "token": "where",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 494
                 },
@@ -1282,7 +1576,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 499
                 },
@@ -1291,7 +1587,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 500
                 },
@@ -1300,7 +1598,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 501
                 },
@@ -1309,7 +1609,9 @@
                     "token": "`fc`",
                     "value": "fc",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 502
                 },
@@ -1318,7 +1620,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 506
                 },
@@ -1327,7 +1631,9 @@
                     "token": "`category_id`",
                     "value": "category_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 507
                 },
@@ -1336,7 +1642,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 520
                 },
@@ -1345,7 +1653,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 2,
                     "position": 521
                 },
@@ -1354,7 +1664,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 522
                 },
@@ -1363,7 +1675,9 @@
                     "token": "`c`",
                     "value": "c",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 523
                 },
@@ -1372,7 +1686,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 526
                 },
@@ -1381,7 +1697,9 @@
                     "token": "`category_id`",
                     "value": "category_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 527
                 },
@@ -1390,7 +1708,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 540
                 },
@@ -1399,7 +1719,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 541
                 },
@@ -1408,7 +1730,9 @@
                     "token": "and",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 542
                 },
@@ -1417,7 +1741,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 545
                 },
@@ -1426,7 +1752,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 546
                 },
@@ -1435,7 +1763,9 @@
                     "token": "`fa`",
                     "value": "fa",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 547
                 },
@@ -1444,7 +1774,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 551
                 },
@@ -1453,7 +1785,9 @@
                     "token": "`actor_id`",
                     "value": "actor_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 552
                 },
@@ -1462,7 +1796,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 562
                 },
@@ -1471,7 +1807,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 2,
                     "position": 563
                 },
@@ -1480,7 +1818,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 564
                 },
@@ -1489,7 +1829,9 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 565
                 },
@@ -1498,7 +1840,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 568
                 },
@@ -1507,7 +1851,9 @@
                     "token": "`actor_id`",
                     "value": "actor_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 569
                 },
@@ -1516,7 +1862,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 579
                 },
@@ -1525,7 +1873,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 580
                 },
@@ -1534,7 +1884,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 581
                 },
@@ -1543,7 +1895,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 582
                 },
@@ -1552,7 +1906,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 583
                 },
@@ -1561,7 +1917,9 @@
                     "token": "order by",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 584
                 },
@@ -1570,7 +1928,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 592
                 },
@@ -1579,7 +1939,9 @@
                     "token": "`c`",
                     "value": "c",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 593
                 },
@@ -1588,7 +1950,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 596
                 },
@@ -1597,7 +1961,9 @@
                     "token": "`name`",
                     "value": "name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 597
                 },
@@ -1606,7 +1972,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 603
                 },
@@ -1615,7 +1983,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 604
                 },
@@ -1624,7 +1994,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 607
                 },
@@ -1633,7 +2005,9 @@
                     "token": "separator",
                     "value": "SEPARATOR",
                     "keyword": "SEPARATOR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 608
                 },
@@ -1642,7 +2016,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 617
                 },
@@ -1651,7 +2027,9 @@
                     "token": "'; '",
                     "value": "; ",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@65"
+                    },
                     "flags": 1,
                     "position": 618
                 },
@@ -1660,7 +2038,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 622
                 },
@@ -1669,7 +2049,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 623
                 },
@@ -1678,7 +2060,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 624
                 },
@@ -1687,7 +2071,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 626
                 },
@@ -1696,7 +2082,9 @@
                     "token": "`film_info`",
                     "value": "film_info",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 627
                 },
@@ -1705,7 +2093,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 638
                 },
@@ -1714,7 +2104,9 @@
                     "token": "from",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 639
                 },
@@ -1723,7 +2115,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 643
                 },
@@ -1732,7 +2126,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 644
                 },
@@ -1741,7 +2137,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 645
                 },
@@ -1750,7 +2148,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 646
                 },
@@ -1759,7 +2159,9 @@
                     "token": "`sakila`",
                     "value": "sakila",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 647
                 },
@@ -1768,7 +2170,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 655
                 },
@@ -1777,7 +2181,9 @@
                     "token": "`actor`",
                     "value": "actor",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 656
                 },
@@ -1786,7 +2192,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 663
                 },
@@ -1795,7 +2203,9 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 664
                 },
@@ -1804,7 +2214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 667
                 },
@@ -1813,7 +2225,9 @@
                     "token": "left join",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 668
                 },
@@ -1822,7 +2236,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 677
                 },
@@ -1831,7 +2247,9 @@
                     "token": "`sakila`",
                     "value": "sakila",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 678
                 },
@@ -1840,7 +2258,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 686
                 },
@@ -1849,7 +2269,9 @@
                     "token": "`film_actor`",
                     "value": "film_actor",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 687
                 },
@@ -1858,7 +2280,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 699
                 },
@@ -1867,7 +2291,9 @@
                     "token": "`fa`",
                     "value": "fa",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 700
                 },
@@ -1876,7 +2302,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 704
                 },
@@ -1885,7 +2313,9 @@
                     "token": "on",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 705
                 },
@@ -1894,7 +2324,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 707
                 },
@@ -1903,7 +2335,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 708
                 },
@@ -1912,7 +2346,9 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 709
                 },
@@ -1921,7 +2357,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 712
                 },
@@ -1930,7 +2368,9 @@
                     "token": "`actor_id`",
                     "value": "actor_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 713
                 },
@@ -1939,7 +2379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 723
                 },
@@ -1948,7 +2390,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 2,
                     "position": 724
                 },
@@ -1957,7 +2401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 725
                 },
@@ -1966,7 +2412,9 @@
                     "token": "`fa`",
                     "value": "fa",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 726
                 },
@@ -1975,7 +2423,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 730
                 },
@@ -1984,7 +2434,9 @@
                     "token": "`actor_id`",
                     "value": "actor_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 731
                 },
@@ -1993,7 +2445,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 741
                 },
@@ -2002,7 +2456,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 742
                 },
@@ -2011,7 +2467,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 743
                 },
@@ -2020,7 +2478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 744
                 },
@@ -2029,7 +2489,9 @@
                     "token": "left join",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 745
                 },
@@ -2038,7 +2500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 754
                 },
@@ -2047,7 +2511,9 @@
                     "token": "`sakila`",
                     "value": "sakila",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 755
                 },
@@ -2056,7 +2522,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 763
                 },
@@ -2065,7 +2533,9 @@
                     "token": "`film_category`",
                     "value": "film_category",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 764
                 },
@@ -2074,7 +2544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 779
                 },
@@ -2083,7 +2555,9 @@
                     "token": "`fc`",
                     "value": "fc",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 780
                 },
@@ -2092,7 +2566,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 784
                 },
@@ -2101,7 +2577,9 @@
                     "token": "on",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 785
                 },
@@ -2110,7 +2588,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 787
                 },
@@ -2119,7 +2599,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 788
                 },
@@ -2128,7 +2610,9 @@
                     "token": "`fa`",
                     "value": "fa",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 789
                 },
@@ -2137,7 +2621,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 793
                 },
@@ -2146,7 +2632,9 @@
                     "token": "`film_id`",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 794
                 },
@@ -2155,7 +2643,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 803
                 },
@@ -2164,7 +2654,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 2,
                     "position": 804
                 },
@@ -2173,7 +2665,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 805
                 },
@@ -2182,7 +2676,9 @@
                     "token": "`fc`",
                     "value": "fc",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 806
                 },
@@ -2191,7 +2687,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 810
                 },
@@ -2200,7 +2698,9 @@
                     "token": "`film_id`",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 811
                 },
@@ -2209,7 +2709,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 820
                 },
@@ -2218,7 +2720,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 821
                 },
@@ -2227,7 +2731,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 822
                 },
@@ -2236,7 +2742,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 823
                 },
@@ -2245,7 +2753,9 @@
                     "token": "left join",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 824
                 },
@@ -2254,7 +2764,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 833
                 },
@@ -2263,7 +2775,9 @@
                     "token": "`sakila`",
                     "value": "sakila",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 834
                 },
@@ -2272,7 +2786,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 842
                 },
@@ -2281,7 +2797,9 @@
                     "token": "`category`",
                     "value": "category",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 843
                 },
@@ -2290,7 +2808,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 853
                 },
@@ -2299,7 +2819,9 @@
                     "token": "`c`",
                     "value": "c",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 854
                 },
@@ -2308,7 +2830,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 857
                 },
@@ -2317,7 +2841,9 @@
                     "token": "on",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 858
                 },
@@ -2326,7 +2852,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 860
                 },
@@ -2335,7 +2863,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 861
                 },
@@ -2344,7 +2874,9 @@
                     "token": "`fc`",
                     "value": "fc",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 862
                 },
@@ -2353,7 +2885,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 866
                 },
@@ -2362,7 +2896,9 @@
                     "token": "`category_id`",
                     "value": "category_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 867
                 },
@@ -2371,7 +2907,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 880
                 },
@@ -2380,7 +2918,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 2,
                     "position": 881
                 },
@@ -2389,7 +2929,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 882
                 },
@@ -2398,7 +2940,9 @@
                     "token": "`c`",
                     "value": "c",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 883
                 },
@@ -2407,7 +2951,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 886
                 },
@@ -2416,7 +2962,9 @@
                     "token": "`category_id`",
                     "value": "category_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 887
                 },
@@ -2425,7 +2973,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 900
                 },
@@ -2434,7 +2984,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 901
                 },
@@ -2443,7 +2995,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 902
                 },
@@ -2452,7 +3006,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 903
                 },
@@ -2461,7 +3017,9 @@
                     "token": "group by",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 904
                 },
@@ -2470,7 +3028,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 912
                 },
@@ -2479,7 +3039,9 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 913
                 },
@@ -2488,7 +3050,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 916
                 },
@@ -2497,7 +3061,9 @@
                     "token": "`actor_id`",
                     "value": "actor_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 917
                 },
@@ -2506,7 +3072,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 927
                 },
@@ -2515,7 +3083,9 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 928
                 },
@@ -2524,7 +3094,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 931
                 },
@@ -2533,7 +3105,9 @@
                     "token": "`first_name`",
                     "value": "first_name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 932
                 },
@@ -2542,7 +3116,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 944
                 },
@@ -2551,7 +3127,9 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 945
                 },
@@ -2560,7 +3138,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 948
                 },
@@ -2569,7 +3149,9 @@
                     "token": "`last_name`",
                     "value": "last_name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 949
                 },
@@ -2578,13 +3160,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 286,
-            "idx": 286
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateView2.out
+++ b/tests/data/parser/parseCreateView2.out
@@ -7,13 +7,19 @@
         "last": 89,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 35,
+            "idx": 35,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "myView",
                     "value": "myView",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -76,7 +100,9 @@
                     "token": "vid",
                     "value": "vid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +111,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 23
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -103,7 +133,9 @@
                     "token": "vfirstname",
                     "value": "vfirstname",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -112,7 +144,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -130,7 +166,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 37
                 },
@@ -139,7 +177,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -148,7 +188,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -166,7 +210,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -175,7 +221,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 49
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -193,7 +243,9 @@
                     "token": "first_name",
                     "value": "first_name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -211,7 +265,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 62
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -229,7 +287,9 @@
                     "token": "employee",
                     "value": "employee",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -247,7 +309,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 76
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -265,7 +331,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -274,7 +342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -283,7 +353,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 85
                 },
@@ -292,7 +364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -301,7 +375,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -310,7 +388,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -319,13 +401,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@41"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 35,
-            "idx": 35
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -375,18 +457,6 @@
                 "parameters": null,
                 "body": [
                     {
-                        "@type": "@16"
-                    },
-                    {
-                        "@type": "@17"
-                    },
-                    {
-                        "@type": "@18"
-                    },
-                    {
-                        "@type": "@19"
-                    },
-                    {
                         "@type": "@20"
                     },
                     {
@@ -430,6 +500,18 @@
                     },
                     {
                         "@type": "@34"
+                    },
+                    {
+                        "@type": "@35"
+                    },
+                    {
+                        "@type": "@36"
+                    },
+                    {
+                        "@type": "@37"
+                    },
+                    {
+                        "@type": "@38"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseCreateView3.out
+++ b/tests/data/parser/parseCreateView3.out
@@ -7,13 +7,19 @@
         "last": 148,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 34,
+            "idx": 34,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "GoodStudent",
                     "value": "GoodStudent",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -76,7 +98,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,7 +109,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 31
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -103,7 +131,11 @@
                     "token": "`one space`",
                     "value": "one space",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 38
                 },
@@ -112,7 +144,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 49
                 },
@@ -121,7 +157,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -130,7 +168,9 @@
                     "token": "`two spaces`",
                     "value": "two spaces",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 51
                 },
@@ -139,7 +179,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -148,7 +190,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 70
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -166,7 +212,9 @@
                     "token": "`Une table espace`",
                     "value": "Une table espace",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 75
                 },
@@ -175,7 +223,9 @@
                     "token": "\n        ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -184,7 +234,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 102
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -202,7 +256,9 @@
                     "token": "`one space`",
                     "value": "one space",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 108
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -220,7 +278,9 @@
                     "token": ">",
                     "value": ">",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 2,
                     "position": 120
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -238,7 +300,11 @@
                     "token": "3.0",
                     "value": 3.0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 2,
                     "position": 122
                 },
@@ -247,7 +313,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -256,7 +324,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 130
                 },
@@ -265,7 +335,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 134
                 },
@@ -274,7 +346,9 @@
                     "token": "CHECK",
                     "value": "CHECK",
                     "keyword": "CHECK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 135
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -292,7 +368,9 @@
                     "token": "OPTION",
                     "value": "OPTION",
                     "keyword": "OPTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 141
                 },
@@ -301,7 +379,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -310,13 +390,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 34,
-            "idx": 34
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -420,22 +502,22 @@
                 "parameters": null,
                 "body": [
                     {
-                        "@type": "@29"
+                        "@type": "@35"
                     },
                     {
-                        "@type": "@30"
+                        "@type": "@36"
                     },
                     {
-                        "@type": "@31"
+                        "@type": "@37"
                     },
                     {
-                        "@type": "@32"
+                        "@type": "@38"
                     },
                     {
-                        "@type": "@33"
+                        "@type": "@39"
                     },
                     {
-                        "@type": "@34"
+                        "@type": "@40"
                     }
                 ],
                 "options": {
@@ -458,7 +540,7 @@
             [
                 "A new statement was found, but no delimiter between it and the previous one.",
                 {
-                    "@type": "@29"
+                    "@type": "@35"
                 },
                 0
             ]

--- a/tests/data/parser/parseCreateView4.out
+++ b/tests/data/parser/parseCreateView4.out
@@ -7,13 +7,19 @@
         "last": 39,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 18,
+            "idx": 18,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "v",
                     "value": "v",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": "mycol",
                     "value": "mycol",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -85,7 +111,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 20
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -103,7 +133,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -121,7 +155,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 25
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -139,7 +177,11 @@
                     "token": "'abc'",
                     "value": "abc",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 32
                 },
@@ -148,7 +190,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -157,7 +203,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -166,13 +214,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 18,
-            "idx": 18
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -220,16 +268,16 @@
                 "parameters": null,
                 "body": [
                     {
-                        "@type": "@13"
+                        "@type": "@17"
                     },
                     {
-                        "@type": "@14"
+                        "@type": "@18"
                     },
                     {
-                        "@type": "@15"
+                        "@type": "@19"
                     },
                     {
-                        "@type": "@16"
+                        "@type": "@20"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseCreateView5.out
+++ b/tests/data/parser/parseCreateView5.out
@@ -7,13 +7,19 @@
         "last": 75,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 26,
+            "idx": 26,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`t3`",
                     "value": "t3",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +109,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +131,9 @@
                     "token": "`t1`",
                     "value": "t1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +153,9 @@
                     "token": "IS",
                     "value": "IS",
                     "keyword": "IS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 32
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -139,7 +175,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 35
                 },
@@ -148,7 +186,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -157,7 +197,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -166,7 +208,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -175,7 +219,9 @@
                     "token": "`is_not_null`",
                     "value": "is_not_null",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 47
                 },
@@ -184,7 +230,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -193,7 +241,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 61
                 },
@@ -202,7 +252,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -211,7 +263,9 @@
                     "token": "`test3`",
                     "value": "test3",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 66
                 },
@@ -220,7 +274,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -229,7 +287,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -238,13 +298,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 26,
-            "idx": 26
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateViewAsWithAs.out
+++ b/tests/data/parser/parseCreateViewAsWithAs.out
@@ -7,13 +7,19 @@
         "last": 388,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 150,
+            "idx": 150,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- create first view",
                     "value": "-- create first view",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -31,7 +41,11 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -49,7 +65,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 28
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +87,11 @@
                     "token": "withclause",
                     "value": "withclause",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -85,7 +111,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -94,7 +122,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -103,7 +133,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 48
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -121,7 +155,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -139,7 +177,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 57
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -157,7 +199,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 60
                 },
@@ -166,7 +212,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -175,7 +223,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 64
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -238,7 +300,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -247,7 +311,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -256,7 +322,9 @@
                     "token": "shape",
                     "value": "shape",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -265,7 +333,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 89
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -292,7 +366,9 @@
                     "token": "gis_all",
                     "value": "gis_all",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -310,7 +388,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 102
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -328,7 +410,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -337,7 +421,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -346,7 +432,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 107
                 },
@@ -355,7 +443,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -364,7 +454,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 110
                 },
@@ -373,7 +465,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -382,7 +476,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -391,7 +487,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 120
                 },
@@ -400,7 +498,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 121
                 },
@@ -409,7 +509,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -418,7 +520,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 123
                 },
@@ -427,7 +531,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -436,7 +542,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 128
                 },
@@ -445,7 +553,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -454,7 +564,9 @@
                     "token": "CROSS JOIN",
                     "value": "CROSS JOIN",
                     "keyword": "CROSS JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 7,
                     "position": 132
                 },
@@ -463,7 +575,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -472,7 +586,9 @@
                     "token": "gis_all",
                     "value": "gis_all",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -481,7 +597,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 150
                 },
@@ -490,7 +610,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 151
                 },
@@ -499,7 +621,9 @@
                     "token": "-- create second view",
                     "value": "-- create second view",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 4,
                     "position": 152
                 },
@@ -508,7 +632,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 173
                 },
@@ -517,7 +643,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 174
                 },
@@ -526,7 +654,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 180
                 },
@@ -535,7 +665,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 181
                 },
@@ -544,7 +676,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 185
                 },
@@ -553,7 +687,9 @@
                     "token": "withclause2",
                     "value": "withclause2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 186
                 },
@@ -562,7 +698,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 197
                 },
@@ -571,7 +709,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 198
                 },
@@ -580,7 +720,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 200
                 },
@@ -589,7 +731,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 202
                 },
@@ -598,7 +742,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 206
                 },
@@ -607,7 +753,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 207
                 },
@@ -616,7 +764,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 210
                 },
@@ -625,7 +775,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 211
                 },
@@ -634,7 +786,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 213
                 },
@@ -643,7 +797,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 214
                 },
@@ -652,7 +808,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 215
                 },
@@ -661,7 +819,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 218
                 },
@@ -670,7 +830,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 224
                 },
@@ -679,7 +841,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 225
                 },
@@ -688,7 +852,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 226
                 },
@@ -697,7 +863,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 227
                 },
@@ -706,7 +874,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 231
                 },
@@ -715,7 +885,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 232
                 },
@@ -724,7 +896,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 233
                 },
@@ -733,7 +907,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 234
                 },
@@ -742,7 +918,9 @@
                     "token": "shape",
                     "value": "shape",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 235
                 },
@@ -751,7 +929,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 240
                 },
@@ -760,7 +940,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 243
                 },
@@ -769,7 +951,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 247
                 },
@@ -778,7 +962,9 @@
                     "token": "gis_all",
                     "value": "gis_all",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 248
                 },
@@ -787,7 +973,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 255
                 },
@@ -796,7 +984,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 256
                 },
@@ -805,7 +995,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 258
                 },
@@ -814,7 +1006,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 259
                 },
@@ -823,7 +1017,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 260
                 },
@@ -832,7 +1028,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 261
                 },
@@ -841,7 +1039,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 262
                 },
@@ -850,7 +1050,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 263
                 },
@@ -859,7 +1061,9 @@
                     "token": "cte2",
                     "value": "cte2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 264
                 },
@@ -868,7 +1072,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 268
                 },
@@ -877,7 +1083,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 269
                 },
@@ -886,7 +1094,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 271
                 },
@@ -895,7 +1105,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 272
                 },
@@ -904,7 +1116,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 273
                 },
@@ -913,7 +1127,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 276
                 },
@@ -922,7 +1138,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 282
                 },
@@ -931,7 +1149,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 283
                 },
@@ -940,7 +1160,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 284
                 },
@@ -949,7 +1171,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 285
                 },
@@ -958,7 +1182,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 289
                 },
@@ -967,7 +1193,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 290
                 },
@@ -976,7 +1204,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 292
                 },
@@ -985,7 +1215,9 @@
                     "token": "n2",
                     "value": "n2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 293
                 },
@@ -994,7 +1226,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 295
                 },
@@ -1003,7 +1237,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 296
                 },
@@ -1012,7 +1248,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 297
                 },
@@ -1021,7 +1259,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 298
                 },
@@ -1030,7 +1270,9 @@
                     "token": "shape",
                     "value": "shape",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 299
                 },
@@ -1039,7 +1281,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 304
                 },
@@ -1048,7 +1292,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 305
                 },
@@ -1057,7 +1303,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 307
                 },
@@ -1066,7 +1314,9 @@
                     "token": "sh2",
                     "value": "sh2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 308
                 },
@@ -1075,7 +1325,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 311
                 },
@@ -1084,7 +1336,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 314
                 },
@@ -1093,7 +1347,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 318
                 },
@@ -1102,7 +1358,9 @@
                     "token": "gis_all",
                     "value": "gis_all",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 319
                 },
@@ -1111,7 +1369,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 326
                 },
@@ -1120,7 +1380,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 327
                 },
@@ -1129,7 +1391,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 329
                 },
@@ -1138,7 +1402,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 330
                 },
@@ -1147,7 +1413,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 331
                 },
@@ -1156,7 +1424,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 332
                 },
@@ -1165,7 +1435,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 333
                 },
@@ -1174,7 +1446,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 335
                 },
@@ -1183,7 +1457,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 341
                 },
@@ -1192,7 +1468,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 342
                 },
@@ -1201,7 +1479,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 345
                 },
@@ -1210,7 +1490,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 346
                 },
@@ -1219,7 +1501,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 347
                 },
@@ -1228,7 +1512,9 @@
                     "token": "cte2",
                     "value": "cte2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 348
                 },
@@ -1237,7 +1523,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 352
                 },
@@ -1246,7 +1534,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 353
                 },
@@ -1255,7 +1545,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 354
                 },
@@ -1264,7 +1556,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 355
                 },
@@ -1273,7 +1567,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 359
                 },
@@ -1282,7 +1578,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 360
                 },
@@ -1291,7 +1589,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 363
                 },
@@ -1300,7 +1600,9 @@
                     "token": "cte2",
                     "value": "cte2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 364
                 },
@@ -1309,7 +1611,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 368
                 },
@@ -1318,7 +1622,9 @@
                     "token": "CROSS JOIN",
                     "value": "CROSS JOIN",
                     "keyword": "CROSS JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 7,
                     "position": 369
                 },
@@ -1327,7 +1633,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 379
                 },
@@ -1336,7 +1644,9 @@
                     "token": "gis_all",
                     "value": "gis_all",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 380
                 },
@@ -1345,7 +1655,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@60"
+                    },
                     "flags": 0,
                     "position": 387
                 },
@@ -1354,13 +1666,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@60"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 150,
-            "idx": 150
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -1398,22 +1710,9 @@
                                 "@type": "PhpMyAdmin\\SqlParser\\Parser",
                                 "list": {
                                     "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                    "count": 20,
+                                    "idx": 20,
                                     "tokens": [
-                                        {
-                                            "@type": "@19"
-                                        },
-                                        {
-                                            "@type": "@20"
-                                        },
-                                        {
-                                            "@type": "@21"
-                                        },
-                                        {
-                                            "@type": "@22"
-                                        },
-                                        {
-                                            "@type": "@23"
-                                        },
                                         {
                                             "@type": "@24"
                                         },
@@ -1458,10 +1757,23 @@
                                         },
                                         {
                                             "@type": "@38"
+                                        },
+                                        {
+                                            "@type": "@39"
+                                        },
+                                        {
+                                            "@type": "@40"
+                                        },
+                                        {
+                                            "@type": "@41"
+                                        },
+                                        {
+                                            "@type": "@42"
+                                        },
+                                        {
+                                            "@type": "@43"
                                         }
-                                    ],
-                                    "count": 20,
-                                    "idx": 20
+                                    ]
                                 },
                                 "statements": [
                                     {
@@ -1531,22 +1843,9 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Parser",
                         "list": {
                             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                            "count": 111,
+                            "idx": 111,
                             "tokens": [
-                                {
-                                    "@type": "@41"
-                                },
-                                {
-                                    "@type": "@42"
-                                },
-                                {
-                                    "@type": "@43"
-                                },
-                                {
-                                    "@type": "@44"
-                                },
-                                {
-                                    "@type": "@45"
-                                },
                                 {
                                     "@type": "@46"
                                 },
@@ -1588,9 +1887,6 @@
                                 },
                                 {
                                     "@type": "@59"
-                                },
-                                {
-                                    "@type": "@60"
                                 },
                                 {
                                     "@type": "@61"
@@ -1864,10 +2160,26 @@
                                 },
                                 {
                                     "@type": "@151"
+                                },
+                                {
+                                    "@type": "@152"
+                                },
+                                {
+                                    "@type": "@153"
+                                },
+                                {
+                                    "@type": "@154"
+                                },
+                                {
+                                    "@type": "@155"
+                                },
+                                {
+                                    "@type": "@156"
+                                },
+                                {
+                                    "@type": "@157"
                                 }
-                            ],
-                            "count": 111,
-                            "idx": 111
+                            ]
                         },
                         "statements": [
                             {
@@ -1958,25 +2270,9 @@
                                                 "@type": "PhpMyAdmin\\SqlParser\\Parser",
                                                 "list": {
                                                     "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                                    "count": 20,
+                                                    "idx": 20,
                                                     "tokens": [
-                                                        {
-                                                            "@type": "@73"
-                                                        },
-                                                        {
-                                                            "@type": "@74"
-                                                        },
-                                                        {
-                                                            "@type": "@75"
-                                                        },
-                                                        {
-                                                            "@type": "@76"
-                                                        },
-                                                        {
-                                                            "@type": "@77"
-                                                        },
-                                                        {
-                                                            "@type": "@78"
-                                                        },
                                                         {
                                                             "@type": "@79"
                                                         },
@@ -2018,10 +2314,26 @@
                                                         },
                                                         {
                                                             "@type": "@92"
+                                                        },
+                                                        {
+                                                            "@type": "@93"
+                                                        },
+                                                        {
+                                                            "@type": "@94"
+                                                        },
+                                                        {
+                                                            "@type": "@95"
+                                                        },
+                                                        {
+                                                            "@type": "@96"
+                                                        },
+                                                        {
+                                                            "@type": "@97"
+                                                        },
+                                                        {
+                                                            "@type": "@98"
                                                         }
-                                                    ],
-                                                    "count": 20,
-                                                    "idx": 20
+                                                    ]
                                                 },
                                                 "statements": [
                                                     {
@@ -2094,25 +2406,9 @@
                                                 "@type": "PhpMyAdmin\\SqlParser\\Parser",
                                                 "list": {
                                                     "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                                    "count": 28,
+                                                    "idx": 28,
                                                     "tokens": [
-                                                        {
-                                                            "@type": "@101"
-                                                        },
-                                                        {
-                                                            "@type": "@102"
-                                                        },
-                                                        {
-                                                            "@type": "@103"
-                                                        },
-                                                        {
-                                                            "@type": "@104"
-                                                        },
-                                                        {
-                                                            "@type": "@105"
-                                                        },
-                                                        {
-                                                            "@type": "@106"
-                                                        },
                                                         {
                                                             "@type": "@107"
                                                         },
@@ -2178,10 +2474,26 @@
                                                         },
                                                         {
                                                             "@type": "@128"
+                                                        },
+                                                        {
+                                                            "@type": "@129"
+                                                        },
+                                                        {
+                                                            "@type": "@130"
+                                                        },
+                                                        {
+                                                            "@type": "@131"
+                                                        },
+                                                        {
+                                                            "@type": "@132"
+                                                        },
+                                                        {
+                                                            "@type": "@133"
+                                                        },
+                                                        {
+                                                            "@type": "@134"
                                                         }
-                                                    ],
-                                                    "count": 28,
-                                                    "idx": 28
+                                                    ]
                                                 },
                                                 "statements": [
                                                     {
@@ -2251,25 +2563,9 @@
                                         "@type": "PhpMyAdmin\\SqlParser\\Parser",
                                         "list": {
                                             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                            "count": 21,
+                                            "idx": 21,
                                             "tokens": [
-                                                {
-                                                    "@type": "@131"
-                                                },
-                                                {
-                                                    "@type": "@132"
-                                                },
-                                                {
-                                                    "@type": "@133"
-                                                },
-                                                {
-                                                    "@type": "@134"
-                                                },
-                                                {
-                                                    "@type": "@135"
-                                                },
-                                                {
-                                                    "@type": "@136"
-                                                },
                                                 {
                                                     "@type": "@137"
                                                 },
@@ -2314,10 +2610,26 @@
                                                 },
                                                 {
                                                     "@type": "@151"
+                                                },
+                                                {
+                                                    "@type": "@152"
+                                                },
+                                                {
+                                                    "@type": "@153"
+                                                },
+                                                {
+                                                    "@type": "@154"
+                                                },
+                                                {
+                                                    "@type": "@155"
+                                                },
+                                                {
+                                                    "@type": "@156"
+                                                },
+                                                {
+                                                    "@type": "@157"
                                                 }
-                                            ],
-                                            "count": 21,
-                                            "idx": 21
+                                            ]
                                         },
                                         "statements": [
                                             {

--- a/tests/data/parser/parseCreateViewMultiple.out
+++ b/tests/data/parser/parseCreateViewMultiple.out
@@ -7,13 +7,19 @@
         "last": 464,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 152,
+            "idx": 152,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "T1",
                     "value": "T1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 16
                 },
@@ -76,7 +100,9 @@
                     "token": "COL1",
                     "value": "COL1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -94,7 +122,9 @@
                     "token": "CHAR",
                     "value": "CHAR",
                     "keyword": "CHAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 22
                 },
@@ -103,7 +133,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 26
                 },
@@ -112,7 +144,11 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -121,7 +157,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 29
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -139,7 +179,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -148,7 +190,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -166,7 +212,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 40
                 },
@@ -175,7 +223,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -184,7 +234,9 @@
                     "token": "V1",
                     "value": "V1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -202,7 +256,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 49
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -220,7 +278,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 52
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -238,7 +300,9 @@
                     "token": "COL1",
                     "value": "COL1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -247,7 +311,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -256,7 +322,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 68
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -274,7 +344,9 @@
                     "token": "T1",
                     "value": "T1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -292,7 +366,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 76
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -310,7 +388,9 @@
                     "token": "COL1",
                     "value": "COL1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -328,7 +410,9 @@
                     "token": "LIKE",
                     "value": "LIKE",
                     "keyword": "LIKE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 87
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -346,7 +432,11 @@
                     "token": "'A%'",
                     "value": "A%",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 92
                 },
@@ -355,7 +445,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -364,7 +456,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 98
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -382,7 +478,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 105
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -400,7 +500,9 @@
                     "token": "V2",
                     "value": "V2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -418,7 +522,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 113
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -436,7 +544,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 116
                 },
@@ -445,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -454,7 +566,9 @@
                     "token": "COL1",
                     "value": "COL1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -463,7 +577,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -472,7 +588,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 132
                 },
@@ -481,7 +599,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 136
                 },
@@ -490,7 +610,9 @@
                     "token": "V1",
                     "value": "V1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 137
                 },
@@ -499,7 +621,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -508,7 +632,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 140
                 },
@@ -517,7 +643,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 145
                 },
@@ -526,7 +654,9 @@
                     "token": "COL1",
                     "value": "COL1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 146
                 },
@@ -535,7 +665,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 150
                 },
@@ -544,7 +676,9 @@
                     "token": "LIKE",
                     "value": "LIKE",
                     "keyword": "LIKE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 151
                 },
@@ -553,7 +687,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 155
                 },
@@ -562,7 +698,9 @@
                     "token": "'%Z'",
                     "value": "%Z",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 1,
                     "position": 156
                 },
@@ -571,7 +709,9 @@
                     "token": "\n                            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -580,7 +720,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 189
                 },
@@ -589,7 +731,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 193
                 },
@@ -598,7 +742,9 @@
                     "token": "LOCAL",
                     "value": "LOCAL",
                     "keyword": "LOCAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 194
                 },
@@ -607,7 +753,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 199
                 },
@@ -616,7 +764,9 @@
                     "token": "CHECK",
                     "value": "CHECK",
                     "keyword": "CHECK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 200
                 },
@@ -625,7 +775,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 205
                 },
@@ -634,7 +786,9 @@
                     "token": "OPTION",
                     "value": "OPTION",
                     "keyword": "OPTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 206
                 },
@@ -643,7 +797,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 212
                 },
@@ -652,7 +808,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 214
                 },
@@ -661,7 +819,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 220
                 },
@@ -670,7 +830,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 221
                 },
@@ -679,7 +841,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 225
                 },
@@ -688,7 +852,9 @@
                     "token": "V3",
                     "value": "V3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 226
                 },
@@ -697,7 +863,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 228
                 },
@@ -706,7 +874,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 229
                 },
@@ -715,7 +885,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 231
                 },
@@ -724,7 +896,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 232
                 },
@@ -733,7 +907,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 238
                 },
@@ -742,7 +918,9 @@
                     "token": "COL1",
                     "value": "COL1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 239
                 },
@@ -751,7 +929,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 243
                 },
@@ -760,7 +940,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 248
                 },
@@ -769,7 +951,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 252
                 },
@@ -778,7 +962,9 @@
                     "token": "V2",
                     "value": "V2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 253
                 },
@@ -787,7 +973,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 255
                 },
@@ -796,7 +984,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 256
                 },
@@ -805,7 +995,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 261
                 },
@@ -814,7 +1006,9 @@
                     "token": "COL1",
                     "value": "COL1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 262
                 },
@@ -823,7 +1017,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 266
                 },
@@ -832,7 +1028,9 @@
                     "token": "LIKE",
                     "value": "LIKE",
                     "keyword": "LIKE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 267
                 },
@@ -841,7 +1039,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 271
                 },
@@ -850,7 +1050,9 @@
                     "token": "'AB%'",
                     "value": "AB%",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 1,
                     "position": 272
                 },
@@ -859,7 +1061,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 277
                 },
@@ -868,7 +1072,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 279
                 },
@@ -877,7 +1083,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 285
                 },
@@ -886,7 +1094,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 286
                 },
@@ -895,7 +1105,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 290
                 },
@@ -904,7 +1116,9 @@
                     "token": "V4",
                     "value": "V4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 291
                 },
@@ -913,7 +1127,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 293
                 },
@@ -922,7 +1138,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 294
                 },
@@ -931,7 +1149,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 296
                 },
@@ -940,7 +1160,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 297
                 },
@@ -949,7 +1171,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 303
                 },
@@ -958,7 +1182,9 @@
                     "token": "COL1",
                     "value": "COL1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 304
                 },
@@ -967,7 +1193,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 308
                 },
@@ -976,7 +1204,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 313
                 },
@@ -985,7 +1215,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 317
                 },
@@ -994,7 +1226,9 @@
                     "token": "V3",
                     "value": "V3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 318
                 },
@@ -1003,7 +1237,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 320
                 },
@@ -1012,7 +1248,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 321
                 },
@@ -1021,7 +1259,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 326
                 },
@@ -1030,7 +1270,9 @@
                     "token": "COL1",
                     "value": "COL1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 327
                 },
@@ -1039,7 +1281,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 331
                 },
@@ -1048,7 +1292,9 @@
                     "token": "LIKE",
                     "value": "LIKE",
                     "keyword": "LIKE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 332
                 },
@@ -1057,7 +1303,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 336
                 },
@@ -1066,7 +1314,9 @@
                     "token": "'%YZ'",
                     "value": "%YZ",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 1,
                     "position": 337
                 },
@@ -1075,7 +1325,9 @@
                     "token": "\n                            ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 342
                 },
@@ -1084,7 +1336,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 371
                 },
@@ -1093,7 +1347,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 375
                 },
@@ -1102,7 +1358,9 @@
                     "token": "CASCADED",
                     "value": "CASCADED",
                     "keyword": "CASCADED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 376
                 },
@@ -1111,7 +1369,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 384
                 },
@@ -1120,7 +1380,9 @@
                     "token": "CHECK",
                     "value": "CHECK",
                     "keyword": "CHECK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 385
                 },
@@ -1129,7 +1391,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 390
                 },
@@ -1138,7 +1402,9 @@
                     "token": "OPTION",
                     "value": "OPTION",
                     "keyword": "OPTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 391
                 },
@@ -1147,7 +1413,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 397
                 },
@@ -1156,7 +1424,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 399
                 },
@@ -1165,7 +1435,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 405
                 },
@@ -1174,7 +1446,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 406
                 },
@@ -1183,7 +1457,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 410
                 },
@@ -1192,7 +1468,9 @@
                     "token": "V5",
                     "value": "V5",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 411
                 },
@@ -1201,7 +1479,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 413
                 },
@@ -1210,7 +1490,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 414
                 },
@@ -1219,7 +1501,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 416
                 },
@@ -1228,7 +1512,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 417
                 },
@@ -1237,7 +1523,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 423
                 },
@@ -1246,7 +1534,9 @@
                     "token": "COL1",
                     "value": "COL1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 424
                 },
@@ -1255,7 +1545,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 428
                 },
@@ -1264,7 +1556,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 433
                 },
@@ -1273,7 +1567,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 437
                 },
@@ -1282,7 +1578,9 @@
                     "token": "V4",
                     "value": "V4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 438
                 },
@@ -1291,7 +1589,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 440
                 },
@@ -1300,7 +1600,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 441
                 },
@@ -1309,7 +1611,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 446
                 },
@@ -1318,7 +1622,9 @@
                     "token": "COL1",
                     "value": "COL1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 447
                 },
@@ -1327,7 +1633,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 451
                 },
@@ -1336,7 +1644,9 @@
                     "token": "LIKE",
                     "value": "LIKE",
                     "keyword": "LIKE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 452
                 },
@@ -1345,7 +1655,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 456
                 },
@@ -1354,7 +1666,9 @@
                     "token": "'ABC%'",
                     "value": "ABC%",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 1,
                     "position": 457
                 },
@@ -1363,7 +1677,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 463
                 },
@@ -1372,13 +1688,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 152,
-            "idx": 152
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateViewWithQuotes.out
+++ b/tests/data/parser/parseCreateViewWithQuotes.out
@@ -7,13 +7,19 @@
         "last": 211,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 44,
+            "idx": 44,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "ALGORITHM",
                     "value": "ALGORITHM",
                     "keyword": "ALGORITHM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 16
                 },
@@ -49,7 +65,9 @@
                     "token": "UNDEFINED",
                     "value": "UNDEFINED",
                     "keyword": "UNDEFINED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -67,7 +87,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 27
                 },
@@ -76,7 +98,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 2,
                     "position": 34
                 },
@@ -85,7 +109,11 @@
                     "token": "`root`@`localhost`",
                     "value": "root@localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 35
                 },
@@ -94,7 +122,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -103,7 +133,9 @@
                     "token": "SQL SECURITY",
                     "value": "SQL SECURITY",
                     "keyword": "SQL SECURITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 54
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -121,7 +155,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 67
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -139,7 +177,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 75
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -157,7 +199,9 @@
                     "token": "`test_view`",
                     "value": "test_view",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 80
                 },
@@ -166,7 +210,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -175,7 +221,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 93
                 },
@@ -184,7 +232,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -193,7 +243,9 @@
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -211,7 +265,9 @@
                     "token": "`email_content`",
                     "value": "email_content",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 103
                 },
@@ -220,7 +276,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 118
                 },
@@ -229,7 +287,9 @@
                     "token": "`content_id`",
                     "value": "content_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 119
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -247,7 +309,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 132
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 134
                 },
@@ -265,7 +331,9 @@
                     "token": "`content_id`",
                     "value": "content_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 135
                 },
@@ -274,7 +342,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 147
                 },
@@ -283,7 +353,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -292,7 +364,9 @@
                     "token": "`email_content`",
                     "value": "email_content",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 149
                 },
@@ -301,7 +375,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 164
                 },
@@ -310,7 +386,9 @@
                     "token": "`brand_id`",
                     "value": "brand_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 165
                 },
@@ -319,7 +397,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 175
                 },
@@ -328,7 +408,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 176
                 },
@@ -337,7 +419,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 178
                 },
@@ -346,7 +430,9 @@
                     "token": "`brand_id`",
                     "value": "brand_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 179
                 },
@@ -355,7 +441,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 189
                 },
@@ -364,7 +452,9 @@
                     "token": "from",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 190
                 },
@@ -373,7 +463,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 194
                 },
@@ -382,7 +474,9 @@
                     "token": "`email_content`",
                     "value": "email_content",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 195
                 },
@@ -391,7 +485,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 210
                 },
@@ -400,13 +498,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@49"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 44,
-            "idx": 44
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseCreateViewWithUnion.out
+++ b/tests/data/parser/parseCreateViewWithUnion.out
@@ -7,13 +7,19 @@
         "last": 173,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 47,
+            "idx": 47,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`employees_view`",
                     "value": "employees_view",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 30
                 },
@@ -76,7 +98,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +109,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -103,7 +131,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -112,7 +144,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -121,7 +155,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -130,7 +166,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -139,7 +177,9 @@
                     "token": "`employees`",
                     "value": "employees",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 51
                 },
@@ -148,7 +188,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -157,7 +199,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 63
                 },
@@ -166,7 +210,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": "`employees`",
                     "value": "employees",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 73
                 },
@@ -184,7 +232,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 84
                 },
@@ -193,7 +243,9 @@
                     "token": "`gender`",
                     "value": "gender",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 85
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -211,7 +265,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 94
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -229,7 +287,11 @@
                     "token": "'M'",
                     "value": "M",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 96
                 },
@@ -238,7 +300,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -247,7 +311,9 @@
                     "token": "UNION",
                     "value": "UNION",
                     "keyword": "UNION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 100
                 },
@@ -256,7 +322,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -265,7 +333,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 106
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -283,7 +355,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 113
                 },
@@ -292,7 +366,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -301,7 +377,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 115
                 },
@@ -310,7 +388,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -319,7 +399,9 @@
                     "token": "`employees`",
                     "value": "employees",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 124
                 },
@@ -328,7 +410,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -337,7 +421,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 136
                 },
@@ -346,7 +432,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -355,7 +443,9 @@
                     "token": "`employees`",
                     "value": "employees",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 146
                 },
@@ -364,7 +454,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 157
                 },
@@ -373,7 +465,9 @@
                     "token": "`gender`",
                     "value": "gender",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 158
                 },
@@ -382,7 +476,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 166
                 },
@@ -391,7 +487,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 167
                 },
@@ -400,7 +498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 168
                 },
@@ -409,7 +509,9 @@
                     "token": "'F'",
                     "value": "F",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 1,
                     "position": 169
                 },
@@ -418,7 +520,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 172
                 },
@@ -427,13 +533,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@53"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 47,
-            "idx": 47
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -529,21 +635,6 @@
                 "parameters": null,
                 "body": [
                     {
-                        "@type": "@28"
-                    },
-                    {
-                        "@type": "@29"
-                    },
-                    {
-                        "@type": "@30"
-                    },
-                    {
-                        "@type": "@31"
-                    },
-                    {
-                        "@type": "@32"
-                    },
-                    {
                         "@type": "@33"
                     },
                     {
@@ -584,6 +675,21 @@
                     },
                     {
                         "@type": "@46"
+                    },
+                    {
+                        "@type": "@47"
+                    },
+                    {
+                        "@type": "@48"
+                    },
+                    {
+                        "@type": "@49"
+                    },
+                    {
+                        "@type": "@50"
+                    },
+                    {
+                        "@type": "@51"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseCreateViewWithWrongSyntax.out
+++ b/tests/data/parser/parseCreateViewWithWrongSyntax.out
@@ -7,13 +7,19 @@
         "last": 38,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 20,
+            "idx": 20,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "abc",
                     "value": "abc",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 16
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -85,7 +109,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +131,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -112,7 +142,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 27
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -130,7 +166,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -139,7 +177,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -157,7 +199,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 32
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -175,7 +221,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -184,13 +232,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 20,
-            "idx": 20
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -304,7 +354,7 @@
             [
                 "An expression was expected.",
                 {
-                    "@type": "@18"
+                    "@type": "@22"
                 },
                 0
             ]

--- a/tests/data/parser/parseCreateViewWithoutQuotes.out
+++ b/tests/data/parser/parseCreateViewWithoutQuotes.out
@@ -7,13 +7,19 @@
         "last": 207,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 45,
+            "idx": 45,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "ALGORITHM",
                     "value": "ALGORITHM",
                     "keyword": "ALGORITHM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 16
                 },
@@ -49,7 +65,9 @@
                     "token": "UNDEFINED",
                     "value": "UNDEFINED",
                     "keyword": "UNDEFINED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -67,7 +87,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 27
                 },
@@ -76,7 +98,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 2,
                     "position": 34
                 },
@@ -85,7 +109,11 @@
                     "token": "root",
                     "value": "root",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -94,7 +122,11 @@
                     "token": "@localhost",
                     "value": "localhost",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 39
                 },
@@ -103,7 +135,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -112,7 +146,9 @@
                     "token": "SQL SECURITY",
                     "value": "SQL SECURITY",
                     "keyword": "SQL SECURITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 50
                 },
@@ -121,7 +157,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -130,7 +168,9 @@
                     "token": "DEFINER",
                     "value": "DEFINER",
                     "keyword": "DEFINER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 63
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -148,7 +190,9 @@
                     "token": "VIEW",
                     "value": "VIEW",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 71
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -166,7 +212,9 @@
                     "token": "`test_view`",
                     "value": "test_view",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 76
                 },
@@ -175,7 +223,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -184,7 +234,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 89
                 },
@@ -193,7 +245,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -202,7 +256,9 @@
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 92
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -220,7 +278,9 @@
                     "token": "`email_content`",
                     "value": "email_content",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 99
                 },
@@ -229,7 +289,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 114
                 },
@@ -238,7 +300,9 @@
                     "token": "`content_id`",
                     "value": "content_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 115
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -256,7 +322,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 128
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -274,7 +344,9 @@
                     "token": "`content_id`",
                     "value": "content_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 131
                 },
@@ -283,7 +355,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 143
                 },
@@ -292,7 +366,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 144
                 },
@@ -301,7 +377,9 @@
                     "token": "`email_content`",
                     "value": "email_content",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 145
                 },
@@ -310,7 +388,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 160
                 },
@@ -319,7 +399,9 @@
                     "token": "`brand_id`",
                     "value": "brand_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 161
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 171
                 },
@@ -337,7 +421,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 172
                 },
@@ -346,7 +432,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 174
                 },
@@ -355,7 +443,9 @@
                     "token": "`brand_id`",
                     "value": "brand_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 175
                 },
@@ -364,7 +454,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 185
                 },
@@ -373,7 +465,9 @@
                     "token": "from",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 186
                 },
@@ -382,7 +476,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 190
                 },
@@ -391,7 +487,9 @@
                     "token": "`email_content`",
                     "value": "email_content",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 191
                 },
@@ -400,7 +498,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 206
                 },
@@ -409,13 +511,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@51"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 45,
-            "idx": 45
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete.out
+++ b/tests/data/parser/parseDelete.out
@@ -7,13 +7,19 @@
         "last": 122,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 38,
+            "idx": 38,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "LOW_PRIORITY",
                     "value": "LOW_PRIORITY",
                     "keyword": "LOW_PRIORITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -49,7 +63,11 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 20
                 },
@@ -58,7 +76,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -67,7 +87,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 26
                 },
@@ -76,7 +98,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -85,7 +109,11 @@
                     "token": "`test`",
                     "value": "test",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 35
                 },
@@ -94,7 +122,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -103,7 +135,11 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -112,7 +148,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -121,7 +159,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 48
                 },
@@ -130,7 +170,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -139,7 +181,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 58
                 },
@@ -148,7 +192,9 @@
                     "token": "<",
                     "value": "<",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 62
                 },
@@ -157,7 +203,11 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -166,7 +216,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -175,7 +227,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 65
                 },
@@ -184,7 +238,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -193,7 +249,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 69
                 },
@@ -202,7 +260,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -211,7 +271,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 78
                 },
@@ -220,7 +282,11 @@
                     "token": "\"Dan\"",
                     "value": "Dan",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 79
                 },
@@ -229,7 +295,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -238,7 +306,9 @@
                     "token": "or",
                     "value": "OR",
                     "keyword": "OR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 85
                 },
@@ -247,7 +317,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -256,7 +328,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -265,7 +339,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 96
                 },
@@ -274,7 +350,9 @@
                     "token": "\"Paul\"",
                     "value": "Paul",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 2,
                     "position": 97
                 },
@@ -283,7 +361,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 103
                 },
@@ -292,7 +372,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -301,7 +383,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 105
                 },
@@ -310,7 +394,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -319,7 +405,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -328,7 +416,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -337,7 +427,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -346,13 +440,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@47"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 38,
-            "idx": 38
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete10.out
+++ b/tests/data/parser/parseDelete10.out
@@ -7,13 +7,19 @@
         "last": 71,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 32,
+            "idx": 32,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 27
                 },
@@ -94,7 +122,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 28
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -112,7 +144,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 30
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +188,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +221,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 47
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -193,7 +243,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -211,7 +265,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 56
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -229,7 +287,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -247,7 +309,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 62
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -265,7 +331,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -274,7 +344,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 69
                 },
@@ -283,7 +355,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@35"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -292,13 +366,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 32,
-            "idx": 32
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete11.out
+++ b/tests/data/parser/parseDelete11.out
@@ -7,13 +7,19 @@
         "last": 81,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 34,
+            "idx": 34,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +98,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 35
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -148,7 +188,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -166,7 +210,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 48
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -184,7 +232,11 @@
                     "token": "`t1`",
                     "value": "t1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 51
                 },
@@ -193,7 +245,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 55
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -211,7 +267,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -229,7 +289,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 64
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -247,7 +311,9 @@
                     "token": "`t2`",
                     "value": "t2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 2,
                     "position": 67
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -265,7 +333,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 72
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -283,7 +355,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -292,7 +368,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 79
                 },
@@ -301,7 +379,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@38"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -310,13 +390,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 34,
-            "idx": 34
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete12.out
+++ b/tests/data/parser/parseDelete12.out
@@ -7,13 +7,19 @@
         "last": 46,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 25
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +131,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -112,7 +144,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 32
                 },
@@ -121,7 +157,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -139,7 +179,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 35
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -157,7 +201,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -166,7 +212,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -184,7 +234,9 @@
                     "token": "25",
                     "value": 25,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -193,13 +245,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete13.out
+++ b/tests/data/parser/parseDelete13.out
@@ -7,13 +7,19 @@
         "last": 37,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 18,
+            "idx": 18,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "emp",
                     "value": "emp",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": "x",
                     "value": "x",
                     "keyword": "x",
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -85,7 +109,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -103,7 +131,9 @@
                     "token": "x",
                     "value": "x",
                     "keyword": "x",
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -112,7 +142,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 25
                 },
@@ -121,7 +155,9 @@
                     "token": "salary",
                     "value": "salary",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -139,7 +177,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 33
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -157,7 +199,11 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -166,13 +212,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 18,
-            "idx": 18
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete2.out
+++ b/tests/data/parser/parseDelete2.out
@@ -7,13 +7,19 @@
         "last": 21,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 8,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 14
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +85,11 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,13 +98,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 8
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete3.out
+++ b/tests/data/parser/parseDelete3.out
@@ -7,13 +7,19 @@
         "last": 31,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 14,
+            "idx": 14,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 14
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +85,11 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +131,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -112,7 +144,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 29
                 },
@@ -121,7 +157,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -130,13 +168,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 14,
-            "idx": 14
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete4.out
+++ b/tests/data/parser/parseDelete4.out
@@ -7,13 +7,19 @@
         "last": 43,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 18,
+            "idx": 18,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 14
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +85,11 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +131,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -112,7 +144,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 29
                 },
@@ -121,7 +157,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -139,7 +179,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 32
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -157,7 +201,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -166,13 +212,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 18,
-            "idx": 18
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete5.out
+++ b/tests/data/parser/parseDelete5.out
@@ -7,13 +7,19 @@
         "last": 54,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 24,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 14
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +85,11 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +131,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -112,7 +144,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 29
                 },
@@ -121,7 +157,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -139,7 +179,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 32
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -157,7 +201,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -175,7 +223,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -193,7 +245,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -202,7 +256,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 51
                 },
@@ -211,7 +267,9 @@
                     "token": "25",
                     "value": 25,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -220,13 +278,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 24
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete6.out
+++ b/tests/data/parser/parseDelete6.out
@@ -7,13 +7,19 @@
         "last": 33,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 12,
+            "idx": 12,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 14
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +85,11 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 22
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +131,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -112,13 +142,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 12,
-            "idx": 12
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete7.out
+++ b/tests/data/parser/parseDelete7.out
@@ -7,13 +7,19 @@
         "last": 44,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 18,
+            "idx": 18,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 14
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +85,11 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 22
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +131,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +153,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 34
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +175,11 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -148,7 +188,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -157,7 +201,9 @@
                     "token": "25",
                     "value": 25,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -166,13 +212,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 18,
-            "idx": 18
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete8.out
+++ b/tests/data/parser/parseDelete8.out
@@ -7,13 +7,19 @@
         "last": 33,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 15,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 14
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +85,11 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +131,11 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -112,7 +144,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 29
                 },
@@ -121,7 +157,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -130,7 +168,9 @@
                     "token": "25",
                     "value": 25,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -139,13 +179,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 15
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelete9.out
+++ b/tests/data/parser/parseDelete9.out
@@ -7,13 +7,19 @@
         "last": 61,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 26,
+            "idx": 26,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 27
                 },
@@ -94,7 +122,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 28
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -112,7 +144,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 30
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +188,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +221,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 47
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -193,7 +243,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -211,7 +265,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 56
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -229,7 +287,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -238,13 +298,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 26,
-            "idx": 26
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDeleteErr1.out
+++ b/tests/data/parser/parseDeleteErr1.out
@@ -7,13 +7,19 @@
         "last": 35,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 13,
+            "idx": 14,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +85,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 25
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -94,7 +122,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 1,
                     "position": 34
                 },
@@ -121,13 +155,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 13,
-            "idx": 14
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -170,14 +206,14 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ]

--- a/tests/data/parser/parseDeleteErr10.out
+++ b/tests/data/parser/parseDeleteErr10.out
@@ -7,13 +7,19 @@
         "last": 65,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 33,
+            "idx": 33,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +98,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -130,7 +166,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +188,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,9 @@
                     "token": "t",
                     "value": "t",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +221,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 46
                 },
@@ -184,7 +232,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -202,7 +254,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 50
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -220,7 +276,9 @@
                     "token": "tt",
                     "value": "tt",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -238,7 +298,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 56
                 },
@@ -247,7 +309,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -256,7 +320,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -265,7 +331,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -274,7 +342,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 62
                 },
@@ -283,7 +353,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -292,7 +366,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -301,13 +379,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 33,
-            "idx": 33
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -392,14 +470,14 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@27"
+                    "@type": "@31"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@27"
+                    "@type": "@31"
                 },
                 0
             ]

--- a/tests/data/parser/parseDeleteErr11.out
+++ b/tests/data/parser/parseDeleteErr11.out
@@ -7,13 +7,19 @@
         "last": 40,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 18,
+            "idx": 19,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 25
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +131,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -121,7 +153,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 33
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -139,7 +177,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -157,7 +201,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 37
                 },
@@ -166,13 +212,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 18,
-            "idx": 19
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -235,14 +283,14 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@18"
+                    "@type": "@23"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@18"
+                    "@type": "@23"
                 },
                 0
             ]

--- a/tests/data/parser/parseDeleteErr12.out
+++ b/tests/data/parser/parseDeleteErr12.out
@@ -7,13 +7,19 @@
         "last": 74,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 38,
+            "idx": 38,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +98,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -130,7 +166,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +188,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,9 @@
                     "token": "t",
                     "value": "t",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +221,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 46
                 },
@@ -184,7 +232,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -202,7 +254,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 50
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -220,7 +276,9 @@
                     "token": "tt",
                     "value": "tt",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -238,7 +298,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 56
                 },
@@ -247,7 +309,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -256,7 +320,9 @@
                     "token": "ttt",
                     "value": "ttt",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -265,7 +331,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -274,7 +342,9 @@
                     "token": "WHEE",
                     "value": "WHEE",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -283,7 +353,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -292,7 +364,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -301,7 +375,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -310,7 +386,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 70
                 },
@@ -319,7 +397,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -328,7 +410,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -337,7 +423,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -346,13 +434,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@43"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 38,
-            "idx": 38
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -437,35 +525,21 @@
             [
                 "An alias was previously found.",
                 {
-                    "@type": "@29"
+                    "@type": "@33"
                 },
                 0
             ],
             [
                 "An alias was expected.",
                 {
-                    "@type": "@28"
+                    "@type": "@32"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@29"
-                },
-                0
-            ],
-            [
-                "Unexpected beginning of statement.",
-                {
-                    "@type": "@29"
-                },
-                0
-            ],
-            [
-                "Unexpected beginning of statement.",
-                {
-                    "@type": "@31"
+                    "@type": "@33"
                 },
                 0
             ],
@@ -479,7 +553,21 @@
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@36"
+                    "@type": "@35"
+                },
+                0
+            ],
+            [
+                "Unexpected beginning of statement.",
+                {
+                    "@type": "@37"
+                },
+                0
+            ],
+            [
+                "Unexpected beginning of statement.",
+                {
+                    "@type": "@40"
                 },
                 0
             ]

--- a/tests/data/parser/parseDeleteErr2.out
+++ b/tests/data/parser/parseDeleteErr2.out
@@ -7,13 +7,19 @@
         "last": 76,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 32,
+            "idx": 33,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 27
                 },
@@ -94,7 +122,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 28
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -112,7 +144,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 30
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -130,7 +166,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -148,7 +188,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 43
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -166,7 +210,11 @@
                     "token": "`t1`",
                     "value": "t1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 46
                 },
@@ -175,7 +223,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 50
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -193,7 +245,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -211,7 +267,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 59
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -229,7 +289,9 @@
                     "token": "`t2`",
                     "value": "t2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@24"
+                    },
                     "flags": 2,
                     "position": 62
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -247,7 +311,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 67
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -265,7 +333,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -274,7 +346,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 74
                 },
@@ -283,7 +357,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@36"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -292,13 +368,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 32,
-            "idx": 33
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -362,14 +440,14 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@13"
+                    "@type": "@17"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@13"
+                    "@type": "@17"
                 },
                 0
             ]

--- a/tests/data/parser/parseDeleteErr3.out
+++ b/tests/data/parser/parseDeleteErr3.out
@@ -7,13 +7,19 @@
         "last": 69,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 29,
+            "idx": 30,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 27
                 },
@@ -94,7 +122,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 28
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -112,7 +144,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -130,7 +166,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 37
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -148,7 +188,11 @@
                     "token": "`t1`",
                     "value": "t1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 40
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +212,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -184,7 +234,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 52
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -202,7 +256,9 @@
                     "token": "`t2`",
                     "value": "t2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 2,
                     "position": 55
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -220,7 +278,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 60
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -238,7 +300,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -247,7 +313,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 67
                 },
@@ -256,7 +324,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -265,13 +335,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 29,
-            "idx": 30
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -335,28 +407,28 @@
             [
                 "An alias was previously found.",
                 {
-                    "@type": "@19"
+                    "@type": "@24"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@19"
+                    "@type": "@24"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@19"
+                    "@type": "@24"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@21"
+                    "@type": "@26"
                 },
                 0
             ]

--- a/tests/data/parser/parseDeleteErr4.out
+++ b/tests/data/parser/parseDeleteErr4.out
@@ -7,13 +7,19 @@
         "last": 96,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 39,
+            "idx": 40,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +98,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 1,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +188,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,11 @@
                     "token": "`t1`",
                     "value": "t1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 45
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -184,7 +234,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 50
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -202,7 +256,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -220,7 +278,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 63
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -238,7 +300,9 @@
                     "token": "`t2`",
                     "value": "t2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@24"
+                    },
                     "flags": 2,
                     "position": 66
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -256,7 +322,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 71
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -274,7 +344,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -283,7 +357,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 78
                 },
@@ -292,7 +368,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -310,7 +390,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 81
                 },
@@ -319,7 +401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -328,7 +412,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -346,7 +434,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 93
                 },
@@ -355,13 +445,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 39,
-            "idx": 40
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -443,14 +535,14 @@
             [
                 "This type of clause is not valid in Multi-table queries.",
                 {
-                    "@type": "@35"
+                    "@type": "@41"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@35"
+                    "@type": "@41"
                 },
                 0
             ]

--- a/tests/data/parser/parseDeleteErr5.out
+++ b/tests/data/parser/parseDeleteErr5.out
@@ -7,13 +7,19 @@
         "last": 60,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 26,
+            "idx": 27,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 25
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +131,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -112,7 +144,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 32
                 },
@@ -121,7 +157,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -139,7 +179,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 35
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -157,7 +201,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -175,7 +223,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 47
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -193,7 +245,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 51
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -211,7 +267,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -220,7 +278,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 2,
                     "position": 58
                 },
@@ -229,7 +289,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -238,13 +300,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 26,
-            "idx": 27
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -320,14 +384,14 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@22"
+                    "@type": "@27"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@22"
+                    "@type": "@27"
                 },
                 0
             ]

--- a/tests/data/parser/parseDeleteErr6.out
+++ b/tests/data/parser/parseDeleteErr6.out
@@ -7,13 +7,19 @@
         "last": 92,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 40,
+            "idx": 41,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +98,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 1,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +188,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,11 @@
                     "token": "`t1`",
                     "value": "t1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 45
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -184,7 +234,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 50
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -202,7 +256,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -220,7 +278,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 63
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -238,7 +300,9 @@
                     "token": "`t2`",
                     "value": "t2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@24"
+                    },
                     "flags": 2,
                     "position": 66
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -256,7 +322,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 71
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -274,7 +344,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -283,7 +357,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 78
                 },
@@ -292,7 +368,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -310,7 +390,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 81
                 },
@@ -319,7 +401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -328,7 +412,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -337,7 +423,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 88
                 },
@@ -346,7 +434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -355,7 +445,9 @@
                     "token": "25",
                     "value": 25,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -364,13 +456,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 40,
-            "idx": 41
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -452,14 +546,14 @@
             [
                 "This type of clause is not valid in Multi-table queries.",
                 {
-                    "@type": "@35"
+                    "@type": "@41"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@35"
+                    "@type": "@41"
                 },
                 0
             ]

--- a/tests/data/parser/parseDeleteErr7.out
+++ b/tests/data/parser/parseDeleteErr7.out
@@ -7,13 +7,19 @@
         "last": 58,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 25,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 25
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +131,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -121,7 +153,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 33
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -139,7 +177,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -157,7 +201,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 37
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +223,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -193,7 +245,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 49
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -211,7 +267,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 53
                 },
@@ -220,13 +278,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 25
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -304,14 +364,14 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@24"
+                    "@type": "@29"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@24"
+                    "@type": "@29"
                 },
                 0
             ]

--- a/tests/data/parser/parseDeleteErr8.out
+++ b/tests/data/parser/parseDeleteErr8.out
@@ -7,13 +7,19 @@
         "last": 28,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 25
                 },
@@ -94,13 +120,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -154,14 +182,14 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@10"
+                    "@type": "@13"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@10"
+                    "@type": "@13"
                 },
                 0
             ]

--- a/tests/data/parser/parseDeleteErr9.out
+++ b/tests/data/parser/parseDeleteErr9.out
@@ -7,13 +7,19 @@
         "last": 66,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 33,
+            "idx": 33,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "QUICK",
                     "value": "QUICK",
                     "keyword": "QUICK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +98,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -130,7 +166,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +188,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,9 @@
                     "token": "t",
                     "value": "t",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +221,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 46
                 },
@@ -184,7 +232,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -202,7 +254,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 50
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -220,7 +276,9 @@
                     "token": "tt",
                     "value": "tt",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -238,7 +298,9 @@
                     "token": "WHEE",
                     "value": "WHEE",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -247,7 +309,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -256,7 +320,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -265,7 +331,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -274,7 +342,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 63
                 },
@@ -283,7 +353,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -292,7 +366,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -301,13 +379,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 33,
-            "idx": 33
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -392,35 +470,35 @@
             [
                 "An alias was previously found.",
                 {
-                    "@type": "@27"
+                    "@type": "@31"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@27"
+                    "@type": "@31"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@27"
+                    "@type": "@31"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@29"
+                    "@type": "@33"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@32"
+                    "@type": "@36"
                 },
                 0
             ]

--- a/tests/data/parser/parseDeleteJoin.out
+++ b/tests/data/parser/parseDeleteJoin.out
@@ -7,13 +7,19 @@
         "last": 83,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 39,
+            "idx": 39,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 9
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -58,7 +78,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -76,7 +100,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 14
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -94,7 +122,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -112,7 +144,9 @@
                     "token": "INNER JOIN",
                     "value": "INNER JOIN",
                     "keyword": "INNER JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 22
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -130,7 +166,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -148,7 +188,9 @@
                     "token": "INNER JOIN",
                     "value": "INNER JOIN",
                     "keyword": "INNER JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 36
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -166,7 +210,9 @@
                     "token": "t3",
                     "value": "t3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -184,7 +232,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 50
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -202,7 +254,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -211,7 +265,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 58
                 },
@@ -220,7 +276,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -229,7 +287,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 61
                 },
@@ -238,7 +298,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -247,7 +309,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 64
                 },
@@ -256,7 +320,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -265,7 +331,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -274,7 +342,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 68
                 },
@@ -283,7 +353,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -292,7 +364,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -301,7 +375,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 74
                 },
@@ -310,7 +386,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -319,7 +397,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 77
                 },
@@ -328,7 +408,9 @@
                     "token": "t3",
                     "value": "t3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -337,7 +419,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -346,7 +430,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -355,13 +441,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 39,
-            "idx": 39
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDelimiter.out
+++ b/tests/data/parser/parseDelimiter.out
@@ -7,13 +7,19 @@
         "last": 82,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 35,
+            "idx": 35,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -85,7 +113,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -94,7 +124,9 @@
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -103,7 +135,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -112,7 +146,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -121,7 +157,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -130,7 +168,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 32
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -148,7 +190,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 39
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -166,7 +212,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 41
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -184,7 +234,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -193,7 +245,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -202,7 +256,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -211,7 +267,9 @@
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -229,7 +289,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -238,7 +300,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -247,7 +311,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 64
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -265,7 +333,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -283,7 +355,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -301,7 +377,9 @@
                     "token": "baz",
                     "value": "baz",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -310,7 +388,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -319,13 +399,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 35,
-            "idx": 35
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDrop.out
+++ b/tests/data/parser/parseDrop.out
@@ -7,13 +7,19 @@
         "last": 35,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 9,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DROP",
                     "value": "DROP",
                     "keyword": "DROP",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -49,7 +63,9 @@
                     "token": "IF EXISTS",
                     "value": "IF EXISTS",
                     "keyword": "IF EXISTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 10
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +85,11 @@
                     "token": "'testtest'@'%'",
                     "value": "testtest@%",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 20
                 },
@@ -76,7 +98,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -85,13 +111,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 9,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseDrop2.out
+++ b/tests/data/parser/parseDrop2.out
@@ -7,13 +7,19 @@
         "last": 25,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 7,
+            "idx": 7,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DROP",
                     "value": "DROP",
                     "keyword": "DROP",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "USER",
                     "value": "USER",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -49,7 +63,11 @@
                     "token": "'testtest'@'%'",
                     "value": "testtest@%",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 4,
                     "position": 10
                 },
@@ -58,7 +76,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -67,13 +89,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 7,
-            "idx": 7
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseExplain.out
+++ b/tests/data/parser/parseExplain.out
@@ -7,13 +7,19 @@
         "last": 27,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "EXPLAIN",
                     "value": "EXPLAIN",
                     "keyword": "EXPLAIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -49,7 +63,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 15
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +122,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,13 +135,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -128,13 +160,9 @@
                     "@type": "PhpMyAdmin\\SqlParser\\Parser",
                     "list": {
                         "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                        "count": 9,
+                        "idx": 9,
                         "tokens": [
-                            {
-                                "@type": "@4"
-                            },
-                            {
-                                "@type": "@5"
-                            },
                             {
                                 "@type": "@6"
                             },
@@ -145,9 +173,6 @@
                                 "@type": "@8"
                             },
                             {
-                                "@type": "@9"
-                            },
-                            {
                                 "@type": "@10"
                             },
                             {
@@ -155,10 +180,17 @@
                             },
                             {
                                 "@type": "@12"
+                            },
+                            {
+                                "@type": "@13"
+                            },
+                            {
+                                "@type": "@15"
+                            },
+                            {
+                                "@type": "@17"
                             }
-                        ],
-                        "count": 9,
-                        "idx": 9
+                        ]
                     },
                     "statements": [
                         {

--- a/tests/data/parser/parseExplain1.out
+++ b/tests/data/parser/parseExplain1.out
@@ -7,13 +7,19 @@
         "last": 28,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ANALYZE",
                     "value": "ANALYZE",
                     "keyword": "ANALYZE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -49,7 +63,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 15
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,11 @@
                     "token": "orders",
                     "value": "orders",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,13 +122,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -119,13 +149,9 @@
                     "@type": "PhpMyAdmin\\SqlParser\\Parser",
                     "list": {
                         "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                        "count": 8,
+                        "idx": 8,
                         "tokens": [
-                            {
-                                "@type": "@4"
-                            },
-                            {
-                                "@type": "@5"
-                            },
                             {
                                 "@type": "@6"
                             },
@@ -136,17 +162,21 @@
                                 "@type": "@8"
                             },
                             {
-                                "@type": "@9"
-                            },
-                            {
                                 "@type": "@10"
                             },
                             {
                                 "@type": "@11"
+                            },
+                            {
+                                "@type": "@12"
+                            },
+                            {
+                                "@type": "@13"
+                            },
+                            {
+                                "@type": "@15"
                             }
-                        ],
-                        "count": 8,
-                        "idx": 8
+                        ]
                     },
                     "statements": [
                         {

--- a/tests/data/parser/parseExplain10.out
+++ b/tests/data/parser/parseExplain10.out
@@ -7,13 +7,19 @@
         "last": 64,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DESC",
                     "value": "DESC",
                     "keyword": "DESC",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,7 +109,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 23
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -103,7 +131,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +157,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -139,7 +179,11 @@
                     "token": "'Old'",
                     "value": "Old",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 34
                 },
@@ -148,7 +192,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 39
                 },
@@ -157,7 +203,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -166,7 +214,9 @@
                     "token": "'2014-08-20 18:47:00'",
                     "value": "2014-08-20 18:47:00",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 41
                 },
@@ -175,7 +225,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 62
                 },
@@ -184,7 +236,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -193,13 +249,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -218,13 +274,9 @@
                     "@type": "PhpMyAdmin\\SqlParser\\Parser",
                     "list": {
                         "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                        "count": 19,
+                        "idx": 19,
                         "tokens": [
-                            {
-                                "@type": "@4"
-                            },
-                            {
-                                "@type": "@5"
-                            },
                             {
                                 "@type": "@6"
                             },
@@ -241,9 +293,6 @@
                                 "@type": "@10"
                             },
                             {
-                                "@type": "@11"
-                            },
-                            {
                                 "@type": "@12"
                             },
                             {
@@ -256,13 +305,7 @@
                                 "@type": "@15"
                             },
                             {
-                                "@type": "@16"
-                            },
-                            {
                                 "@type": "@17"
-                            },
-                            {
-                                "@type": "@18"
                             },
                             {
                                 "@type": "@19"
@@ -274,11 +317,24 @@
                                 "@type": "@21"
                             },
                             {
-                                "@type": "@22"
+                                "@type": "@23"
+                            },
+                            {
+                                "@type": "@24"
+                            },
+                            {
+                                "@type": "@25"
+                            },
+                            {
+                                "@type": "@26"
+                            },
+                            {
+                                "@type": "@27"
+                            },
+                            {
+                                "@type": "@29"
                             }
-                        ],
-                        "count": 19,
-                        "idx": 19
+                        ]
                     },
                     "statements": [
                         {

--- a/tests/data/parser/parseExplain11.out
+++ b/tests/data/parser/parseExplain11.out
@@ -7,13 +7,19 @@
         "last": 68,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 22,
+            "idx": 22,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ANALYSE",
                     "value": "ANALYSE",
                     "keyword": "ANALYSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 1,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -49,7 +63,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 16
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +85,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -85,7 +109,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 26
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +131,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -112,7 +144,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -121,7 +157,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -139,7 +179,11 @@
                     "token": "'Old'",
                     "value": "Old",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 37
                 },
@@ -148,7 +192,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -157,7 +203,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -166,7 +214,9 @@
                     "token": "'2014-08-20 18:47:00'",
                     "value": "2014-08-20 18:47:00",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 44
                 },
@@ -175,7 +225,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 65
                 },
@@ -184,7 +236,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -193,7 +249,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -202,13 +260,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 22,
-            "idx": 22
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseExplain12.out
+++ b/tests/data/parser/parseExplain12.out
@@ -7,13 +7,19 @@
         "last": 79,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 25,
+            "idx": 25,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "EXPLAIN",
                     "value": "EXPLAIN",
                     "keyword": "EXPLAIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "FORMAT",
                     "value": "FORMAT",
                     "keyword": "FORMAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 8
                 },
@@ -40,7 +52,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 14
                 },
@@ -49,7 +65,9 @@
                     "token": "json",
                     "value": "json",
                     "keyword": "JSON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 9,
                     "position": 15
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +87,9 @@
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 20
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -85,7 +109,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 28
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +131,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -121,7 +155,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 38
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -139,7 +177,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 45
                 },
@@ -148,7 +188,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 47
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -175,7 +223,11 @@
                     "token": "'Old'",
                     "value": "Old",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 49
                 },
@@ -184,7 +236,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 54
                 },
@@ -193,7 +247,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -202,7 +258,9 @@
                     "token": "'2014-08-20 18:47:00'",
                     "value": "2014-08-20 18:47:00",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 1,
                     "position": 56
                 },
@@ -211,7 +269,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -220,7 +280,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -229,13 +293,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@32"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 25,
-            "idx": 25
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -254,16 +318,9 @@
                     "@type": "PhpMyAdmin\\SqlParser\\Parser",
                     "list": {
                         "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                        "count": 19,
+                        "idx": 19,
                         "tokens": [
-                            {
-                                "@type": "@8"
-                            },
-                            {
-                                "@type": "@9"
-                            },
-                            {
-                                "@type": "@10"
-                            },
                             {
                                 "@type": "@11"
                             },
@@ -278,9 +335,6 @@
                             },
                             {
                                 "@type": "@15"
-                            },
-                            {
-                                "@type": "@16"
                             },
                             {
                                 "@type": "@17"
@@ -298,9 +352,6 @@
                                 "@type": "@21"
                             },
                             {
-                                "@type": "@22"
-                            },
-                            {
                                 "@type": "@23"
                             },
                             {
@@ -310,11 +361,24 @@
                                 "@type": "@25"
                             },
                             {
-                                "@type": "@26"
+                                "@type": "@27"
+                            },
+                            {
+                                "@type": "@28"
+                            },
+                            {
+                                "@type": "@29"
+                            },
+                            {
+                                "@type": "@30"
+                            },
+                            {
+                                "@type": "@31"
+                            },
+                            {
+                                "@type": "@33"
                             }
-                        ],
-                        "count": 19,
-                        "idx": 19
+                        ]
                     },
                     "statements": [
                         {

--- a/tests/data/parser/parseExplain13.out
+++ b/tests/data/parser/parseExplain13.out
@@ -7,13 +7,19 @@
         "last": 80,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 25,
+            "idx": 25,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DESCRIBE",
                     "value": "DESCRIBE",
                     "keyword": "DESCRIBE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -31,7 +41,9 @@
                     "token": "FORMAT",
                     "value": "FORMAT",
                     "keyword": "FORMAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 9
                 },
@@ -40,7 +52,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 15
                 },
@@ -49,7 +65,9 @@
                     "token": "json",
                     "value": "json",
                     "keyword": "JSON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 9,
                     "position": 16
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +109,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -103,7 +131,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -121,7 +155,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 39
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 46
                 },
@@ -148,7 +188,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 48
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -175,7 +223,11 @@
                     "token": "'Old'",
                     "value": "Old",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -184,7 +236,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 55
                 },
@@ -193,7 +247,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -202,7 +258,9 @@
                     "token": "'2014-08-20 18:47:00'",
                     "value": "2014-08-20 18:47:00",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 1,
                     "position": 57
                 },
@@ -211,7 +269,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 78
                 },
@@ -220,7 +280,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -229,13 +293,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@32"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 25,
-            "idx": 25
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -254,16 +318,9 @@
                     "@type": "PhpMyAdmin\\SqlParser\\Parser",
                     "list": {
                         "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                        "count": 19,
+                        "idx": 19,
                         "tokens": [
-                            {
-                                "@type": "@8"
-                            },
-                            {
-                                "@type": "@9"
-                            },
-                            {
-                                "@type": "@10"
-                            },
                             {
                                 "@type": "@11"
                             },
@@ -278,9 +335,6 @@
                             },
                             {
                                 "@type": "@15"
-                            },
-                            {
-                                "@type": "@16"
                             },
                             {
                                 "@type": "@17"
@@ -298,9 +352,6 @@
                                 "@type": "@21"
                             },
                             {
-                                "@type": "@22"
-                            },
-                            {
                                 "@type": "@23"
                             },
                             {
@@ -310,11 +361,24 @@
                                 "@type": "@25"
                             },
                             {
-                                "@type": "@26"
+                                "@type": "@27"
+                            },
+                            {
+                                "@type": "@28"
+                            },
+                            {
+                                "@type": "@29"
+                            },
+                            {
+                                "@type": "@30"
+                            },
+                            {
+                                "@type": "@31"
+                            },
+                            {
+                                "@type": "@33"
                             }
-                        ],
-                        "count": 19,
-                        "idx": 19
+                        ]
                     },
                     "statements": [
                         {

--- a/tests/data/parser/parseExplain14.out
+++ b/tests/data/parser/parseExplain14.out
@@ -7,13 +7,19 @@
         "last": 41,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 15,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DESC",
                     "value": "DESC",
                     "keyword": "DESC",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "`fo`",
                     "value": "fo",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 16
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "`fo`",
                     "value": "fo",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 25
                 },
@@ -94,7 +120,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 29
                 },
@@ -103,7 +133,9 @@
                     "token": "`uuid`",
                     "value": "uuid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -121,7 +155,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 37
                 },
@@ -130,7 +166,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -139,13 +179,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 15
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -164,13 +204,9 @@
                     "@type": "PhpMyAdmin\\SqlParser\\Parser",
                     "list": {
                         "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                        "count": 13,
+                        "idx": 13,
                         "tokens": [
-                            {
-                                "@type": "@4"
-                            },
-                            {
-                                "@type": "@5"
-                            },
                             {
                                 "@type": "@6"
                             },
@@ -179,9 +215,6 @@
                             },
                             {
                                 "@type": "@8"
-                            },
-                            {
-                                "@type": "@9"
                             },
                             {
                                 "@type": "@10"
@@ -199,14 +232,21 @@
                                 "@type": "@14"
                             },
                             {
-                                "@type": "@15"
+                                "@type": "@16"
                             },
                             {
-                                "@type": "@16"
+                                "@type": "@17"
+                            },
+                            {
+                                "@type": "@18"
+                            },
+                            {
+                                "@type": "@19"
+                            },
+                            {
+                                "@type": "@21"
                             }
-                        ],
-                        "count": 13,
-                        "idx": 13
+                        ]
                     },
                     "statements": [],
                     "brackets": 0,
@@ -215,12 +255,12 @@
                         {
                             "@type": "PhpMyAdmin\\SqlParser\\Exceptions\\ParserException",
                             "token": {
-                                "@type": "@4"
+                                "@type": "@6"
                             },
                             "message": "Unrecognized statement type.",
                             "code": 0,
                             "file": "<project-root>/src/Parser.php",
-                            "line": 628
+                            "line": 620
                         }
                     ]
                 },
@@ -247,21 +287,21 @@
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@4"
+                    "@type": "@6"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@8"
+                    "@type": "@11"
                 },
                 0
             ]

--- a/tests/data/parser/parseExplain2.out
+++ b/tests/data/parser/parseExplain2.out
@@ -7,13 +7,19 @@
         "last": 14,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 4,
+            "idx": 4,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DESC",
                     "value": "DESC",
                     "keyword": "DESC",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "tablename",
                     "value": "tablename",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -40,13 +54,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 4,
-            "idx": 4
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseExplain3.out
+++ b/tests/data/parser/parseExplain3.out
@@ -7,13 +7,19 @@
         "last": 198,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 57,
+            "idx": 57,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "EXPLAIN",
                     "value": "EXPLAIN",
                     "keyword": "EXPLAIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "ANALYZE",
                     "value": "ANALYZE",
                     "keyword": "ANALYZE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -49,7 +63,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 16
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +85,11 @@
                     "token": "first_name",
                     "value": "first_name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -76,7 +98,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -94,7 +122,9 @@
                     "token": "last_name",
                     "value": "last_name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -103,7 +133,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 44
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -121,7 +155,9 @@
                     "token": "SUM",
                     "value": "SUM",
                     "keyword": "SUM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 46
                 },
@@ -130,7 +166,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 49
                 },
@@ -139,7 +177,9 @@
                     "token": "amount",
                     "value": "amount",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 56
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -166,7 +210,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 58
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -184,7 +232,9 @@
                     "token": "total",
                     "value": "total",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -202,7 +254,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 67
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -220,7 +276,9 @@
                     "token": "staff",
                     "value": "staff",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -238,7 +298,9 @@
                     "token": "INNER JOIN",
                     "value": "INNER JOIN",
                     "keyword": "INNER JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 78
                 },
@@ -247,7 +309,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -256,7 +320,9 @@
                     "token": "payment",
                     "value": "payment",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -265,7 +331,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -274,7 +342,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 97
                 },
@@ -283,7 +353,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -292,7 +364,9 @@
                     "token": "staff",
                     "value": "staff",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -301,7 +375,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 105
                 },
@@ -310,7 +386,9 @@
                     "token": "staff_id",
                     "value": "staff_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -319,7 +397,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -328,7 +408,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 115
                 },
@@ -337,7 +419,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -346,7 +430,9 @@
                     "token": "payment",
                     "value": "payment",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -355,7 +441,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 124
                 },
@@ -364,7 +452,9 @@
                     "token": "staff_id",
                     "value": "staff_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -373,7 +463,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -382,7 +474,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 134
                 },
@@ -391,7 +485,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 137
                 },
@@ -400,7 +496,9 @@
                     "token": "payment_date",
                     "value": "payment_date",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -409,7 +507,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 150
                 },
@@ -418,7 +518,9 @@
                     "token": "LIKE",
                     "value": "LIKE",
                     "keyword": "LIKE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 151
                 },
@@ -427,7 +529,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 155
                 },
@@ -436,7 +540,11 @@
                     "token": "'2005-08%'",
                     "value": "2005-08%",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 156
                 },
@@ -445,7 +553,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 166
                 },
@@ -454,7 +564,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 167
                 },
@@ -463,7 +575,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 175
                 },
@@ -472,7 +586,9 @@
                     "token": "first_name",
                     "value": "first_name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -481,7 +597,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 186
                 },
@@ -490,7 +608,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 187
                 },
@@ -499,7 +619,9 @@
                     "token": "last_name",
                     "value": "last_name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 188
                 },
@@ -508,7 +630,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 197
                 },
@@ -517,13 +643,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@63"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 57,
-            "idx": 57
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -542,13 +668,9 @@
                     "@type": "PhpMyAdmin\\SqlParser\\Parser",
                     "list": {
                         "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                        "count": 53,
+                        "idx": 53,
                         "tokens": [
-                            {
-                                "@type": "@6"
-                            },
-                            {
-                                "@type": "@7"
-                            },
                             {
                                 "@type": "@8"
                             },
@@ -559,13 +681,7 @@
                                 "@type": "@10"
                             },
                             {
-                                "@type": "@11"
-                            },
-                            {
                                 "@type": "@12"
-                            },
-                            {
-                                "@type": "@13"
                             },
                             {
                                 "@type": "@14"
@@ -688,9 +804,6 @@
                                 "@type": "@53"
                             },
                             {
-                                "@type": "@54"
-                            },
-                            {
                                 "@type": "@55"
                             },
                             {
@@ -701,10 +814,23 @@
                             },
                             {
                                 "@type": "@58"
+                            },
+                            {
+                                "@type": "@59"
+                            },
+                            {
+                                "@type": "@60"
+                            },
+                            {
+                                "@type": "@61"
+                            },
+                            {
+                                "@type": "@62"
+                            },
+                            {
+                                "@type": "@64"
                             }
-                        ],
-                        "count": 53,
-                        "idx": 53
+                        ]
                     },
                     "statements": [
                         {

--- a/tests/data/parser/parseExplain4.out
+++ b/tests/data/parser/parseExplain4.out
@@ -7,13 +7,19 @@
         "last": 36,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 14,
+            "idx": 14,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "EXPLAIN",
                     "value": "EXPLAIN",
                     "keyword": "EXPLAIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "FORMAT",
                     "value": "FORMAT",
                     "keyword": "FORMAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 8
                 },
@@ -40,7 +52,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 14
                 },
@@ -49,7 +65,11 @@
                     "token": "TREE",
                     "value": "TREE",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,7 +111,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 27
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -103,7 +133,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": "db",
                     "value": "db",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -130,13 +166,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 14,
-            "idx": 14
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -155,19 +193,9 @@
                     "@type": "PhpMyAdmin\\SqlParser\\Parser",
                     "list": {
                         "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                        "count": 8,
+                        "idx": 8,
                         "tokens": [
-                            {
-                                "@type": "@8"
-                            },
-                            {
-                                "@type": "@9"
-                            },
-                            {
-                                "@type": "@10"
-                            },
-                            {
-                                "@type": "@11"
-                            },
                             {
                                 "@type": "@12"
                             },
@@ -179,10 +207,20 @@
                             },
                             {
                                 "@type": "@15"
+                            },
+                            {
+                                "@type": "@16"
+                            },
+                            {
+                                "@type": "@17"
+                            },
+                            {
+                                "@type": "@18"
+                            },
+                            {
+                                "@type": "@19"
                             }
-                        ],
-                        "count": 8,
-                        "idx": 8
+                        ]
                     },
                     "statements": [
                         {

--- a/tests/data/parser/parseExplain5.out
+++ b/tests/data/parser/parseExplain5.out
@@ -7,13 +7,19 @@
         "last": 27,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 7,
+            "idx": 7,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DESC",
                     "value": "DESC",
                     "keyword": "DESC",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "phpmyadmin",
                     "value": "phpmyadmin",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -40,7 +54,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 15
                 },
@@ -49,7 +67,9 @@
                     "token": "pma__users",
                     "value": "pma__users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -58,7 +78,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -67,13 +91,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 7,
-            "idx": 7
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseExplain6.out
+++ b/tests/data/parser/parseExplain6.out
@@ -7,13 +7,19 @@
         "last": 20,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 8,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DESCRIBE",
                     "value": "DESCRIBE",
                     "keyword": "DESCRIBE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -31,7 +41,11 @@
                     "token": "Shop",
                     "value": "Shop",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +65,11 @@
                     "token": "'N%'",
                     "value": "N%",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 14
                 },
@@ -58,7 +78,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +91,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,13 +102,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 8
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseExplain7.out
+++ b/tests/data/parser/parseExplain7.out
@@ -7,13 +7,19 @@
         "last": 21,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 7,
+            "idx": 7,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DESCRIBE",
                     "value": "DESCRIBE",
                     "keyword": "DESCRIBE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -31,7 +41,11 @@
                     "token": "Shop",
                     "value": "Shop",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +65,11 @@
                     "token": "'Name'",
                     "value": "Name",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 14
                 },
@@ -58,7 +78,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,13 +91,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 7,
-            "idx": 7
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseExplain8.out
+++ b/tests/data/parser/parseExplain8.out
@@ -7,13 +7,19 @@
         "last": 19,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 7,
+            "idx": 7,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DESCRIBE",
                     "value": "DESCRIBE",
                     "keyword": "DESCRIBE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -31,7 +41,11 @@
                     "token": "Shop",
                     "value": "Shop",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +65,9 @@
                     "token": "N__e",
                     "value": "N__e",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,13 +89,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 7,
-            "idx": 7
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseExplain9.out
+++ b/tests/data/parser/parseExplain9.out
@@ -7,13 +7,19 @@
         "last": 22,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 6,
+            "idx": 6,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "DESCRIBE",
                     "value": "DESCRIBE",
                     "keyword": "DESCRIBE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -31,7 +41,11 @@
                     "token": "tablename",
                     "value": "tablename",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -49,7 +65,11 @@
                     "token": "581",
                     "value": 581,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -58,13 +78,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 6,
-            "idx": 6
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseExplainErr.out
+++ b/tests/data/parser/parseExplainErr.out
@@ -7,13 +7,19 @@
         "last": 20,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 8,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "EXPLAIN",
                     "value": "EXPLAIN",
                     "keyword": "EXPLAIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "FOR",
                     "value": "FOR",
                     "keyword": "FOR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 12
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +85,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 1,
                     "position": 19
                 },
@@ -76,13 +98,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 8
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -156,7 +180,7 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@4"
+                    "@type": "@6"
                 },
                 0
             ]

--- a/tests/data/parser/parseExplainErr1.out
+++ b/tests/data/parser/parseExplainErr1.out
@@ -7,13 +7,19 @@
         "last": 19,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 6,
+            "idx": 7,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "ANALYZE",
                     "value": "ANALYZE",
                     "keyword": "ANALYZE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 15
                 },
@@ -58,13 +74,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 6,
-            "idx": 7
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -83,22 +101,22 @@
                     "@type": "PhpMyAdmin\\SqlParser\\Parser",
                     "list": {
                         "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                        "count": 4,
+                        "idx": 4,
                         "tokens": [
-                            {
-                                "@type": "@4"
-                            },
-                            {
-                                "@type": "@5"
-                            },
                             {
                                 "@type": "@6"
                             },
                             {
                                 "@type": "@7"
+                            },
+                            {
+                                "@type": "@8"
+                            },
+                            {
+                                "@type": "@9"
                             }
-                        ],
-                        "count": 4,
-                        "idx": 4
+                        ]
                     },
                     "statements": [
                         {
@@ -132,22 +150,22 @@
                         {
                             "@type": "PhpMyAdmin\\SqlParser\\Exceptions\\ParserException",
                             "token": {
-                                "@type": "@6"
+                                "@type": "@8"
                             },
                             "message": "An expression was expected.",
                             "code": 0,
                             "file": "<project-root>/src/Parser.php",
-                            "line": 628
+                            "line": 620
                         },
                         {
                             "@type": "PhpMyAdmin\\SqlParser\\Exceptions\\ParserException",
                             "token": {
-                                "@type": "@7"
+                                "@type": "@9"
                             },
                             "message": "An expression was expected.",
                             "code": 0,
                             "file": "<project-root>/src/Parser.php",
-                            "line": 628
+                            "line": 620
                         }
                     ]
                 },
@@ -174,21 +192,21 @@
             [
                 "An expression was expected.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ],
             [
                 "An expression was expected.",
                 {
-                    "@type": "@7"
+                    "@type": "@9"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ]

--- a/tests/data/parser/parseExplainErr2.out
+++ b/tests/data/parser/parseExplainErr2.out
@@ -7,13 +7,19 @@
         "last": 26,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "EXPLAIN",
                     "value": "EXPLAIN",
                     "keyword": "EXPLAIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "ANALYZE",
                     "value": "ANALYZE",
                     "keyword": "ANALYZE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 16
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +85,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -76,13 +96,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -121,14 +143,14 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@8"
+                    "@type": "@10"
                 },
                 0
             ]

--- a/tests/data/parser/parseExplainErr3.out
+++ b/tests/data/parser/parseExplainErr3.out
@@ -7,13 +7,19 @@
         "last": 8,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 3,
+            "idx": 3,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "EXPLAIN",
                     "value": "EXPLAIN",
                     "keyword": "EXPLAIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,13 +41,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 3,
-            "idx": 3
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -73,7 +85,7 @@
             [
                 "Expected a table name.",
                 {
-                    "@type": "@3"
+                    "@type": "@4"
                 },
                 0
             ]

--- a/tests/data/parser/parseInsert.out
+++ b/tests/data/parser/parseInsert.out
@@ -7,13 +7,19 @@
         "last": 176,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 41,
+            "idx": 41,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "LOW_PRIORITY",
                     "value": "LOW_PRIORITY",
                     "keyword": "LOW_PRIORITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -49,7 +63,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -58,7 +74,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -67,7 +85,11 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -76,7 +98,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 34
                 },
@@ -85,7 +111,11 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 35
                 },
@@ -94,7 +124,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 39
                 },
@@ -103,7 +135,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -112,7 +146,9 @@
                     "token": "`username`",
                     "value": "username",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 41
                 },
@@ -121,7 +157,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 51
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -139,7 +179,9 @@
                     "token": "`password`",
                     "value": "password",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 2,
                     "position": 53
                 },
@@ -148,7 +190,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 63
                 },
@@ -157,7 +201,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -166,7 +212,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 65
                 },
@@ -175,7 +223,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -184,7 +234,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 76
                 },
@@ -193,7 +245,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -202,7 +258,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 78
                 },
@@ -211,7 +269,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -220,7 +280,11 @@
                     "token": "\"Dan\"",
                     "value": "Dan",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 80
                 },
@@ -229,7 +293,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 85
                 },
@@ -238,7 +304,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -247,7 +315,9 @@
                     "token": "\"5d41402abc4b2a76b9719d911017c592\"",
                     "value": "5d41402abc4b2a76b9719d911017c592",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@32"
+                    },
                     "flags": 2,
                     "position": 87
                 },
@@ -256,7 +326,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 121
                 },
@@ -265,7 +337,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 122
                 },
@@ -274,7 +348,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -283,7 +359,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 128
                 },
@@ -292,7 +370,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -301,7 +381,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 130
                 },
@@ -310,7 +392,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -319,7 +403,9 @@
                     "token": "\"Paul\"",
                     "value": "Paul",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@32"
+                    },
                     "flags": 2,
                     "position": 132
                 },
@@ -328,7 +414,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 138
                 },
@@ -337,7 +425,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -346,7 +436,9 @@
                     "token": "\"7d793037a0760186574b0282f2f435e7\"",
                     "value": "7d793037a0760186574b0282f2f435e7",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@32"
+                    },
                     "flags": 2,
                     "position": 140
                 },
@@ -355,7 +447,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 174
                 },
@@ -364,7 +458,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 175
                 },
@@ -373,13 +471,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@49"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 41,
-            "idx": 41
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseInsertErr.out
+++ b/tests/data/parser/parseInsertErr.out
@@ -7,13 +7,19 @@
         "last": 14,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 5,
+            "idx": 5,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,13 +63,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 5,
-            "idx": 5
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -118,14 +134,14 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@4"
+                    "@type": "@6"
                 },
                 0
             ],
             [
                 "An expression was expected.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ]

--- a/tests/data/parser/parseInsertErr2.out
+++ b/tests/data/parser/parseInsertErr2.out
@@ -7,13 +7,19 @@
         "last": 24,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 9,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,9 @@
                     "token": "x",
                     "value": "x",
                     "keyword": "X",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 12
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +85,11 @@
                     "token": "\"string\"",
                     "value": "string",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 14
                 },
@@ -76,7 +98,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,13 +109,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 9,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -148,14 +174,14 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@8"
+                    "@type": "@10"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@8"
+                    "@type": "@10"
                 },
                 0
             ]

--- a/tests/data/parser/parseInsertFunction.out
+++ b/tests/data/parser/parseInsertFunction.out
@@ -7,13 +7,19 @@
         "last": 63,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 25,
+            "idx": 25,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "labels",
                     "value": "labels",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 18
                 },
@@ -67,7 +89,11 @@
                     "token": "`label`",
                     "value": "label",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 19
                 },
@@ -76,7 +102,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 26
                 },
@@ -85,7 +113,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -94,7 +124,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 28
                 },
@@ -103,7 +135,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -112,7 +146,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -121,7 +157,9 @@
                     "token": "concat",
                     "value": "concat",
                     "keyword": "CONCAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 36
                 },
@@ -130,7 +168,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -139,7 +179,11 @@
                     "token": "'A'",
                     "value": "A",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 43
                 },
@@ -148,7 +192,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 46
                 },
@@ -157,7 +203,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -166,7 +214,9 @@
                     "token": "' '",
                     "value": " ",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 48
                 },
@@ -175,7 +225,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 51
                 },
@@ -184,7 +236,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -193,7 +247,9 @@
                     "token": "'label'",
                     "value": "label",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 53
                 },
@@ -202,7 +258,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 60
                 },
@@ -211,7 +269,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 61
                 },
@@ -220,7 +280,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -229,13 +293,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@32"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 25,
-            "idx": 25
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseInsertIntoErr.out
+++ b/tests/data/parser/parseInsertIntoErr.out
@@ -7,13 +7,19 @@
         "last": 22,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 9,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,9 @@
                     "token": "x",
                     "value": "x",
                     "keyword": "X",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 12
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +85,9 @@
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 14
                 },
@@ -76,7 +96,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,13 +107,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 9,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -163,7 +187,7 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@8"
+                    "@type": "@10"
                 },
                 0
             ]

--- a/tests/data/parser/parseInsertIntoSet.out
+++ b/tests/data/parser/parseInsertIntoSet.out
@@ -7,13 +7,19 @@
         "last": 50,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 15,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "aa",
                     "value": "aa",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -67,7 +87,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 15
                 },
@@ -76,7 +98,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -85,7 +109,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 20
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -103,7 +133,9 @@
                     "token": "INET6_ATON",
                     "value": "INET6_ATON",
                     "keyword": "INET6_ATON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 22
                 },
@@ -112,7 +144,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -121,7 +155,11 @@
                     "token": "'::ffff:8.8.8.8'",
                     "value": "::ffff:8.8.8.8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 33
                 },
@@ -130,7 +168,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 49
                 },
@@ -139,13 +179,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 15
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseInsertOnDuplicateKey.out
+++ b/tests/data/parser/parseInsertOnDuplicateKey.out
@@ -7,13 +7,19 @@
         "last": 103,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 36,
+            "idx": 36,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`champs`",
                     "value": "champs",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 21
                 },
@@ -76,7 +100,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 22
                 },
@@ -85,7 +111,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 26
                 },
@@ -94,7 +122,9 @@
                     "token": "`val`",
                     "value": "val",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -103,7 +133,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -139,7 +177,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -148,7 +188,11 @@
                     "token": "412",
                     "value": 412,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 45
                 },
@@ -166,7 +212,11 @@
                     "token": "'Thresh'",
                     "value": "Thresh",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 46
                 },
@@ -175,7 +225,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 54
                 },
@@ -184,7 +236,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -193,7 +247,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 56
                 },
@@ -202,7 +258,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -211,7 +269,9 @@
                     "token": "DUPLICATE",
                     "value": "DUPLICATE",
                     "keyword": "DUPLICATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 59
                 },
@@ -220,7 +280,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -229,7 +291,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 69
                 },
@@ -238,7 +302,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -247,7 +313,9 @@
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -256,7 +324,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -265,7 +335,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 80
                 },
@@ -274,7 +346,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 84
                 },
@@ -283,7 +357,9 @@
                     "token": "412",
                     "value": 412,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -292,7 +368,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 88
                 },
@@ -301,7 +379,9 @@
                     "token": "`val`",
                     "value": "val",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 89
                 },
@@ -310,7 +390,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 94
                 },
@@ -319,7 +401,9 @@
                     "token": "'Thresh'",
                     "value": "Thresh",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 1,
                     "position": 95
                 },
@@ -328,13 +412,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 36,
-            "idx": 36
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseInsertOnDuplicateKeyErr.out
+++ b/tests/data/parser/parseInsertOnDuplicateKeyErr.out
@@ -7,13 +7,19 @@
         "last": 96,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 34,
+            "idx": 34,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`champs`",
                     "value": "champs",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 21
                 },
@@ -76,7 +100,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 22
                 },
@@ -85,7 +111,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 26
                 },
@@ -94,7 +122,9 @@
                     "token": "`val`",
                     "value": "val",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -103,7 +133,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -139,7 +177,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -148,7 +188,11 @@
                     "token": "412",
                     "value": 412,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 45
                 },
@@ -166,7 +212,11 @@
                     "token": "'Thresh'",
                     "value": "Thresh",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 46
                 },
@@ -175,7 +225,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 54
                 },
@@ -184,7 +236,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -193,7 +247,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 56
                 },
@@ -202,7 +258,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -211,7 +269,9 @@
                     "token": "DUPLICATE",
                     "value": "DUPLICATE",
                     "keyword": "DUPLICATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 59
                 },
@@ -220,7 +280,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -229,7 +291,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 69
                 },
@@ -238,7 +302,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -247,7 +313,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 73
                 },
@@ -256,7 +324,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 77
                 },
@@ -265,7 +335,9 @@
                     "token": "412",
                     "value": 412,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -274,7 +346,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 81
                 },
@@ -283,7 +357,9 @@
                     "token": "`val`",
                     "value": "val",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 82
                 },
@@ -292,7 +368,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 87
                 },
@@ -301,7 +379,9 @@
                     "token": "'Thresh'",
                     "value": "Thresh",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 1,
                     "position": 88
                 },
@@ -310,13 +390,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 34,
-            "idx": 34
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -388,28 +470,7 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@28"
-                },
-                0
-            ],
-            [
-                "Unexpected beginning of statement.",
-                {
-                    "@type": "@28"
-                },
-                0
-            ],
-            [
-                "Unexpected beginning of statement.",
-                {
-                    "@type": "@30"
-                },
-                0
-            ],
-            [
-                "Unexpected beginning of statement.",
-                {
-                    "@type": "@32"
+                    "@type": "@34"
                 },
                 0
             ],
@@ -417,6 +478,27 @@
                 "Unexpected beginning of statement.",
                 {
                     "@type": "@34"
+                },
+                0
+            ],
+            [
+                "Unexpected beginning of statement.",
+                {
+                    "@type": "@36"
+                },
+                0
+            ],
+            [
+                "Unexpected beginning of statement.",
+                {
+                    "@type": "@38"
+                },
+                0
+            ],
+            [
+                "Unexpected beginning of statement.",
+                {
+                    "@type": "@40"
                 },
                 0
             ]

--- a/tests/data/parser/parseInsertSelect.out
+++ b/tests/data/parser/parseInsertSelect.out
@@ -7,13 +7,19 @@
         "last": 53,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 20,
+            "idx": 20,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 16
                 },
@@ -76,7 +100,9 @@
                     "token": "`value`",
                     "value": "value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 17
                 },
@@ -85,7 +111,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 24
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 26
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -121,7 +155,9 @@
                     "token": "`b`",
                     "value": "b",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 33
                 },
@@ -130,7 +166,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 36
                 },
@@ -139,7 +177,9 @@
                     "token": "`value`",
                     "value": "value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 37
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -157,7 +199,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -175,7 +221,9 @@
                     "token": "`b`",
                     "value": "b",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 50
                 },
@@ -184,13 +232,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 20,
-            "idx": 20
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseInsertSelectOnDuplicateKey.out
+++ b/tests/data/parser/parseInsertSelectOnDuplicateKey.out
@@ -7,13 +7,19 @@
         "last": 65,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 28,
+            "idx": 28,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "tbl",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 16
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,7 +109,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 23
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -103,7 +133,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 25
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -121,7 +155,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -139,7 +177,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 34
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -157,7 +199,9 @@
                     "token": "DUPLICATE",
                     "value": "DUPLICATE",
                     "keyword": "DUPLICATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 37
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -175,7 +221,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 47
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -193,7 +243,9 @@
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 51
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -211,7 +265,9 @@
                     "token": "baz",
                     "value": "baz",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -229,7 +287,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 62
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -247,7 +309,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -256,13 +322,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 28,
-            "idx": 28
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseInsertSet.out
+++ b/tests/data/parser/parseInsertSet.out
@@ -7,13 +7,19 @@
         "last": 45,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 18,
+            "idx": 18,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 16
                 },
@@ -76,7 +100,9 @@
                     "token": "`value`",
                     "value": "value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 17
                 },
@@ -85,7 +111,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 24
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 26
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -121,7 +155,9 @@
                     "token": "`value`",
                     "value": "value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 30
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -139,7 +177,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 38
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -157,7 +199,11 @@
                     "token": "'123'",
                     "value": "123",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 40
                 },
@@ -166,13 +212,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 18,
-            "idx": 18
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseInsertSetOnDuplicateKey.out
+++ b/tests/data/parser/parseInsertSetOnDuplicateKey.out
@@ -7,13 +7,19 @@
         "last": 86,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 32,
+            "idx": 32,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 16
                 },
@@ -76,7 +100,9 @@
                     "token": "`value`",
                     "value": "value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 17
                 },
@@ -85,7 +111,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 24
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 26
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -121,7 +155,9 @@
                     "token": "`value`",
                     "value": "value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 30
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -139,7 +177,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 38
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -157,7 +199,11 @@
                     "token": "'123'",
                     "value": "123",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 40
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +223,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 46
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -193,7 +245,9 @@
                     "token": "DUPLICATE",
                     "value": "DUPLICATE",
                     "keyword": "DUPLICATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 49
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -211,7 +267,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 59
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -229,7 +289,9 @@
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 63
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -247,7 +311,9 @@
                     "token": "`value`",
                     "value": "value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 70
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -265,7 +333,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 78
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -283,7 +355,9 @@
                     "token": "'1234'",
                     "value": "1234",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 1,
                     "position": 80
                 },
@@ -292,13 +366,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 32,
-            "idx": 32
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLimitErr1.out
+++ b/tests/data/parser/parseLimitErr1.out
@@ -7,13 +7,19 @@
         "last": 43,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 19,
+            "idx": 19,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -85,7 +111,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -103,7 +133,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -121,7 +157,9 @@
                     "token": "OFFSET",
                     "value": "OFFSET",
                     "keyword": "OFFSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 27
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -139,7 +179,9 @@
                     "token": "OFFSET",
                     "value": "OFFSET",
                     "keyword": "OFFSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 34
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -157,7 +201,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -166,7 +212,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -175,13 +225,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 19,
-            "idx": 19
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -255,7 +305,7 @@
             [
                 "An offset was expected.",
                 {
-                    "@type": "@16"
+                    "@type": "@21"
                 },
                 0
             ]

--- a/tests/data/parser/parseLimitErr2.out
+++ b/tests/data/parser/parseLimitErr2.out
@@ -7,13 +7,19 @@
         "last": 33,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 14,
+            "idx": 14,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -85,7 +111,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -103,7 +133,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -121,7 +157,9 @@
                     "token": "OFFSET",
                     "value": "OFFSET",
                     "keyword": "OFFSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 27
                 },
@@ -130,13 +168,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 14,
-            "idx": 14
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -210,7 +250,7 @@
             [
                 "An offset was expected.",
                 {
-                    "@type": "@14"
+                    "@type": "@19"
                 },
                 0
             ]

--- a/tests/data/parser/parseLoad1.out
+++ b/tests/data/parser/parseLoad1.out
@@ -7,13 +7,19 @@
         "last": 64,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 15,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOAD DATA",
                     "value": "LOAD DATA",
                     "keyword": "LOAD DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,9 @@
                     "token": "CONCURRENT",
                     "value": "CONCURRENT",
                     "keyword": "CONCURRENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -49,7 +63,9 @@
                     "token": "INFILE",
                     "value": "INFILE",
                     "keyword": "INFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -67,7 +85,11 @@
                     "token": "'employee1.txt'",
                     "value": "employee1.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 28
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -85,7 +109,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -103,7 +131,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 49
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -121,7 +153,11 @@
                     "token": "employee",
                     "value": "employee",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -130,7 +166,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -139,13 +179,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 15
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLoad2.out
+++ b/tests/data/parser/parseLoad2.out
@@ -7,13 +7,19 @@
         "last": 89,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 25,
+            "idx": 25,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOAD DATA",
                     "value": "LOAD DATA",
                     "keyword": "LOAD DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,9 @@
                     "token": "INFILE",
                     "value": "INFILE",
                     "keyword": "INFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +63,11 @@
                     "token": "'/tmp/test.txt'",
                     "value": "/tmp/test.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +87,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -85,7 +109,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 38
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -103,7 +131,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -121,7 +155,9 @@
                     "token": "FIELDS",
                     "value": "FIELDS",
                     "keyword": "FIELDS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 49
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -139,7 +177,9 @@
                     "token": "TERMINATED BY",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 56
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -157,7 +199,9 @@
                     "token": "','",
                     "value": ",",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 70
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -175,7 +221,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 74
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -193,7 +243,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -211,7 +267,9 @@
                     "token": "LINES",
                     "value": "LINES",
                     "keyword": "LINES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 83
                 },
@@ -220,7 +278,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -229,13 +291,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 25,
-            "idx": 25
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLoad3.out
+++ b/tests/data/parser/parseLoad3.out
@@ -7,13 +7,19 @@
         "last": 94,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 23,
+            "idx": 23,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOAD DATA",
                     "value": "LOAD DATA",
                     "keyword": "LOAD DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,9 @@
                     "token": "INFILE",
                     "value": "INFILE",
                     "keyword": "INFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +63,11 @@
                     "token": "'employee3.txt'",
                     "value": "employee3.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +87,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -85,7 +109,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 38
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -103,7 +131,11 @@
                     "token": "employee",
                     "value": "employee",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -121,7 +155,9 @@
                     "token": "FIELDS",
                     "value": "FIELDS",
                     "keyword": "FIELDS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 53
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -139,7 +177,9 @@
                     "token": "TERMINATED BY",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 60
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -157,7 +199,9 @@
                     "token": "','",
                     "value": ",",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 74
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -175,7 +221,9 @@
                     "token": "ENCLOSED BY",
                     "value": "ENCLOSED BY",
                     "keyword": "ENCLOSED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 78
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -193,7 +243,9 @@
                     "token": "'\"'",
                     "value": "\"",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 90
                 },
@@ -202,7 +254,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -211,13 +267,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 23,
-            "idx": 23
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLoad4.out
+++ b/tests/data/parser/parseLoad4.out
@@ -7,13 +7,19 @@
         "last": 166,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 52,
+            "idx": 52,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOAD DATA",
                     "value": "LOAD DATA",
                     "keyword": "LOAD DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,9 @@
                     "token": "INFILE",
                     "value": "INFILE",
                     "keyword": "INFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +63,11 @@
                     "token": "'/tmp/test.txt'",
                     "value": "/tmp/test.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +87,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -76,7 +98,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -85,7 +109,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -103,7 +131,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -121,7 +153,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -130,7 +166,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -139,7 +177,9 @@
                     "token": "CHARACTER SET",
                     "value": "CHARACTER SET",
                     "keyword": "CHARACTER SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 56
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -157,7 +199,9 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 70
                 },
@@ -166,7 +210,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -175,7 +221,9 @@
                     "token": "COLUMNS",
                     "value": "COLUMNS",
                     "keyword": "COLUMNS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 77
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -193,7 +243,9 @@
                     "token": "TERMINATED BY",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 85
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -211,7 +265,9 @@
                     "token": "','",
                     "value": ",",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 99
                 },
@@ -220,7 +276,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -229,7 +287,9 @@
                     "token": "LINES",
                     "value": "LINES",
                     "keyword": "LINES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 103
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -247,7 +309,9 @@
                     "token": "TERMINATED BY",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 109
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -265,7 +331,9 @@
                     "token": "';'",
                     "value": ";",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 123
                 },
@@ -274,7 +342,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -283,7 +353,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 127
                 },
@@ -292,7 +364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -301,7 +375,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 134
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -319,7 +399,9 @@
                     "token": "LINES",
                     "value": "LINES",
                     "keyword": "LINES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 136
                 },
@@ -328,7 +410,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -337,7 +421,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 142
                 },
@@ -346,7 +434,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -355,7 +445,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@44"
+                    },
                     "flags": 16,
                     "position": 147
                 },
@@ -364,7 +456,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -373,7 +467,9 @@
                     "token": "col2",
                     "value": "col2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -382,7 +478,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@44"
+                    },
                     "flags": 16,
                     "position": 153
                 },
@@ -391,7 +489,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -400,7 +500,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 155
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -418,7 +522,11 @@
                     "token": "@a",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 159
                 },
@@ -427,7 +535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 161
                 },
@@ -436,7 +546,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@44"
+                    },
                     "flags": 2,
                     "position": 162
                 },
@@ -445,7 +557,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 163
                 },
@@ -454,7 +568,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": 164
                 },
@@ -463,7 +579,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 165
                 },
@@ -472,13 +592,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@60"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 52,
-            "idx": 52
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLoad5.out
+++ b/tests/data/parser/parseLoad5.out
@@ -7,13 +7,19 @@
         "last": 98,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 27,
+            "idx": 27,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOAD DATA",
                     "value": "LOAD DATA",
                     "keyword": "LOAD DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,9 @@
                     "token": "INFILE",
                     "value": "INFILE",
                     "keyword": "INFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +63,11 @@
                     "token": "'/tmp/test.txt'",
                     "value": "/tmp/test.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +87,9 @@
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 34
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -85,7 +109,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -103,7 +131,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 47
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -121,7 +153,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -139,7 +177,9 @@
                     "token": "COLUMNS",
                     "value": "COLUMNS",
                     "keyword": "COLUMNS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 58
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -157,7 +199,9 @@
                     "token": "TERMINATED BY",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 66
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -175,7 +221,9 @@
                     "token": "','",
                     "value": ",",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 80
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -193,7 +243,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 84
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -211,7 +265,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -229,7 +289,9 @@
                     "token": "ROWS",
                     "value": "ROWS",
                     "keyword": "ROWS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 93
                 },
@@ -238,7 +300,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -247,13 +313,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 27,
-            "idx": 27
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLoad6.out
+++ b/tests/data/parser/parseLoad6.out
@@ -7,13 +7,19 @@
         "last": 189,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 64,
+            "idx": 64,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOAD DATA",
                     "value": "LOAD DATA",
                     "keyword": "LOAD DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,9 @@
                     "token": "INFILE",
                     "value": "INFILE",
                     "keyword": "INFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +63,11 @@
                     "token": "'/tmp/test.txt'",
                     "value": "/tmp/test.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +87,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -76,7 +98,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -85,7 +109,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -103,7 +131,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -121,7 +153,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -130,7 +166,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -139,7 +177,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 56
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -157,7 +199,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 66
                 },
@@ -166,7 +212,9 @@
                     "token": "p0",
                     "value": "p0",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -175,7 +223,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 69
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 73
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -220,7 +278,9 @@
                     "token": "p2",
                     "value": "p2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -238,7 +300,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -247,7 +311,9 @@
                     "token": "CHARACTER SET",
                     "value": "CHARACTER SET",
                     "keyword": "CHARACTER SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 79
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -265,7 +333,9 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 93
                 },
@@ -274,7 +344,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -283,7 +355,9 @@
                     "token": "COLUMNS",
                     "value": "COLUMNS",
                     "keyword": "COLUMNS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 100
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -301,7 +377,9 @@
                     "token": "TERMINATED BY",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 108
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -319,7 +399,9 @@
                     "token": "','",
                     "value": ",",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 122
                 },
@@ -328,7 +410,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -337,7 +421,9 @@
                     "token": "LINES",
                     "value": "LINES",
                     "keyword": "LINES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 126
                 },
@@ -346,7 +432,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -355,7 +443,9 @@
                     "token": "TERMINATED BY",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 132
                 },
@@ -364,7 +454,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 145
                 },
@@ -373,7 +465,9 @@
                     "token": "';'",
                     "value": ";",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 146
                 },
@@ -382,7 +476,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -391,7 +487,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 150
                 },
@@ -400,7 +498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 156
                 },
@@ -409,7 +509,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -418,7 +522,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -427,7 +533,9 @@
                     "token": "LINES",
                     "value": "LINES",
                     "keyword": "LINES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 159
                 },
@@ -436,7 +544,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 164
                 },
@@ -445,7 +555,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 165
                 },
@@ -454,7 +566,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 166
                 },
@@ -463,7 +577,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 170
                 },
@@ -472,7 +588,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 171
                 },
@@ -481,7 +599,9 @@
                     "token": "col2",
                     "value": "col2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 172
                 },
@@ -490,7 +610,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 16,
                     "position": 176
                 },
@@ -499,7 +621,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 177
                 },
@@ -508,7 +632,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 178
                 },
@@ -517,7 +643,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 181
                 },
@@ -526,7 +654,11 @@
                     "token": "@a",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 182
                 },
@@ -535,7 +667,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 184
                 },
@@ -544,7 +678,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 2,
                     "position": 185
                 },
@@ -553,7 +689,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 186
                 },
@@ -562,7 +700,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@52"
+                    },
                     "flags": 0,
                     "position": 187
                 },
@@ -571,7 +711,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 188
                 },
@@ -580,13 +724,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@72"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 64,
-            "idx": 64
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLoad7.out
+++ b/tests/data/parser/parseLoad7.out
@@ -7,13 +7,19 @@
         "last": 109,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 28,
+            "idx": 28,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "into",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,9 @@
                     "token": "outfile",
                     "value": "OUTFILE",
                     "keyword": "OUTFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 14
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,11 @@
                     "token": "'/tmp/temp.data'",
                     "value": "/tmp/temp.data",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -103,7 +133,9 @@
                     "token": "fields",
                     "value": "fields",
                     "keyword": "FIELDS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 39
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -121,7 +155,9 @@
                     "token": "terminated by",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 46
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -139,7 +177,9 @@
                     "token": "','",
                     "value": ",",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 1,
                     "position": 60
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -157,7 +199,9 @@
                     "token": "enclosed by",
                     "value": "ENCLOSED BY",
                     "keyword": "ENCLOSED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 64
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -175,7 +221,9 @@
                     "token": "'\"'",
                     "value": "\"",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -193,7 +243,9 @@
                     "token": "ESCAPED BY",
                     "value": "ESCAPED BY",
                     "keyword": "ESCAPED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 80
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -211,7 +265,9 @@
                     "token": "'$'",
                     "value": "$",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 1,
                     "position": 91
                 },
@@ -220,7 +276,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -229,7 +287,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 95
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -247,7 +309,9 @@
                     "token": "sometable",
                     "value": "sometable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -256,13 +320,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 28,
-            "idx": 28
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLoadErr1.out
+++ b/tests/data/parser/parseLoadErr1.out
@@ -7,13 +7,19 @@
         "last": 62,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 15,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOAD DATA",
                     "value": "LOAD DATA",
                     "keyword": "LOAD DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,9 @@
                     "token": "CONCURRENT",
                     "value": "CONCURRENT",
                     "keyword": "CONCURRENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -49,7 +63,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -67,7 +85,11 @@
                     "token": "'employee1.txt'",
                     "value": "employee1.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 26
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -85,7 +109,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -103,7 +131,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 47
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -121,7 +153,11 @@
                     "token": "employee",
                     "value": "employee",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -130,7 +166,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -139,13 +179,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 15
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -192,14 +232,14 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ]

--- a/tests/data/parser/parseLoadErr2.out
+++ b/tests/data/parser/parseLoadErr2.out
@@ -7,13 +7,19 @@
         "last": 61,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 15,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOAD DATA",
                     "value": "LOAD DATA",
                     "keyword": "LOAD DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,9 @@
                     "token": "CONCURRENT",
                     "value": "CONCURRENT",
                     "keyword": "CONCURRENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 10
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -49,7 +63,11 @@
                     "token": "ABC",
                     "value": "ABC",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -67,7 +87,11 @@
                     "token": "'employee1.txt'",
                     "value": "employee1.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 25
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -85,7 +111,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 41
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -103,7 +133,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 46
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -121,7 +155,9 @@
                     "token": "employee",
                     "value": "employee",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -130,7 +166,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -139,13 +179,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 15
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -192,14 +232,7 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@6"
-                },
-                0
-            ],
-            [
-                "Unexpected beginning of statement.",
-                {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ],
@@ -211,9 +244,16 @@
                 0
             ],
             [
+                "Unexpected beginning of statement.",
+                {
+                    "@type": "@11"
+                },
+                0
+            ],
+            [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@10"
+                    "@type": "@14"
                 },
                 0
             ]

--- a/tests/data/parser/parseLoadErr3.out
+++ b/tests/data/parser/parseLoadErr3.out
@@ -7,13 +7,19 @@
         "last": 68,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 23,
+            "idx": 23,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOAD DATA",
                     "value": "LOAD DATA",
                     "keyword": "LOAD DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,9 @@
                     "token": "INFILE",
                     "value": "INFILE",
                     "keyword": "INFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +63,11 @@
                     "token": "'/tmp/test.txt'",
                     "value": "/tmp/test.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +87,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -76,7 +98,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -85,7 +109,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -103,7 +131,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -121,7 +153,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -130,7 +166,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -139,7 +177,9 @@
                     "token": "DATA",
                     "value": "DATA",
                     "keyword": "DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 56
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -157,7 +199,11 @@
                     "token": "@a",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 61
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -175,7 +223,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 64
                 },
@@ -184,7 +236,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -193,7 +247,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -202,7 +260,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -211,13 +273,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 23,
-            "idx": 23
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -281,7 +343,7 @@
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@16"
+                    "@type": "@20"
                 },
                 0
             ]

--- a/tests/data/parser/parseLoadErr4.out
+++ b/tests/data/parser/parseLoadErr4.out
@@ -7,13 +7,19 @@
         "last": 62,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOAD DATA",
                     "value": "LOAD DATA",
                     "keyword": "LOAD DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,9 @@
                     "token": "INFILE",
                     "value": "INFILE",
                     "keyword": "INFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +63,11 @@
                     "token": "'/tmp/test.txt'",
                     "value": "/tmp/test.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +87,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -76,7 +98,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -85,7 +109,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -103,7 +131,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -112,7 +144,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -121,7 +155,9 @@
                     "token": "DATA",
                     "value": "DATA",
                     "keyword": "DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -139,7 +177,11 @@
                     "token": "@a",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 55
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -157,7 +201,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 58
                 },
@@ -166,7 +214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -175,7 +225,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -184,7 +238,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -193,13 +251,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -254,21 +312,21 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@12"
+                    "@type": "@15"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@12"
+                    "@type": "@15"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@14"
+                    "@type": "@18"
                 },
                 0
             ]

--- a/tests/data/parser/parseLoadErr5.out
+++ b/tests/data/parser/parseLoadErr5.out
@@ -7,13 +7,19 @@
         "last": 63,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOAD DATA",
                     "value": "LOAD DATA",
                     "keyword": "LOAD DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,9 @@
                     "token": "INFILE",
                     "value": "INFILE",
                     "keyword": "INFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +63,11 @@
                     "token": "'/tmp/test.txt'",
                     "value": "/tmp/test.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +87,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -76,7 +98,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -85,7 +109,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -103,7 +131,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -121,7 +153,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -130,7 +166,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -139,7 +177,11 @@
                     "token": "@a",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 56
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -157,7 +201,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 59
                 },
@@ -166,7 +214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -175,7 +225,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -184,7 +238,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -193,13 +251,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -263,14 +321,7 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@16"
-                },
-                0
-            ],
-            [
-                "Unexpected beginning of statement.",
-                {
-                    "@type": "@16"
+                    "@type": "@20"
                 },
                 0
             ],
@@ -278,6 +329,13 @@
                 "Unexpected beginning of statement.",
                 {
                     "@type": "@20"
+                },
+                0
+            ],
+            [
+                "Unexpected beginning of statement.",
+                {
+                    "@type": "@26"
                 },
                 0
             ]

--- a/tests/data/parser/parseLoadErr6.out
+++ b/tests/data/parser/parseLoadErr6.out
@@ -7,13 +7,19 @@
         "last": 68,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 23,
+            "idx": 23,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOAD DATA",
                     "value": "LOAD DATA",
                     "keyword": "LOAD DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -31,7 +41,9 @@
                     "token": "INFILE",
                     "value": "INFILE",
                     "keyword": "INFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +63,11 @@
                     "token": "'/tmp/test.txt'",
                     "value": "/tmp/test.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +87,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -76,7 +98,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -85,7 +109,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -103,7 +131,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -121,7 +153,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -130,7 +166,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -139,7 +177,9 @@
                     "token": "DATA",
                     "value": "DATA",
                     "keyword": "DATA",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 56
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -157,7 +199,11 @@
                     "token": "@a",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 61
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -175,7 +223,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 64
                 },
@@ -184,7 +236,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -193,7 +247,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -202,7 +260,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -211,13 +273,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 23,
-            "idx": 23
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -281,7 +343,7 @@
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@16"
+                    "@type": "@20"
                 },
                 0
             ]

--- a/tests/data/parser/parseLock1.out
+++ b/tests/data/parser/parseLock1.out
@@ -7,13 +7,19 @@
         "last": 43,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 15,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": "   ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +109,11 @@
                     "token": "`t1`",
                     "value": "t1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 24
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -103,7 +133,9 @@
                     "token": "READ",
                     "value": "READ",
                     "keyword": "READ",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -112,7 +144,9 @@
                     "token": "    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": "LOCAL",
                     "value": "LOCAL",
                     "keyword": "LOCAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 37
                 },
@@ -130,7 +166,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -139,13 +179,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 15
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLock2.out
+++ b/tests/data/parser/parseLock2.out
@@ -7,13 +7,19 @@
         "last": 32,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 13,
+            "idx": 13,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,11 @@
                     "token": "`t1`",
                     "value": "t1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "READ",
                     "value": "READ",
                     "keyword": "READ",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -112,7 +144,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,13 +157,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 13,
-            "idx": 13
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLock3.out
+++ b/tests/data/parser/parseLock3.out
@@ -7,13 +7,19 @@
         "last": 46,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 15,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,11 @@
                     "token": "`t1`",
                     "value": "t1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "LOW_PRIORITY",
                     "value": "LOW_PRIORITY",
                     "keyword": "LOW_PRIORITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -121,7 +155,9 @@
                     "token": "WRITE",
                     "value": "WRITE",
                     "keyword": "WRITE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -130,7 +166,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -139,13 +179,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 15
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLock4.out
+++ b/tests/data/parser/parseLock4.out
@@ -7,13 +7,19 @@
         "last": 33,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 13,
+            "idx": 13,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,11 @@
                     "token": "`t1`",
                     "value": "t1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "WRITE",
                     "value": "WRITE",
                     "keyword": "WRITE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -112,7 +144,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -121,13 +157,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 13,
-            "idx": 13
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLock5.out
+++ b/tests/data/parser/parseLock5.out
@@ -7,13 +7,19 @@
         "last": 60,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 24,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,11 @@
                     "token": "`t1`",
                     "value": "t1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "READ",
                     "value": "READ",
                     "keyword": "READ",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": "LOCAL",
                     "value": "LOCAL",
                     "keyword": "LOCAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 32
                 },
@@ -130,7 +166,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 37
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -148,7 +190,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -166,7 +212,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 46
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -184,7 +234,9 @@
                     "token": "`t2`",
                     "value": "t2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 49
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -202,7 +256,9 @@
                     "token": "WRITE",
                     "value": "WRITE",
                     "keyword": "WRITE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 54
                 },
@@ -211,7 +267,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -220,13 +280,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@30"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 24
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLock6.out
+++ b/tests/data/parser/parseLock6.out
@@ -7,13 +7,19 @@
         "last": 52,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 20,
+            "idx": 20,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "READ",
                     "value": "READ",
                     "keyword": "READ",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +109,9 @@
                     "token": "LOCAL",
                     "value": "LOCAL",
                     "keyword": "LOCAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 29
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -130,7 +166,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 38
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -148,7 +188,11 @@
                     "token": "`t2`",
                     "value": "t2",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 41
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -166,7 +212,9 @@
                     "token": "WRITE",
                     "value": "WRITE",
                     "keyword": "WRITE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 46
                 },
@@ -175,7 +223,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -184,13 +236,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 20,
-            "idx": 20
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseLockErr1.out
+++ b/tests/data/parser/parseLockErr1.out
@@ -7,13 +7,19 @@
         "last": 18,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 6,
+            "idx": 6,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,13 +76,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 6,
-            "idx": 6
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -111,7 +131,7 @@
             [
                 "Unexpected end of LOCK expression.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ]

--- a/tests/data/parser/parseLockErr10.out
+++ b/tests/data/parser/parseLockErr10.out
@@ -7,13 +7,19 @@
         "last": 51,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 16,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -103,7 +131,9 @@
                     "token": "LOW_PRIORITY",
                     "value": "LOW_PRIORITY",
                     "keyword": "LOW_PRIORITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -121,7 +153,9 @@
                     "token": "WRITE",
                     "value": "WRITE",
                     "keyword": "WRITE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -139,7 +175,9 @@
                     "token": "abc",
                     "value": "abc",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -148,13 +186,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 16
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -201,7 +241,7 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@16"
+                    "@type": "@19"
                 },
                 0
             ]

--- a/tests/data/parser/parseLockErr2.out
+++ b/tests/data/parser/parseLockErr2.out
@@ -7,13 +7,19 @@
         "last": 32,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 12,
+            "idx": 12,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,11 @@
                     "token": "`t1`",
                     "value": "t1",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "LOCAL",
                     "value": "LOCAL",
                     "keyword": "LOCAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 27
                 },
@@ -112,13 +144,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 12,
-            "idx": 12
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -165,7 +199,7 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@12"
+                    "@type": "@16"
                 },
                 0
             ],

--- a/tests/data/parser/parseLockErr3.out
+++ b/tests/data/parser/parseLockErr3.out
@@ -7,13 +7,19 @@
         "last": 49,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 14,
+            "idx": 15,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- TABLES misspelled",
                     "value": "-- TABLES misspelled",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -31,7 +41,11 @@
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -49,7 +65,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 26
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -67,7 +87,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -85,7 +111,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 39
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -103,7 +133,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -121,7 +155,9 @@
                     "token": "READ",
                     "value": "READ",
                     "keyword": "READ",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -130,13 +166,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 14,
-            "idx": 15
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -168,21 +206,21 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@6"
+                    "@type": "@9"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@8"
+                    "@type": "@11"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@10"
+                    "@type": "@14"
                 },
                 0
             ]

--- a/tests/data/parser/parseLockErr4.out
+++ b/tests/data/parser/parseLockErr4.out
@@ -7,13 +7,19 @@
         "last": 48,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- missing TABLES keyword",
                     "value": "-- missing TABLES keyword",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -31,7 +41,11 @@
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 26
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -49,7 +65,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -67,7 +89,9 @@
                     "token": "READ",
                     "value": "READ",
                     "keyword": "READ",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 38
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -85,7 +111,9 @@
                     "token": "LOCAL",
                     "value": "LOCAL",
                     "keyword": "LOCAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 43
                 },
@@ -94,13 +122,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -132,14 +162,14 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@6"
+                    "@type": "@9"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@8"
+                    "@type": "@12"
                 },
                 0
             ]

--- a/tests/data/parser/parseLockErr5.out
+++ b/tests/data/parser/parseLockErr5.out
@@ -7,13 +7,19 @@
         "last": 50,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 13,
+            "idx": 13,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- extraneous comma",
                     "value": "-- extraneous comma",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -31,7 +41,11 @@
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -49,7 +65,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 25
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -67,7 +87,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -85,7 +111,9 @@
                     "token": "READ",
                     "value": "READ",
                     "keyword": "READ",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 39
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -103,7 +133,9 @@
                     "token": "LOCAL",
                     "value": "LOCAL",
                     "keyword": "LOCAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 44
                 },
@@ -112,7 +144,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 49
                 },
@@ -121,13 +157,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 13,
-            "idx": 13
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -174,7 +212,7 @@
             [
                 "Unexpected end of LOCK statement.",
                 {
-                    "@type": "@13"
+                    "@type": "@17"
                 },
                 0
             ]

--- a/tests/data/parser/parseLockErr6.out
+++ b/tests/data/parser/parseLockErr6.out
@@ -7,13 +7,19 @@
         "last": 39,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 8,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- missing lock type",
                     "value": "-- missing lock type",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -31,7 +41,11 @@
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -49,7 +65,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 1,
                     "position": 26
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -67,7 +87,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -76,13 +100,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 8
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -129,7 +155,7 @@
             [
                 "Unexpected end of LOCK expression.",
                 {
-                    "@type": "@8"
+                    "@type": "@11"
                 },
                 0
             ]

--- a/tests/data/parser/parseLockErr7.out
+++ b/tests/data/parser/parseLockErr7.out
@@ -7,13 +7,19 @@
         "last": 40,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 12,
+            "idx": 12,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -103,7 +131,9 @@
                     "token": "non_keyword",
                     "value": "non_keyword",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -112,13 +142,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 12,
-            "idx": 12
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -165,14 +197,14 @@
             [
                 "An alias was previously found.",
                 {
-                    "@type": "@12"
+                    "@type": "@15"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@12"
+                    "@type": "@15"
                 },
                 0
             ],

--- a/tests/data/parser/parseLockErr8.out
+++ b/tests/data/parser/parseLockErr8.out
@@ -7,13 +7,19 @@
         "last": 48,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 14,
+            "idx": 14,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -103,7 +131,9 @@
                     "token": "READ",
                     "value": "READ",
                     "keyword": "READ",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +153,9 @@
                     "token": "AUTO_INCREMENT",
                     "value": "AUTO_INCREMENT",
                     "keyword": "AUTO_INCREMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 34
                 },
@@ -130,13 +164,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 14,
-            "idx": 14
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -183,7 +219,7 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@14"
+                    "@type": "@17"
                 },
                 0
             ]

--- a/tests/data/parser/parseLockErr9.out
+++ b/tests/data/parser/parseLockErr9.out
@@ -7,13 +7,19 @@
         "last": 46,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 14,
+            "idx": 14,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "LOCK",
                     "value": "LOCK",
                     "keyword": "LOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 5
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +109,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -103,7 +131,9 @@
                     "token": "LOW_PRIORITY",
                     "value": "LOW_PRIORITY",
                     "keyword": "LOW_PRIORITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -121,7 +153,9 @@
                     "token": "READ",
                     "value": "READ",
                     "keyword": "READ",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -130,13 +164,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 14,
-            "idx": 14
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -183,14 +219,14 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@14"
+                    "@type": "@17"
                 },
                 0
             ],
             [
                 "Unexpected end of LOCK expression.",
                 {
-                    "@type": "@12"
+                    "@type": "@15"
                 },
                 0
             ]

--- a/tests/data/parser/parsePurge.out
+++ b/tests/data/parser/parsePurge.out
@@ -7,13 +7,19 @@
         "last": 37,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "PURGE",
                     "value": "PURGE",
                     "keyword": "PURGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "BINARY",
                     "value": "BINARY",
                     "keyword": "BINARY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "LOGS",
                     "value": "LOGS",
                     "keyword": "LOGS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +107,11 @@
                     "token": "'mysql-bin.010'",
                     "value": "mysql-bin.010",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 21
                 },
@@ -94,7 +120,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -103,13 +133,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parsePurge2.out
+++ b/tests/data/parser/parsePurge2.out
@@ -7,13 +7,19 @@
         "last": 47,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "PURGE",
                     "value": "PURGE",
                     "keyword": "PURGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "BINARY",
                     "value": "BINARY",
                     "keyword": "BINARY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "LOGS",
                     "value": "LOGS",
                     "keyword": "LOGS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,9 @@
                     "token": "BEFORE",
                     "value": "BEFORE",
                     "keyword": "BEFORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +107,11 @@
                     "token": "'2008-04-02 22:46:26'",
                     "value": "2008-04-02 22:46:26",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 25
                 },
@@ -94,7 +120,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -103,13 +133,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parsePurge3.out
+++ b/tests/data/parser/parsePurge3.out
@@ -7,13 +7,19 @@
         "last": 47,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "PURGE",
                     "value": "PURGE",
                     "keyword": "PURGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "MASTER",
                     "value": "MASTER",
                     "keyword": "MASTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "LOGS",
                     "value": "LOGS",
                     "keyword": "LOGS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,9 @@
                     "token": "BEFORE",
                     "value": "BEFORE",
                     "keyword": "BEFORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +107,11 @@
                     "token": "'2008-04-02 22:46:26'",
                     "value": "2008-04-02 22:46:26",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 25
                 },
@@ -94,7 +120,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -103,13 +133,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parsePurge4.out
+++ b/tests/data/parser/parsePurge4.out
@@ -7,13 +7,19 @@
         "last": 37,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "PURGE",
                     "value": "PURGE",
                     "keyword": "PURGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "MASTER",
                     "value": "MASTER",
                     "keyword": "MASTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "LOGS",
                     "value": "LOGS",
                     "keyword": "LOGS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +107,11 @@
                     "token": "'mysql-bin.010'",
                     "value": "mysql-bin.010",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 21
                 },
@@ -94,7 +120,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -103,13 +133,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parsePurgeErr.out
+++ b/tests/data/parser/parsePurgeErr.out
@@ -7,13 +7,19 @@
         "last": 30,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 9,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "PURGE",
                     "value": "PURGE",
                     "keyword": "PURGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "LOGS",
                     "value": "LOGS",
                     "keyword": "LOGS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 11
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +85,11 @@
                     "token": "'mysql-bin.010'",
                     "value": "mysql-bin.010",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 14
                 },
@@ -76,7 +98,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -85,13 +111,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 9,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -124,20 +150,13 @@
             [
                 "Unexpected keyword",
                 {
-                    "@type": "@4"
+                    "@type": "@6"
                 },
                 0
             ],
             [
                 "Unexpected keyword",
                 {
-                    "@type": "@6"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
                     "@type": "@8"
                 },
                 0
@@ -145,7 +164,14 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@8"
+                    "@type": "@10"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@10"
                 },
                 0
             ]

--- a/tests/data/parser/parsePurgeErr2.out
+++ b/tests/data/parser/parsePurgeErr2.out
@@ -7,13 +7,19 @@
         "last": 23,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 9,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "PURGE",
                     "value": "PURGE",
                     "keyword": "PURGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "BINARY",
                     "value": "BINARY",
                     "keyword": "BINARY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "LOGS",
                     "value": "LOGS",
                     "keyword": "LOGS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +96,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,13 +109,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 9,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -124,14 +148,14 @@
             [
                 "Unexpected keyword",
                 {
-                    "@type": "@8"
+                    "@type": "@10"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@8"
+                    "@type": "@10"
                 },
                 0
             ]

--- a/tests/data/parser/parsePurgeErr3.out
+++ b/tests/data/parser/parsePurgeErr3.out
@@ -7,13 +7,19 @@
         "last": 38,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 13,
+            "idx": 13,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "PURGE",
                     "value": "PURGE",
                     "keyword": "PURGE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,9 @@
                     "token": "BINARY",
                     "value": "BINARY",
                     "keyword": "BINARY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 6
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "LOGS",
                     "value": "LOGS",
                     "keyword": "LOGS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +85,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +107,11 @@
                     "token": "'mysql.bin'",
                     "value": "mysql.bin",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 21
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +131,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -112,7 +142,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -121,13 +155,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 13,
-            "idx": 13
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -169,14 +203,14 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@12"
+                    "@type": "@15"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@12"
+                    "@type": "@15"
                 },
                 0
             ]

--- a/tests/data/parser/parseRename.out
+++ b/tests/data/parser/parseRename.out
@@ -7,13 +7,19 @@
         "last": 23,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +109,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -94,13 +120,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseRename2.out
+++ b/tests/data/parser/parseRename2.out
@@ -7,13 +7,19 @@
         "last": 36,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 18,
+            "idx": 18,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +109,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -94,7 +120,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 23
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -112,7 +144,9 @@
                     "token": "baz",
                     "value": "baz",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -130,7 +166,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -148,7 +188,9 @@
                     "token": "qux",
                     "value": "qux",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -157,7 +199,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -166,13 +212,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 18,
-            "idx": 18
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseRenameErr1.out
+++ b/tests/data/parser/parseRenameErr1.out
@@ -7,13 +7,19 @@
         "last": 20,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -67,7 +87,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 15
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -85,7 +109,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -94,13 +120,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -146,7 +174,7 @@
             [
                 "The new name of the table was expected.",
                 {
-                    "@type": "@10"
+                    "@type": "@13"
                 },
                 0
             ]

--- a/tests/data/parser/parseRenameErr2.out
+++ b/tests/data/parser/parseRenameErr2.out
@@ -7,13 +7,19 @@
         "last": 18,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 6,
+            "idx": 6,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -58,13 +74,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 6,
-            "idx": 6
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -95,14 +113,14 @@
             [
                 "The old name of the table was expected.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ],
             [
                 "A rename operation was expected.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ]

--- a/tests/data/parser/parseRenameErr3.out
+++ b/tests/data/parser/parseRenameErr3.out
@@ -7,13 +7,19 @@
         "last": 19,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 8,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -67,7 +87,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 15
                 },
@@ -76,13 +98,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 8
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -129,21 +153,21 @@
             [
                 "Keyword \"TO\" was expected.",
                 {
-                    "@type": "@8"
+                    "@type": "@11"
                 },
                 0
             ],
             [
                 "A rename operation was expected.",
                 {
-                    "@type": "@7"
+                    "@type": "@10"
                 },
                 0
             ],
             [
                 "An expression was expected.",
                 {
-                    "@type": "@9"
+                    "@type": "@12"
                 },
                 0
             ]

--- a/tests/data/parser/parseRenameErr4.out
+++ b/tests/data/parser/parseRenameErr4.out
@@ -7,13 +7,19 @@
         "last": 26,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 12,
+            "idx": 12,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +109,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -103,7 +131,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -112,13 +142,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 12,
-            "idx": 12
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -173,7 +205,7 @@
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@12"
+                    "@type": "@15"
                 },
                 0
             ]

--- a/tests/data/parser/parseRenameErr5.out
+++ b/tests/data/parser/parseRenameErr5.out
@@ -7,13 +7,19 @@
         "last": 7,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 3,
+            "idx": 4,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "RENAME",
                     "value": "RENAME",
                     "keyword": "RENAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,13 +41,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 3,
-            "idx": 4
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseReplace.out
+++ b/tests/data/parser/parseReplace.out
@@ -7,13 +7,19 @@
         "last": 75,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 31,
+            "idx": 31,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "LOW_PRIORITY",
                     "value": "LOW_PRIORITY",
                     "keyword": "LOW_PRIORITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -49,7 +63,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -67,7 +85,11 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -76,7 +98,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 31
                 },
@@ -85,7 +111,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -94,7 +122,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 34
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -112,7 +144,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -121,7 +155,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 46
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -157,7 +199,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 53
                 },
@@ -166,7 +210,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -175,7 +223,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 55
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -193,7 +245,11 @@
                     "token": "'Foo'",
                     "value": "Foo",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 57
                 },
@@ -202,7 +258,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 62
                 },
@@ -211,7 +269,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 63
                 },
@@ -220,7 +280,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -229,7 +291,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 65
                 },
@@ -238,7 +302,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@24"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -247,7 +313,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 67
                 },
@@ -256,7 +324,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -265,7 +335,9 @@
                     "token": "'Bar'",
                     "value": "Bar",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 1,
                     "position": 69
                 },
@@ -274,7 +346,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 74
                 },
@@ -283,13 +357,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 31,
-            "idx": 31
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseReplace2.out
+++ b/tests/data/parser/parseReplace2.out
@@ -7,13 +7,19 @@
         "last": 65,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 24,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "LOW_PRIORITY",
                     "value": "LOW_PRIORITY",
                     "keyword": "LOW_PRIORITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -49,7 +63,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -67,7 +85,11 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -76,7 +98,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -85,7 +109,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 32
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -103,7 +131,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -121,7 +153,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 39
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -139,7 +177,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +190,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -157,7 +201,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -166,7 +212,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -184,7 +234,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 2,
                     "position": 57
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -202,7 +256,11 @@
                     "token": "'Bar'",
                     "value": "Bar",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 59
                 },
@@ -211,7 +269,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -220,13 +282,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 24
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseReplaceErr.out
+++ b/tests/data/parser/parseReplaceErr.out
@@ -7,13 +7,19 @@
         "last": 68,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 29,
+            "idx": 29,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "LOW_PRIORITY",
                     "value": "LOW_PRIORITY",
                     "keyword": "LOW_PRIORITY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -49,7 +63,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -67,7 +85,11 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -76,7 +98,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 31
                 },
@@ -85,7 +111,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -94,7 +122,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 34
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -112,7 +144,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -121,7 +155,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 46
                 },
@@ -148,7 +188,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -157,7 +201,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 48
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -175,7 +223,11 @@
                     "token": "'Foo'",
                     "value": "Foo",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -184,7 +236,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 55
                 },
@@ -193,7 +247,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 56
                 },
@@ -202,7 +258,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -211,7 +269,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 58
                 },
@@ -220,7 +280,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -229,7 +291,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 60
                 },
@@ -238,7 +302,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -247,7 +313,9 @@
                     "token": "'Bar'",
                     "value": "Bar",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 1,
                     "position": 62
                 },
@@ -256,7 +324,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 67
                 },
@@ -265,13 +335,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 29,
-            "idx": 29
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -331,21 +403,14 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@16"
-                },
-                0
-            ],
-            [
-                "Unexpected beginning of statement.",
-                {
-                    "@type": "@17"
-                },
-                0
-            ],
-            [
-                "Unexpected beginning of statement.",
-                {
                     "@type": "@20"
+                },
+                0
+            ],
+            [
+                "Unexpected beginning of statement.",
+                {
+                    "@type": "@21"
                 },
                 0
             ],
@@ -359,7 +424,14 @@
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@28"
+                    "@type": "@31"
+                },
+                0
+            ],
+            [
+                "Unexpected beginning of statement.",
+                {
+                    "@type": "@34"
                 },
                 0
             ]

--- a/tests/data/parser/parseReplaceErr2.out
+++ b/tests/data/parser/parseReplaceErr2.out
@@ -7,13 +7,19 @@
         "last": 15,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 5,
+            "idx": 5,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -49,13 +63,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 5,
-            "idx": 5
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -116,14 +132,14 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@4"
+                    "@type": "@6"
                 },
                 0
             ],
             [
                 "An expression was expected.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ]

--- a/tests/data/parser/parseReplaceErr3.out
+++ b/tests/data/parser/parseReplaceErr3.out
@@ -7,13 +7,19 @@
         "last": 25,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 9,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "x",
                     "value": "x",
                     "keyword": "X",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -67,7 +85,11 @@
                     "token": "\"string\"",
                     "value": "string",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 15
                 },
@@ -76,7 +98,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,13 +109,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 9,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -146,14 +172,14 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@8"
+                    "@type": "@10"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@8"
+                    "@type": "@10"
                 },
                 0
             ]

--- a/tests/data/parser/parseReplaceIntoErr.out
+++ b/tests/data/parser/parseReplaceIntoErr.out
@@ -7,13 +7,19 @@
         "last": 23,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 9,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "x",
                     "value": "x",
                     "keyword": "X",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -67,7 +85,9 @@
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 15
                 },
@@ -76,7 +96,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,13 +107,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 9,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -161,7 +185,7 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@8"
+                    "@type": "@10"
                 },
                 0
             ]

--- a/tests/data/parser/parseReplaceSelect.out
+++ b/tests/data/parser/parseReplaceSelect.out
@@ -7,13 +7,19 @@
         "last": 49,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 18,
+            "idx": 18,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 17
                 },
@@ -76,7 +100,9 @@
                     "token": "`value`",
                     "value": "value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 18
                 },
@@ -85,7 +111,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": "value",
                     "value": "value",
                     "keyword": "VALUE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +177,9 @@
                     "token": "from",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 41
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -157,7 +199,9 @@
                     "token": "`b`",
                     "value": "b",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 46
                 },
@@ -166,13 +210,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 18,
-            "idx": 18
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseReplaceSet.out
+++ b/tests/data/parser/parseReplaceSet.out
@@ -7,13 +7,19 @@
         "last": 44,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 18,
+            "idx": 18,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 17
                 },
@@ -76,7 +100,9 @@
                     "token": "`value`",
                     "value": "value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 18
                 },
@@ -85,7 +111,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -121,7 +155,9 @@
                     "token": "value",
                     "value": "value",
                     "keyword": "VALUE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 31
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -139,7 +177,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 2,
                     "position": 37
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -157,7 +199,11 @@
                     "token": "'123'",
                     "value": "123",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 39
                 },
@@ -166,13 +212,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 18,
-            "idx": 18
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseReplaceValues.out
+++ b/tests/data/parser/parseReplaceValues.out
@@ -7,13 +7,19 @@
         "last": 50,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "REPLACE",
                     "value": "REPLACE",
                     "keyword": "REPLACE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,11 @@
                     "token": "`a`",
                     "value": "a",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 13
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 17
                 },
@@ -76,7 +100,9 @@
                     "token": "`value`",
                     "value": "value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 18
                 },
@@ -85,7 +111,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 34
                 },
@@ -130,7 +166,11 @@
                     "token": "'123'",
                     "value": "123",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -139,7 +179,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -148,7 +190,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -166,7 +212,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -175,7 +223,9 @@
                     "token": "'123'",
                     "value": "123",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 1,
                     "position": 44
                 },
@@ -184,7 +234,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 16,
                     "position": 49
                 },
@@ -193,13 +245,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseRestore.out
+++ b/tests/data/parser/parseRestore.out
@@ -7,13 +7,19 @@
         "last": 55,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "RESTORE",
                     "value": "RESTORE",
                     "keyword": "RESTORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 1,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,11 @@
                     "token": "my_table",
                     "value": "my_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +87,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 23
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -85,7 +109,11 @@
                     "token": "\"/path/to/backup/directory\"",
                     "value": "/path/to/backup/directory",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 28
                 },
@@ -94,13 +122,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect.out
+++ b/tests/data/parser/parseSelect.out
@@ -7,13 +7,19 @@
         "last": 231,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 81,
+            "idx": 81,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "ALL",
                     "value": "ALL",
                     "keyword": "ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,9 @@
                     "token": "MAX_STATEMENT_TIME",
                     "value": "MAX_STATEMENT_TIME",
                     "keyword": "MAX_STATEMENT_TIME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 11
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -67,7 +85,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 30
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -85,7 +109,11 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -94,7 +122,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -103,7 +133,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -121,7 +155,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 41
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -139,7 +177,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -157,7 +199,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -175,7 +221,11 @@
                     "token": "result",
                     "value": "result",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -184,7 +234,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 54
                 },
@@ -193,7 +245,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -202,7 +256,11 @@
                     "token": "@idx",
                     "value": "idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 60
                 },
@@ -211,7 +269,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 64
                 },
@@ -220,7 +280,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -229,7 +291,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -238,7 +302,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 72
                 },
@@ -247,7 +313,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -256,7 +324,9 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -265,7 +335,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 82
                 },
@@ -274,7 +346,9 @@
                     "token": "`users`",
                     "value": "users",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 2,
                     "position": 83
                 },
@@ -283,7 +357,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 90
                 },
@@ -292,7 +368,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -310,7 +390,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 100
                 },
@@ -319,7 +401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -328,7 +412,9 @@
                     "token": "`name`",
                     "value": "name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 2,
                     "position": 103
                 },
@@ -337,7 +423,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -346,7 +434,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 110
                 },
@@ -355,7 +445,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -364,7 +456,9 @@
                     "token": "`test`",
                     "value": "test",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 2,
                     "position": 119
                 },
@@ -373,7 +467,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 125
                 },
@@ -382,7 +478,9 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -391,7 +489,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 131
                 },
@@ -400,7 +500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -409,7 +511,9 @@
                     "token": "posts",
                     "value": "posts",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -418,7 +522,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -427,7 +533,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 143
                 },
@@ -436,7 +544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -445,7 +555,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 153
                 },
@@ -454,7 +566,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -463,7 +577,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 156
                 },
@@ -472,7 +588,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -481,7 +599,9 @@
                     "token": "p2",
                     "value": "p2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -490,7 +610,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 160
                 },
@@ -499,7 +621,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 161
                 },
@@ -508,7 +632,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 162
                 },
@@ -517,7 +643,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 167
                 },
@@ -526,7 +654,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 172
                 },
@@ -535,7 +665,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 174
                 },
@@ -544,7 +676,9 @@
                     "token": ">",
                     "value": ">",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 175
                 },
@@ -553,7 +687,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -562,7 +698,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 177
                 },
@@ -571,7 +709,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 178
                 },
@@ -580,7 +720,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 179
                 },
@@ -589,7 +731,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 187
                 },
@@ -598,7 +742,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 192
                 },
@@ -607,7 +753,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 200
                 },
@@ -616,7 +764,9 @@
                     "token": "DESC",
                     "value": "DESC",
                     "keyword": "DESC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 201
                 },
@@ -625,7 +775,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 205
                 },
@@ -634,7 +786,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 206
                 },
@@ -643,7 +797,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 211
                 },
@@ -652,7 +808,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 213
                 },
@@ -661,7 +819,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 214
                 },
@@ -670,7 +830,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 219
                 },
@@ -679,7 +841,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 220
                 },
@@ -688,7 +852,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 221
                 },
@@ -697,7 +863,9 @@
                     "token": "OFFSET",
                     "value": "OFFSET",
                     "keyword": "OFFSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 222
                 },
@@ -706,7 +874,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 228
                 },
@@ -715,7 +885,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 229
                 },
@@ -724,7 +896,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 230
                 },
@@ -733,13 +909,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@88"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 81,
-            "idx": 81
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect10.out
+++ b/tests/data/parser/parseSelect10.out
@@ -7,13 +7,19 @@
         "last": 83,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 26,
+            "idx": 26,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "my_column",
                     "value": "my_column",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -67,7 +87,9 @@
                     "token": "my_table",
                     "value": "my_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -85,7 +109,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 31
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -103,7 +131,9 @@
                     "token": "BINARY",
                     "value": "BINARY",
                     "keyword": "BINARY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 37
                 },
@@ -112,7 +142,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -121,7 +155,9 @@
                     "token": "my_column",
                     "value": "my_column",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 53
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -148,7 +188,9 @@
                     "token": "!=",
                     "value": "!=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 55
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -166,7 +210,9 @@
                     "token": "BINARY",
                     "value": "BINARY",
                     "keyword": "BINARY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 43,
                     "position": 58
                 },
@@ -175,7 +221,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 64
                 },
@@ -184,7 +232,9 @@
                     "token": "UPPER",
                     "value": "UPPER",
                     "keyword": "UPPER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 65
                 },
@@ -193,7 +243,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 70
                 },
@@ -202,7 +254,9 @@
                     "token": "my_column",
                     "value": "my_column",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -211,7 +265,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -220,7 +276,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 81
                 },
@@ -229,7 +287,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -238,13 +298,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 26,
-            "idx": 26
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect11.out
+++ b/tests/data/parser/parseSelect11.out
@@ -7,13 +7,19 @@
         "last": 19,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 11,
+            "idx": 11,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -67,7 +87,9 @@
                     "token": "NOT",
                     "value": "NOT",
                     "keyword": "NOT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -85,7 +109,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -94,7 +120,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -103,13 +131,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 11,
-            "idx": 11
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect12.out
+++ b/tests/data/parser/parseSelect12.out
@@ -7,13 +7,19 @@
         "last": 20,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "NOT",
                     "value": "NOT",
                     "keyword": "NOT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 13
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -85,7 +109,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -94,13 +122,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect13.out
+++ b/tests/data/parser/parseSelect13.out
@@ -7,13 +7,19 @@
         "last": 3834,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 1035,
+            "idx": 1035,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 11
                 },
@@ -49,7 +67,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 12
                 },
@@ -58,7 +78,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 13
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -85,7 +111,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -94,7 +122,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -112,7 +144,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 29
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -130,7 +166,9 @@
                     "token": "postusername",
                     "value": "postusername",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -139,7 +177,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 44
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -157,7 +199,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -166,7 +210,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 50
                 },
@@ -175,7 +221,9 @@
                     "token": "ipaddress",
                     "value": "ipaddress",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -193,7 +243,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 61
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -211,7 +265,9 @@
                     "token": "ip",
                     "value": "ip",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -220,7 +276,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 66
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -238,7 +298,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 68
                 },
@@ -247,7 +309,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 70
                 },
@@ -256,7 +320,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -265,7 +331,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 75
                 },
@@ -274,7 +342,9 @@
                     "token": "visible",
                     "value": "visible",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -283,7 +353,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -292,7 +364,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 84
                 },
@@ -301,7 +375,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -310,7 +386,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -319,7 +399,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 87
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -337,7 +421,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -346,7 +432,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 90
                 },
@@ -355,7 +443,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -364,7 +454,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -373,7 +465,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 93
                 },
@@ -382,7 +476,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -391,7 +487,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 95
                 },
@@ -400,7 +498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -409,7 +509,9 @@
                     "token": "isdeleted",
                     "value": "isdeleted",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -418,7 +520,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 107
                 },
@@ -427,7 +531,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -436,7 +542,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "user",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -445,7 +553,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 113
                 },
@@ -454,7 +564,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 114
                 },
@@ -463,7 +575,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 115
                 },
@@ -472,7 +586,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -481,7 +597,9 @@
                     "token": "userfield",
                     "value": "userfield",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -490,7 +608,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 126
                 },
@@ -499,7 +619,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 127
                 },
@@ -508,7 +630,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 128
                 },
@@ -517,7 +641,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -526,7 +652,9 @@
                     "token": "usertextfield",
                     "value": "usertextfield",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -535,7 +663,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 143
                 },
@@ -544,7 +674,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 144
                 },
@@ -553,7 +685,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 145
                 },
@@ -562,7 +696,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 146
                 },
@@ -571,7 +707,9 @@
                     "token": "icon",
                     "value": "icon",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -580,7 +718,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 151
                 },
@@ -589,7 +729,9 @@
                     "token": "title",
                     "value": "title",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -598,7 +740,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -607,7 +751,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 158
                 },
@@ -616,7 +762,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -625,7 +773,9 @@
                     "token": "icontitle",
                     "value": "icontitle",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 161
                 },
@@ -634,7 +784,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 170
                 },
@@ -643,7 +795,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 171
                 },
@@ -652,7 +806,9 @@
                     "token": "icon",
                     "value": "icon",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 172
                 },
@@ -661,7 +817,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 176
                 },
@@ -670,7 +828,9 @@
                     "token": "iconpath",
                     "value": "iconpath",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 177
                 },
@@ -679,7 +839,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 185
                 },
@@ -688,7 +850,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 186
                 },
@@ -697,7 +861,9 @@
                     "token": "avatar",
                     "value": "avatar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 187
                 },
@@ -706,7 +872,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 193
                 },
@@ -715,7 +883,9 @@
                     "token": "avatarpath",
                     "value": "avatarpath",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 194
                 },
@@ -724,7 +894,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 204
                 },
@@ -733,7 +905,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 205
                 },
@@ -742,7 +916,9 @@
                     "token": "NOT",
                     "value": "NOT",
                     "keyword": "NOT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 206
                 },
@@ -751,7 +927,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 209
                 },
@@ -760,7 +938,9 @@
                     "token": "ISNULL",
                     "value": "ISNULL",
                     "keyword": "ISNULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 210
                 },
@@ -769,7 +949,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 216
                 },
@@ -778,7 +960,9 @@
                     "token": "customavatar",
                     "value": "customavatar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 217
                 },
@@ -787,7 +971,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 229
                 },
@@ -796,7 +982,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 230
                 },
@@ -805,7 +993,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 236
                 },
@@ -814,7 +1004,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 237
                 },
@@ -823,7 +1015,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 238
                 },
@@ -832,7 +1026,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 240
                 },
@@ -841,7 +1037,9 @@
                     "token": "hascustomavatar",
                     "value": "hascustomavatar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 241
                 },
@@ -850,7 +1048,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 256
                 },
@@ -859,7 +1059,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 257
                 },
@@ -868,7 +1070,9 @@
                     "token": "customavatar",
                     "value": "customavatar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 258
                 },
@@ -877,7 +1081,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 270
                 },
@@ -886,7 +1092,9 @@
                     "token": "dateline",
                     "value": "dateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 271
                 },
@@ -895,7 +1103,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 279
                 },
@@ -904,7 +1114,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 280
                 },
@@ -913,7 +1125,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 282
                 },
@@ -922,7 +1136,9 @@
                     "token": "avatardateline",
                     "value": "avatardateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 283
                 },
@@ -931,7 +1147,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 297
                 },
@@ -940,7 +1158,9 @@
                     "token": "customavatar",
                     "value": "customavatar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 298
                 },
@@ -949,7 +1169,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 310
                 },
@@ -958,7 +1180,9 @@
                     "token": "width",
                     "value": "width",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 311
                 },
@@ -967,7 +1191,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 316
                 },
@@ -976,7 +1202,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 317
                 },
@@ -985,7 +1213,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 319
                 },
@@ -994,7 +1224,9 @@
                     "token": "avwidth",
                     "value": "avwidth",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 320
                 },
@@ -1003,7 +1235,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 327
                 },
@@ -1012,7 +1246,9 @@
                     "token": "customavatar",
                     "value": "customavatar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 328
                 },
@@ -1021,7 +1257,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 340
                 },
@@ -1030,7 +1268,9 @@
                     "token": "height",
                     "value": "height",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 341
                 },
@@ -1039,7 +1279,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 347
                 },
@@ -1048,7 +1290,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 348
                 },
@@ -1057,7 +1301,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 350
                 },
@@ -1066,7 +1312,9 @@
                     "token": "avheight",
                     "value": "avheight",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 351
                 },
@@ -1075,7 +1323,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 359
                 },
@@ -1084,7 +1334,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 360
                 },
@@ -1093,7 +1345,9 @@
                     "token": "spamlog",
                     "value": "spamlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 361
                 },
@@ -1102,7 +1356,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 368
                 },
@@ -1111,7 +1367,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 369
                 },
@@ -1120,7 +1378,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 375
                 },
@@ -1129,7 +1389,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 376
                 },
@@ -1138,7 +1400,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 378
                 },
@@ -1147,7 +1411,9 @@
                     "token": "spamlog_postid",
                     "value": "spamlog_postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 379
                 },
@@ -1156,7 +1422,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 393
                 },
@@ -1165,7 +1433,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 394
                 },
@@ -1174,7 +1444,9 @@
                     "token": "deletionlog",
                     "value": "deletionlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 395
                 },
@@ -1183,7 +1455,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 406
                 },
@@ -1192,7 +1466,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 407
                 },
@@ -1201,7 +1477,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 413
                 },
@@ -1210,7 +1488,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 414
                 },
@@ -1219,7 +1499,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 416
                 },
@@ -1228,7 +1510,9 @@
                     "token": "del_userid",
                     "value": "del_userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 417
                 },
@@ -1237,7 +1521,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 427
                 },
@@ -1246,7 +1532,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 428
                 },
@@ -1255,7 +1543,9 @@
                     "token": "deletionlog",
                     "value": "deletionlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 429
                 },
@@ -1264,7 +1554,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 440
                 },
@@ -1273,7 +1565,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 441
                 },
@@ -1282,7 +1576,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 449
                 },
@@ -1291,7 +1587,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 450
                 },
@@ -1300,7 +1598,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 452
                 },
@@ -1309,7 +1609,9 @@
                     "token": "del_username",
                     "value": "del_username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 453
                 },
@@ -1318,7 +1620,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 465
                 },
@@ -1327,7 +1631,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 466
                 },
@@ -1336,7 +1642,9 @@
                     "token": "deletionlog",
                     "value": "deletionlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 467
                 },
@@ -1345,7 +1653,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 478
                 },
@@ -1354,7 +1664,9 @@
                     "token": "reason",
                     "value": "reason",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 479
                 },
@@ -1363,7 +1675,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 485
                 },
@@ -1372,7 +1686,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 486
                 },
@@ -1381,7 +1697,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 488
                 },
@@ -1390,7 +1708,9 @@
                     "token": "del_reason",
                     "value": "del_reason",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 489
                 },
@@ -1399,7 +1719,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 499
                 },
@@ -1408,7 +1730,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 500
                 },
@@ -1417,7 +1741,9 @@
                     "token": "editlog",
                     "value": "editlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 501
                 },
@@ -1426,7 +1752,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 508
                 },
@@ -1435,7 +1763,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 509
                 },
@@ -1444,7 +1774,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 515
                 },
@@ -1453,7 +1785,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 516
                 },
@@ -1462,7 +1796,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 518
                 },
@@ -1471,7 +1807,9 @@
                     "token": "edit_userid",
                     "value": "edit_userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 519
                 },
@@ -1480,7 +1818,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 530
                 },
@@ -1489,7 +1829,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 531
                 },
@@ -1498,7 +1840,9 @@
                     "token": "editlog",
                     "value": "editlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 532
                 },
@@ -1507,7 +1851,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 539
                 },
@@ -1516,7 +1862,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 540
                 },
@@ -1525,7 +1873,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 548
                 },
@@ -1534,7 +1884,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 549
                 },
@@ -1543,7 +1895,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 551
                 },
@@ -1552,7 +1906,9 @@
                     "token": "edit_username",
                     "value": "edit_username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 552
                 },
@@ -1561,7 +1917,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 565
                 },
@@ -1570,7 +1928,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 566
                 },
@@ -1579,7 +1939,9 @@
                     "token": "editlog",
                     "value": "editlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 567
                 },
@@ -1588,7 +1950,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 574
                 },
@@ -1597,7 +1961,9 @@
                     "token": "dateline",
                     "value": "dateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 575
                 },
@@ -1606,7 +1972,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 583
                 },
@@ -1615,7 +1983,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 584
                 },
@@ -1624,7 +1994,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 586
                 },
@@ -1633,7 +2005,9 @@
                     "token": "edit_dateline",
                     "value": "edit_dateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 587
                 },
@@ -1642,7 +2016,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 600
                 },
@@ -1651,7 +2027,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 601
                 },
@@ -1660,7 +2038,9 @@
                     "token": "editlog",
                     "value": "editlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 602
                 },
@@ -1669,7 +2049,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 609
                 },
@@ -1678,7 +2060,9 @@
                     "token": "reason",
                     "value": "reason",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 610
                 },
@@ -1687,7 +2071,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 616
                 },
@@ -1696,7 +2082,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 617
                 },
@@ -1705,7 +2093,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 619
                 },
@@ -1714,7 +2104,9 @@
                     "token": "edit_reason",
                     "value": "edit_reason",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 620
                 },
@@ -1723,7 +2115,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 631
                 },
@@ -1732,7 +2126,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 632
                 },
@@ -1741,7 +2137,9 @@
                     "token": "editlog",
                     "value": "editlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 633
                 },
@@ -1750,7 +2148,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 640
                 },
@@ -1759,7 +2159,9 @@
                     "token": "hashistory",
                     "value": "hashistory",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 641
                 },
@@ -1768,7 +2170,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 651
                 },
@@ -1777,7 +2181,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 652
                 },
@@ -1786,7 +2192,9 @@
                     "token": "postparsed",
                     "value": "postparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 653
                 },
@@ -1795,7 +2203,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 663
                 },
@@ -1804,7 +2214,9 @@
                     "token": "pagetext_html",
                     "value": "pagetext_html",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 664
                 },
@@ -1813,7 +2225,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 677
                 },
@@ -1822,7 +2236,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 678
                 },
@@ -1831,7 +2247,9 @@
                     "token": "postparsed",
                     "value": "postparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 679
                 },
@@ -1840,7 +2258,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 689
                 },
@@ -1849,7 +2269,9 @@
                     "token": "hasimages",
                     "value": "hasimages",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 690
                 },
@@ -1858,7 +2280,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 699
                 },
@@ -1867,7 +2291,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 700
                 },
@@ -1876,7 +2302,9 @@
                     "token": "sigparsed",
                     "value": "sigparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 701
                 },
@@ -1885,7 +2313,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 710
                 },
@@ -1894,7 +2324,9 @@
                     "token": "signatureparsed",
                     "value": "signatureparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 711
                 },
@@ -1903,7 +2335,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 726
                 },
@@ -1912,7 +2346,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 727
                 },
@@ -1921,7 +2357,9 @@
                     "token": "sigparsed",
                     "value": "sigparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 728
                 },
@@ -1930,7 +2368,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 737
                 },
@@ -1939,7 +2379,9 @@
                     "token": "hasimages",
                     "value": "hasimages",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 738
                 },
@@ -1948,7 +2390,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 747
                 },
@@ -1957,7 +2401,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 748
                 },
@@ -1966,7 +2412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 750
                 },
@@ -1975,7 +2423,9 @@
                     "token": "sighasimages",
                     "value": "sighasimages",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 751
                 },
@@ -1984,7 +2434,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 763
                 },
@@ -1993,7 +2445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 764
                 },
@@ -2002,7 +2456,9 @@
                     "token": "sigpic",
                     "value": "sigpic",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 765
                 },
@@ -2011,7 +2467,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 771
                 },
@@ -2020,7 +2478,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 772
                 },
@@ -2029,7 +2489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 778
                 },
@@ -2038,7 +2500,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 779
                 },
@@ -2047,7 +2511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 781
                 },
@@ -2056,7 +2522,9 @@
                     "token": "sigpic",
                     "value": "sigpic",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 782
                 },
@@ -2065,7 +2533,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 788
                 },
@@ -2074,7 +2544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 789
                 },
@@ -2083,7 +2555,9 @@
                     "token": "sigpic",
                     "value": "sigpic",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 790
                 },
@@ -2092,7 +2566,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 796
                 },
@@ -2101,7 +2577,9 @@
                     "token": "dateline",
                     "value": "dateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 797
                 },
@@ -2110,7 +2588,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 805
                 },
@@ -2119,7 +2599,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 806
                 },
@@ -2128,7 +2610,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 808
                 },
@@ -2137,7 +2621,9 @@
                     "token": "sigpicdateline",
                     "value": "sigpicdateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 809
                 },
@@ -2146,7 +2632,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 823
                 },
@@ -2155,7 +2643,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 824
                 },
@@ -2164,7 +2654,9 @@
                     "token": "sigpic",
                     "value": "sigpic",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 825
                 },
@@ -2173,7 +2665,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 831
                 },
@@ -2182,7 +2676,9 @@
                     "token": "width",
                     "value": "width",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 832
                 },
@@ -2191,7 +2687,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 837
                 },
@@ -2200,7 +2698,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 838
                 },
@@ -2209,7 +2709,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 840
                 },
@@ -2218,7 +2720,9 @@
                     "token": "sigpicwidth",
                     "value": "sigpicwidth",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 841
                 },
@@ -2227,7 +2731,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 852
                 },
@@ -2236,7 +2742,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 853
                 },
@@ -2245,7 +2753,9 @@
                     "token": "sigpic",
                     "value": "sigpic",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 854
                 },
@@ -2254,7 +2764,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 860
                 },
@@ -2263,7 +2775,9 @@
                     "token": "height",
                     "value": "height",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 861
                 },
@@ -2272,7 +2786,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 867
                 },
@@ -2281,7 +2797,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 868
                 },
@@ -2290,7 +2808,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 870
                 },
@@ -2299,7 +2819,9 @@
                     "token": "sigpicheight",
                     "value": "sigpicheight",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 871
                 },
@@ -2308,7 +2830,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 883
                 },
@@ -2317,7 +2841,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 884
                 },
@@ -2326,7 +2852,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 885
                 },
@@ -2335,7 +2863,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 887
                 },
@@ -2344,7 +2874,9 @@
                     "token": "displaygroupid",
                     "value": "displaygroupid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 888
                 },
@@ -2353,7 +2885,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 902
                 },
@@ -2362,7 +2896,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 903
                 },
@@ -2371,7 +2907,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 904
                 },
@@ -2380,7 +2918,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 905
                 },
@@ -2389,7 +2929,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "user",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 906
                 },
@@ -2398,7 +2940,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 910
                 },
@@ -2407,7 +2951,9 @@
                     "token": "usergroupid",
                     "value": "usergroupid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 911
                 },
@@ -2416,7 +2962,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 922
                 },
@@ -2425,7 +2973,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 923
                 },
@@ -2434,7 +2984,9 @@
                     "token": "displaygroupid",
                     "value": "displaygroupid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 924
                 },
@@ -2443,7 +2995,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 938
                 },
@@ -2452,7 +3006,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 939
                 },
@@ -2461,7 +3017,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 940
                 },
@@ -2470,7 +3028,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 942
                 },
@@ -2479,7 +3039,9 @@
                     "token": "displaygroupid",
                     "value": "displaygroupid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 943
                 },
@@ -2488,7 +3050,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 957
                 },
@@ -2497,7 +3061,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 958
                 },
@@ -2506,7 +3072,9 @@
                     "token": "infractiongroupid",
                     "value": "infractiongroupid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 959
                 },
@@ -2515,7 +3083,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 976
                 },
@@ -2524,7 +3094,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 977
                 },
@@ -2533,7 +3105,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 978
                 },
@@ -2542,7 +3116,9 @@
                     "token": "post_icon_list",
                     "value": "post_icon_list",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 979
                 },
@@ -2551,7 +3127,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 993
                 },
@@ -2560,7 +3138,9 @@
                     "token": "icon_id_list",
                     "value": "icon_id_list",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 994
                 },
@@ -2569,7 +3149,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1006
                 },
@@ -2578,7 +3160,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1007
                 },
@@ -2587,7 +3171,9 @@
                     "token": "post_icon_list",
                     "value": "post_icon_list",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1008
                 },
@@ -2596,7 +3182,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1022
                 },
@@ -2605,7 +3193,9 @@
                     "token": "is_auto",
                     "value": "is_auto",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1023
                 },
@@ -2614,7 +3204,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1030
                 },
@@ -2623,7 +3215,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1031
                 },
@@ -2632,7 +3226,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1033
                 },
@@ -2641,7 +3237,9 @@
                     "token": "icon_is_auto",
                     "value": "icon_is_auto",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1034
                 },
@@ -2650,7 +3248,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1046
                 },
@@ -2659,7 +3259,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1047
                 },
@@ -2668,7 +3270,9 @@
                     "token": "approvedlog",
                     "value": "approvedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1048
                 },
@@ -2677,7 +3281,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1059
                 },
@@ -2686,7 +3292,9 @@
                     "token": "modid",
                     "value": "modid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1060
                 },
@@ -2695,7 +3303,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1065
                 },
@@ -2704,7 +3314,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1066
                 },
@@ -2713,7 +3325,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1068
                 },
@@ -2722,7 +3336,9 @@
                     "token": "approvedmodid",
                     "value": "approvedmodid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1069
                 },
@@ -2731,7 +3347,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1082
                 },
@@ -2740,7 +3358,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1083
                 },
@@ -2749,7 +3369,9 @@
                     "token": "approvedlog",
                     "value": "approvedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1084
                 },
@@ -2758,7 +3380,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1095
                 },
@@ -2767,7 +3391,9 @@
                     "token": "dateline",
                     "value": "dateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1096
                 },
@@ -2776,7 +3402,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1104
                 },
@@ -2785,7 +3413,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1105
                 },
@@ -2794,7 +3424,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1107
                 },
@@ -2803,7 +3435,9 @@
                     "token": "approveddateline",
                     "value": "approveddateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1108
                 },
@@ -2812,7 +3446,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1124
                 },
@@ -2821,7 +3457,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1125
                 },
@@ -2830,7 +3468,9 @@
                     "token": "approvedlog",
                     "value": "approvedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1126
                 },
@@ -2839,7 +3479,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1137
                 },
@@ -2848,7 +3490,9 @@
                     "token": "status",
                     "value": "status",
                     "keyword": "STATUS",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1138
                 },
@@ -2857,7 +3501,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1144
                 },
@@ -2866,7 +3512,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1145
                 },
@@ -2875,7 +3523,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1147
                 },
@@ -2884,7 +3534,9 @@
                     "token": "approvedstatus",
                     "value": "approvedstatus",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1148
                 },
@@ -2893,7 +3545,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1162
                 },
@@ -2902,7 +3556,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1163
                 },
@@ -2911,7 +3567,9 @@
                     "token": "approvedlog",
                     "value": "approvedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1164
                 },
@@ -2920,7 +3578,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1175
                 },
@@ -2929,7 +3589,9 @@
                     "token": "info",
                     "value": "info",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1176
                 },
@@ -2938,7 +3600,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1180
                 },
@@ -2947,7 +3611,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1181
                 },
@@ -2956,7 +3622,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1183
                 },
@@ -2965,7 +3633,9 @@
                     "token": "approvedinfo",
                     "value": "approvedinfo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1184
                 },
@@ -2974,7 +3644,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1196
                 },
@@ -2983,7 +3655,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1197
                 },
@@ -2992,7 +3666,9 @@
                     "token": "movedlog",
                     "value": "movedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1198
                 },
@@ -3001,7 +3677,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1206
                 },
@@ -3010,7 +3688,9 @@
                     "token": "modid",
                     "value": "modid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1207
                 },
@@ -3019,7 +3699,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1212
                 },
@@ -3028,7 +3710,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1213
                 },
@@ -3037,7 +3721,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1215
                 },
@@ -3046,7 +3732,9 @@
                     "token": "movedmodid",
                     "value": "movedmodid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1216
                 },
@@ -3055,7 +3743,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1226
                 },
@@ -3064,7 +3754,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1227
                 },
@@ -3073,7 +3765,9 @@
                     "token": "movedlog",
                     "value": "movedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1228
                 },
@@ -3082,7 +3776,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1236
                 },
@@ -3091,7 +3787,9 @@
                     "token": "dateline",
                     "value": "dateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1237
                 },
@@ -3100,7 +3798,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1245
                 },
@@ -3109,7 +3809,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1246
                 },
@@ -3118,7 +3820,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1248
                 },
@@ -3127,7 +3831,9 @@
                     "token": "moveddateline",
                     "value": "moveddateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1249
                 },
@@ -3136,7 +3842,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1262
                 },
@@ -3145,7 +3853,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1263
                 },
@@ -3154,7 +3864,9 @@
                     "token": "movedlog",
                     "value": "movedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1264
                 },
@@ -3163,7 +3875,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1272
                 },
@@ -3172,7 +3886,9 @@
                     "token": "status",
                     "value": "status",
                     "keyword": "STATUS",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1273
                 },
@@ -3181,7 +3897,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1279
                 },
@@ -3190,7 +3908,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1280
                 },
@@ -3199,7 +3919,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1282
                 },
@@ -3208,7 +3930,9 @@
                     "token": "movedstatus",
                     "value": "movedstatus",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1283
                 },
@@ -3217,7 +3941,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1294
                 },
@@ -3226,7 +3952,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1295
                 },
@@ -3235,7 +3963,9 @@
                     "token": "movedlog",
                     "value": "movedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1296
                 },
@@ -3244,7 +3974,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1304
                 },
@@ -3253,7 +3985,9 @@
                     "token": "info",
                     "value": "info",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1305
                 },
@@ -3262,7 +3996,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1309
                 },
@@ -3271,7 +4007,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1310
                 },
@@ -3280,7 +4018,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1312
                 },
@@ -3289,7 +4029,9 @@
                     "token": "movedinfo",
                     "value": "movedinfo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1313
                 },
@@ -3298,7 +4040,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1322
                 },
@@ -3307,7 +4051,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1323
                 },
@@ -3316,7 +4062,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1324
                 },
@@ -3325,7 +4073,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1325
                 },
@@ -3334,7 +4084,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1326
                 },
@@ -3343,7 +4095,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1332
                 },
@@ -3352,7 +4106,9 @@
                     "token": "useragent",
                     "value": "useragent",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1333
                 },
@@ -3361,7 +4117,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1342
                 },
@@ -3370,7 +4128,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1343
                 },
@@ -3379,7 +4139,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1347
                 },
@@ -3388,7 +4150,9 @@
                     "token": "session",
                     "value": "session",
                     "keyword": "SESSION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 1348
                 },
@@ -3397,7 +4161,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1355
                 },
@@ -3406,7 +4172,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1356
                 },
@@ -3415,7 +4183,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1361
                 },
@@ -3424,7 +4194,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1362
                 },
@@ -3433,7 +4205,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 1368
                 },
@@ -3442,7 +4216,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1369
                 },
@@ -3451,7 +4227,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1373
                 },
@@ -3460,7 +4238,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1374
                 },
@@ -3469,7 +4249,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1380
                 },
@@ -3478,7 +4260,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1381
                 },
@@ -3487,7 +4271,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1384
                 },
@@ -3496,7 +4282,9 @@
                     "token": "lastactivity",
                     "value": "lastactivity",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1385
                 },
@@ -3505,7 +4293,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1397
                 },
@@ -3514,7 +4304,9 @@
                     "token": ">",
                     "value": ">",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 1398
                 },
@@ -3523,7 +4315,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1399
                 },
@@ -3532,7 +4326,9 @@
                     "token": "1644859580",
                     "value": 1644859580,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 1400
                 },
@@ -3541,7 +4337,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1410
                 },
@@ -3550,7 +4348,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 1411
                 },
@@ -3559,7 +4359,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1419
                 },
@@ -3568,7 +4370,9 @@
                     "token": "lastactivity",
                     "value": "lastactivity",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1420
                 },
@@ -3577,7 +4381,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1432
                 },
@@ -3586,7 +4392,9 @@
                     "token": "DESC",
                     "value": "DESC",
                     "keyword": "DESC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1433
                 },
@@ -3595,7 +4403,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1437
                 },
@@ -3604,7 +4414,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1438
                 },
@@ -3613,7 +4425,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1443
                 },
@@ -3622,7 +4436,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 1444
                 },
@@ -3631,7 +4447,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1445
                 },
@@ -3640,7 +4458,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1446
                 },
@@ -3649,7 +4469,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1447
                 },
@@ -3658,7 +4480,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1448
                 },
@@ -3667,7 +4491,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1450
                 },
@@ -3676,7 +4502,9 @@
                     "token": "useragent",
                     "value": "useragent",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1451
                 },
@@ -3685,7 +4513,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1460
                 },
@@ -3694,7 +4524,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1461
                 },
@@ -3703,7 +4535,9 @@
                     "token": "IF",
                     "value": "IF",
                     "keyword": "IF",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 1462
                 },
@@ -3712,7 +4546,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1464
                 },
@@ -3721,7 +4557,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1465
                 },
@@ -3730,7 +4568,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1466
                 },
@@ -3739,7 +4579,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "user",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1467
                 },
@@ -3748,7 +4590,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1471
                 },
@@ -3757,7 +4601,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1472
                 },
@@ -3766,7 +4612,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1478
                 },
@@ -3775,7 +4623,9 @@
                     "token": "IS",
                     "value": "IS",
                     "keyword": "IS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1479
                 },
@@ -3784,7 +4634,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1481
                 },
@@ -3793,7 +4645,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 1482
                 },
@@ -3802,7 +4656,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1490
                 },
@@ -3811,7 +4667,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1491
                 },
@@ -3820,7 +4678,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1492
                 },
@@ -3829,7 +4689,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1493
                 },
@@ -3838,7 +4700,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1499
                 },
@@ -3847,7 +4711,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 1500
                 },
@@ -3856,7 +4722,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1505
                 },
@@ -3865,7 +4733,9 @@
                     "token": "usernoteid",
                     "value": "usernoteid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1506
                 },
@@ -3874,7 +4744,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1516
                 },
@@ -3883,7 +4755,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1517
                 },
@@ -3892,7 +4766,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1518
                 },
@@ -3901,7 +4777,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1522
                 },
@@ -3910,7 +4788,9 @@
                     "token": "usernote",
                     "value": "usernote",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1523
                 },
@@ -3919,7 +4799,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1531
                 },
@@ -3928,7 +4810,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1532
                 },
@@ -3937,7 +4821,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1534
                 },
@@ -3946,7 +4832,9 @@
                     "token": "usernote",
                     "value": "usernote",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1535
                 },
@@ -3955,7 +4843,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1543
                 },
@@ -3964,7 +4854,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1544
                 },
@@ -3973,7 +4865,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1549
                 },
@@ -3982,7 +4876,9 @@
                     "token": "usernote",
                     "value": "usernote",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1550
                 },
@@ -3991,7 +4887,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1558
                 },
@@ -4000,7 +4898,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1559
                 },
@@ -4009,7 +4909,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 1565
                 },
@@ -4018,7 +4920,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "user",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1566
                 },
@@ -4027,7 +4931,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1570
                 },
@@ -4036,7 +4942,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1571
                 },
@@ -4045,7 +4953,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1577
                 },
@@ -4054,7 +4964,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1578
                 },
@@ -4063,7 +4975,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1581
                 },
@@ -4072,7 +4986,9 @@
                     "token": "usernote",
                     "value": "usernote",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1582
                 },
@@ -4081,7 +4997,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1590
                 },
@@ -4090,7 +5008,9 @@
                     "token": "priority",
                     "value": "priority",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1591
                 },
@@ -4099,7 +5019,9 @@
                     "token": ">=",
                     "value": ">=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 1599
                 },
@@ -4108,7 +5030,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 1601
                 },
@@ -4117,7 +5041,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1602
                 },
@@ -4126,7 +5052,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1603
                 },
@@ -4135,7 +5063,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1604
                 },
@@ -4144,7 +5074,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 1605
                 },
@@ -4153,7 +5085,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1606
                 },
@@ -4162,7 +5096,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1607
                 },
@@ -4171,7 +5107,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1608
                 },
@@ -4180,7 +5118,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1609
                 },
@@ -4189,7 +5129,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1611
                 },
@@ -4198,7 +5140,9 @@
                     "token": "usernotecount",
                     "value": "usernotecount",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1612
                 },
@@ -4207,7 +5151,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1625
                 },
@@ -4216,7 +5162,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1626
                 },
@@ -4225,7 +5173,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1627
                 },
@@ -4234,7 +5184,9 @@
                     "token": "deletionlog",
                     "value": "deletionlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1628
                 },
@@ -4243,7 +5195,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1639
                 },
@@ -4252,7 +5206,9 @@
                     "token": "dateline",
                     "value": "dateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1640
                 },
@@ -4261,7 +5217,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1648
                 },
@@ -4270,7 +5228,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1649
                 },
@@ -4279,7 +5239,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1651
                 },
@@ -4288,7 +5250,9 @@
                     "token": "del_dateline",
                     "value": "del_dateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1652
                 },
@@ -4297,7 +5261,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1664
                 },
@@ -4306,7 +5272,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1665
                 },
@@ -4315,7 +5283,9 @@
                     "token": "scheduled_approval",
                     "value": "scheduled_approval",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1666
                 },
@@ -4324,7 +5294,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1684
                 },
@@ -4333,7 +5305,9 @@
                     "token": "defer_time",
                     "value": "defer_time",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1685
                 },
@@ -4342,7 +5316,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1695
                 },
@@ -4351,7 +5327,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1696
                 },
@@ -4360,7 +5338,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1698
                 },
@@ -4369,7 +5349,9 @@
                     "token": "vbpmal_approval_defer_time",
                     "value": "vbpmal_approval_defer_time",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1699
                 },
@@ -4378,7 +5360,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1725
                 },
@@ -4387,7 +5371,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1726
                 },
@@ -4396,7 +5382,9 @@
                     "token": "additional_user_data",
                     "value": "additional_user_data",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1727
                 },
@@ -4405,7 +5393,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1747
                 },
@@ -4414,7 +5404,9 @@
                     "token": "last_year_message_count",
                     "value": "last_year_message_count",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1748
                 },
@@ -4423,7 +5415,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1771
                 },
@@ -4432,7 +5426,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1772
                 },
@@ -4441,7 +5437,9 @@
                     "token": "additional_user_data",
                     "value": "additional_user_data",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1773
                 },
@@ -4450,7 +5448,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1793
                 },
@@ -4459,7 +5459,9 @@
                     "token": "last_year_reputation",
                     "value": "last_year_reputation",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1794
                 },
@@ -4468,7 +5470,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1814
                 },
@@ -4477,7 +5481,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1815
                 },
@@ -4486,7 +5492,9 @@
                     "token": "additional_user_data",
                     "value": "additional_user_data",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1816
                 },
@@ -4495,7 +5503,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1836
                 },
@@ -4504,7 +5514,9 @@
                     "token": "last_year_groan_count",
                     "value": "last_year_groan_count",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1837
                 },
@@ -4513,7 +5525,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1858
                 },
@@ -4522,7 +5536,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1859
                 },
@@ -4531,7 +5547,9 @@
                     "token": "paid_post_activation",
                     "value": "paid_post_activation",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1860
                 },
@@ -4540,7 +5558,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1880
                 },
@@ -4549,7 +5569,9 @@
                     "token": "activation_id",
                     "value": "activation_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1881
                 },
@@ -4558,7 +5580,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1894
                 },
@@ -4567,7 +5591,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1895
                 },
@@ -4576,7 +5602,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1897
                 },
@@ -4585,7 +5613,9 @@
                     "token": "paid_post_activation_id",
                     "value": "paid_post_activation_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1898
                 },
@@ -4594,7 +5624,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1921
                 },
@@ -4603,7 +5635,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1922
                 },
@@ -4612,7 +5646,9 @@
                     "token": "alm_Model_UserData",
                     "value": "alm_Model_UserData",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1923
                 },
@@ -4621,7 +5657,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1941
                 },
@@ -4630,7 +5668,9 @@
                     "token": "credits",
                     "value": "credits",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1942
                 },
@@ -4639,7 +5679,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1949
                 },
@@ -4648,7 +5690,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1950
                 },
@@ -4657,7 +5701,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1954
                 },
@@ -4666,7 +5712,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1955
                 },
@@ -4675,7 +5723,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1959
                 },
@@ -4684,7 +5734,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1960
                 },
@@ -4693,7 +5745,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1962
                 },
@@ -4702,7 +5756,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1963
                 },
@@ -4711,7 +5767,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1967
                 },
@@ -4720,7 +5778,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 1968
                 },
@@ -4729,7 +5789,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1977
                 },
@@ -4738,7 +5800,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 1978
                 },
@@ -4747,7 +5811,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1982
                 },
@@ -4756,7 +5822,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1983
                 },
@@ -4765,7 +5833,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1985
                 },
@@ -4774,7 +5844,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 1986
                 },
@@ -4783,7 +5855,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 1990
                 },
@@ -4792,7 +5866,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 1991
                 },
@@ -4801,7 +5877,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1993
                 },
@@ -4810,7 +5888,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "user",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1994
                 },
@@ -4819,7 +5899,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 1998
                 },
@@ -4828,7 +5910,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 1999
                 },
@@ -4837,7 +5921,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2005
                 },
@@ -4846,7 +5932,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2006
                 },
@@ -4855,7 +5943,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2007
                 },
@@ -4864,7 +5954,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2008
                 },
@@ -4873,7 +5965,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2012
                 },
@@ -4882,7 +5976,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2013
                 },
@@ -4891,7 +5987,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2019
                 },
@@ -4900,7 +5998,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2020
                 },
@@ -4909,7 +6009,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2021
                 },
@@ -4918,7 +6020,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2030
                 },
@@ -4927,7 +6031,9 @@
                     "token": "userfield",
                     "value": "userfield",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2031
                 },
@@ -4936,7 +6042,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2040
                 },
@@ -4945,7 +6053,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2041
                 },
@@ -4954,7 +6064,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2043
                 },
@@ -4963,7 +6075,9 @@
                     "token": "userfield",
                     "value": "userfield",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2044
                 },
@@ -4972,7 +6086,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2053
                 },
@@ -4981,7 +6097,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2054
                 },
@@ -4990,7 +6108,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2056
                 },
@@ -4999,7 +6119,9 @@
                     "token": "userfield",
                     "value": "userfield",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2057
                 },
@@ -5008,7 +6130,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2066
                 },
@@ -5017,7 +6141,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2067
                 },
@@ -5026,7 +6152,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2073
                 },
@@ -5035,7 +6163,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2074
                 },
@@ -5044,7 +6174,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2075
                 },
@@ -5053,7 +6185,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "user",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2076
                 },
@@ -5062,7 +6196,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2080
                 },
@@ -5071,7 +6207,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2081
                 },
@@ -5080,7 +6218,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2087
                 },
@@ -5089,7 +6229,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2088
                 },
@@ -5098,7 +6240,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2089
                 },
@@ -5107,7 +6251,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2098
                 },
@@ -5116,7 +6262,9 @@
                     "token": "usertextfield",
                     "value": "usertextfield",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2099
                 },
@@ -5125,7 +6273,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2112
                 },
@@ -5134,7 +6284,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2113
                 },
@@ -5143,7 +6295,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2115
                 },
@@ -5152,7 +6306,9 @@
                     "token": "usertextfield",
                     "value": "usertextfield",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2116
                 },
@@ -5161,7 +6317,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2129
                 },
@@ -5170,7 +6328,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2130
                 },
@@ -5179,7 +6339,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2132
                 },
@@ -5188,7 +6350,9 @@
                     "token": "usertextfield",
                     "value": "usertextfield",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2133
                 },
@@ -5197,7 +6361,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2146
                 },
@@ -5206,7 +6372,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2147
                 },
@@ -5215,7 +6383,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2153
                 },
@@ -5224,7 +6394,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2154
                 },
@@ -5233,7 +6405,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2155
                 },
@@ -5242,7 +6416,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "user",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2156
                 },
@@ -5251,7 +6427,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2160
                 },
@@ -5260,7 +6438,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2161
                 },
@@ -5269,7 +6449,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2167
                 },
@@ -5278,7 +6460,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2168
                 },
@@ -5287,7 +6471,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2169
                 },
@@ -5296,7 +6482,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2178
                 },
@@ -5305,7 +6493,9 @@
                     "token": "icon",
                     "value": "icon",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2179
                 },
@@ -5314,7 +6504,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2183
                 },
@@ -5323,7 +6515,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2184
                 },
@@ -5332,7 +6526,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2186
                 },
@@ -5341,7 +6537,9 @@
                     "token": "icon",
                     "value": "icon",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2187
                 },
@@ -5350,7 +6548,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2191
                 },
@@ -5359,7 +6559,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2192
                 },
@@ -5368,7 +6570,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2194
                 },
@@ -5377,7 +6581,9 @@
                     "token": "icon",
                     "value": "icon",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2195
                 },
@@ -5386,7 +6592,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2199
                 },
@@ -5395,7 +6603,9 @@
                     "token": "iconid",
                     "value": "iconid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2200
                 },
@@ -5404,7 +6614,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2206
                 },
@@ -5413,7 +6625,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2207
                 },
@@ -5422,7 +6636,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2208
                 },
@@ -5431,7 +6647,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2209
                 },
@@ -5440,7 +6658,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2213
                 },
@@ -5449,7 +6669,9 @@
                     "token": "iconid",
                     "value": "iconid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2214
                 },
@@ -5458,7 +6680,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2220
                 },
@@ -5467,7 +6691,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2221
                 },
@@ -5476,7 +6702,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2222
                 },
@@ -5485,7 +6713,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2231
                 },
@@ -5494,7 +6724,9 @@
                     "token": "avatar",
                     "value": "avatar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2232
                 },
@@ -5503,7 +6735,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2238
                 },
@@ -5512,7 +6746,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2239
                 },
@@ -5521,7 +6757,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2241
                 },
@@ -5530,7 +6768,9 @@
                     "token": "avatar",
                     "value": "avatar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2242
                 },
@@ -5539,7 +6779,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2248
                 },
@@ -5548,7 +6790,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2250
                 },
@@ -5557,7 +6801,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2252
                 },
@@ -5566,7 +6812,9 @@
                     "token": "avatar",
                     "value": "avatar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2253
                 },
@@ -5575,7 +6823,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2259
                 },
@@ -5584,7 +6834,9 @@
                     "token": "avatarid",
                     "value": "avatarid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2260
                 },
@@ -5593,7 +6845,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2268
                 },
@@ -5602,7 +6856,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2269
                 },
@@ -5611,7 +6867,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2270
                 },
@@ -5620,7 +6878,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "user",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2271
                 },
@@ -5629,7 +6889,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2275
                 },
@@ -5638,7 +6900,9 @@
                     "token": "avatarid",
                     "value": "avatarid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2276
                 },
@@ -5647,7 +6911,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2284
                 },
@@ -5656,7 +6922,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2285
                 },
@@ -5665,7 +6933,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2286
                 },
@@ -5674,7 +6944,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2295
                 },
@@ -5683,7 +6955,9 @@
                     "token": "customavatar",
                     "value": "customavatar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2296
                 },
@@ -5692,7 +6966,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2308
                 },
@@ -5701,7 +6977,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2309
                 },
@@ -5710,7 +6988,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2311
                 },
@@ -5719,7 +6999,9 @@
                     "token": "customavatar",
                     "value": "customavatar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2312
                 },
@@ -5728,7 +7010,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2324
                 },
@@ -5737,7 +7021,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2325
                 },
@@ -5746,7 +7032,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2327
                 },
@@ -5755,7 +7043,9 @@
                     "token": "customavatar",
                     "value": "customavatar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2328
                 },
@@ -5764,7 +7054,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2340
                 },
@@ -5773,7 +7065,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2341
                 },
@@ -5782,7 +7076,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2347
                 },
@@ -5791,7 +7087,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2348
                 },
@@ -5800,7 +7098,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2349
                 },
@@ -5809,7 +7109,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "user",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2350
                 },
@@ -5818,7 +7120,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2354
                 },
@@ -5827,7 +7131,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2355
                 },
@@ -5836,7 +7142,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2361
                 },
@@ -5845,7 +7153,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2362
                 },
@@ -5854,7 +7164,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2363
                 },
@@ -5863,7 +7175,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2372
                 },
@@ -5872,7 +7186,9 @@
                     "token": "spamlog",
                     "value": "spamlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2373
                 },
@@ -5881,7 +7197,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2380
                 },
@@ -5890,7 +7208,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2381
                 },
@@ -5899,7 +7219,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2383
                 },
@@ -5908,7 +7230,9 @@
                     "token": "spamlog",
                     "value": "spamlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2384
                 },
@@ -5917,7 +7241,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2391
                 },
@@ -5926,7 +7252,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2392
                 },
@@ -5935,7 +7263,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2394
                 },
@@ -5944,7 +7274,9 @@
                     "token": "spamlog",
                     "value": "spamlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2395
                 },
@@ -5953,7 +7285,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2402
                 },
@@ -5962,7 +7296,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2403
                 },
@@ -5971,7 +7307,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2409
                 },
@@ -5980,7 +7318,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2410
                 },
@@ -5989,7 +7329,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2411
                 },
@@ -5998,7 +7340,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2412
                 },
@@ -6007,7 +7351,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2416
                 },
@@ -6016,7 +7362,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2417
                 },
@@ -6025,7 +7373,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2423
                 },
@@ -6034,7 +7384,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2424
                 },
@@ -6043,7 +7395,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2425
                 },
@@ -6052,7 +7406,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2434
                 },
@@ -6061,7 +7417,9 @@
                     "token": "deletionlog",
                     "value": "deletionlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2435
                 },
@@ -6070,7 +7428,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2446
                 },
@@ -6079,7 +7439,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2447
                 },
@@ -6088,7 +7450,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2449
                 },
@@ -6097,7 +7461,9 @@
                     "token": "deletionlog",
                     "value": "deletionlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2450
                 },
@@ -6106,7 +7472,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2461
                 },
@@ -6115,7 +7483,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2462
                 },
@@ -6124,7 +7494,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2464
                 },
@@ -6133,7 +7505,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2465
                 },
@@ -6142,7 +7516,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2469
                 },
@@ -6151,7 +7527,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2470
                 },
@@ -6160,7 +7538,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2476
                 },
@@ -6169,7 +7549,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2477
                 },
@@ -6178,7 +7560,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2478
                 },
@@ -6187,7 +7571,9 @@
                     "token": "deletionlog",
                     "value": "deletionlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2479
                 },
@@ -6196,7 +7582,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2490
                 },
@@ -6205,7 +7593,9 @@
                     "token": "primaryid",
                     "value": "primaryid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2491
                 },
@@ -6214,7 +7604,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2500
                 },
@@ -6223,7 +7615,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2501
                 },
@@ -6232,7 +7626,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2504
                 },
@@ -6241,7 +7637,9 @@
                     "token": "deletionlog",
                     "value": "deletionlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2505
                 },
@@ -6250,7 +7648,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2516
                 },
@@ -6259,7 +7659,9 @@
                     "token": "type",
                     "value": "type",
                     "keyword": "TYPE",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2517
                 },
@@ -6268,7 +7670,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2521
                 },
@@ -6277,7 +7681,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2522
                 },
@@ -6286,7 +7692,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2523
                 },
@@ -6295,7 +7703,11 @@
                     "token": "'post'",
                     "value": "post",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 2524
                 },
@@ -6304,7 +7716,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2530
                 },
@@ -6313,7 +7727,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2531
                 },
@@ -6322,7 +7738,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2532
                 },
@@ -6331,7 +7749,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2541
                 },
@@ -6340,7 +7760,9 @@
                     "token": "editlog",
                     "value": "editlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2542
                 },
@@ -6349,7 +7771,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2549
                 },
@@ -6358,7 +7782,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2550
                 },
@@ -6367,7 +7793,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2552
                 },
@@ -6376,7 +7804,9 @@
                     "token": "editlog",
                     "value": "editlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2553
                 },
@@ -6385,7 +7815,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2560
                 },
@@ -6394,7 +7826,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2561
                 },
@@ -6403,7 +7837,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2563
                 },
@@ -6412,7 +7848,9 @@
                     "token": "editlog",
                     "value": "editlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2564
                 },
@@ -6421,7 +7859,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2571
                 },
@@ -6430,7 +7870,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2572
                 },
@@ -6439,7 +7881,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2578
                 },
@@ -6448,7 +7892,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2579
                 },
@@ -6457,7 +7903,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2580
                 },
@@ -6466,7 +7914,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2581
                 },
@@ -6475,7 +7925,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2585
                 },
@@ -6484,7 +7936,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2586
                 },
@@ -6493,7 +7947,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2592
                 },
@@ -6502,7 +7958,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2593
                 },
@@ -6511,7 +7969,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2594
                 },
@@ -6520,7 +7980,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2603
                 },
@@ -6529,7 +7991,9 @@
                     "token": "postparsed",
                     "value": "postparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2604
                 },
@@ -6538,7 +8002,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2614
                 },
@@ -6547,7 +8013,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2615
                 },
@@ -6556,7 +8024,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2617
                 },
@@ -6565,7 +8035,9 @@
                     "token": "postparsed",
                     "value": "postparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2618
                 },
@@ -6574,7 +8046,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2628
                 },
@@ -6583,7 +8057,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2629
                 },
@@ -6592,7 +8068,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2631
                 },
@@ -6601,7 +8079,9 @@
                     "token": "postparsed",
                     "value": "postparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2632
                 },
@@ -6610,7 +8090,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2642
                 },
@@ -6619,7 +8101,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2643
                 },
@@ -6628,7 +8112,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2649
                 },
@@ -6637,7 +8123,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2650
                 },
@@ -6646,7 +8134,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2651
                 },
@@ -6655,7 +8145,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2652
                 },
@@ -6664,7 +8156,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2656
                 },
@@ -6673,7 +8167,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2657
                 },
@@ -6682,7 +8178,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2663
                 },
@@ -6691,7 +8189,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2664
                 },
@@ -6700,7 +8200,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2667
                 },
@@ -6709,7 +8211,9 @@
                     "token": "postparsed",
                     "value": "postparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2668
                 },
@@ -6718,7 +8222,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2678
                 },
@@ -6727,7 +8233,9 @@
                     "token": "styleid",
                     "value": "styleid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2679
                 },
@@ -6736,7 +8244,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2686
                 },
@@ -6745,7 +8255,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2687
                 },
@@ -6754,7 +8266,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2688
                 },
@@ -6763,7 +8277,9 @@
                     "token": "23",
                     "value": 23,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 2689
                 },
@@ -6772,7 +8288,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2691
                 },
@@ -6781,7 +8299,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2692
                 },
@@ -6790,7 +8310,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2695
                 },
@@ -6799,7 +8321,9 @@
                     "token": "postparsed",
                     "value": "postparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2696
                 },
@@ -6808,7 +8332,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2706
                 },
@@ -6817,7 +8343,9 @@
                     "token": "languageid",
                     "value": "languageid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2707
                 },
@@ -6826,7 +8354,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2717
                 },
@@ -6835,7 +8365,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2718
                 },
@@ -6844,7 +8376,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2719
                 },
@@ -6853,7 +8387,9 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 2720
                 },
@@ -6862,7 +8398,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2721
                 },
@@ -6871,7 +8409,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2722
                 },
@@ -6880,7 +8420,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2723
                 },
@@ -6889,7 +8431,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2732
                 },
@@ -6898,7 +8442,9 @@
                     "token": "sigparsed",
                     "value": "sigparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2733
                 },
@@ -6907,7 +8453,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2742
                 },
@@ -6916,7 +8464,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2743
                 },
@@ -6925,7 +8475,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2745
                 },
@@ -6934,7 +8486,9 @@
                     "token": "sigparsed",
                     "value": "sigparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2746
                 },
@@ -6943,7 +8497,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2755
                 },
@@ -6952,7 +8508,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2756
                 },
@@ -6961,7 +8519,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2758
                 },
@@ -6970,7 +8530,9 @@
                     "token": "sigparsed",
                     "value": "sigparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2759
                 },
@@ -6979,7 +8541,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2768
                 },
@@ -6988,7 +8552,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2769
                 },
@@ -6997,7 +8563,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2775
                 },
@@ -7006,7 +8574,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2776
                 },
@@ -7015,7 +8585,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2777
                 },
@@ -7024,7 +8596,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "user",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2778
                 },
@@ -7033,7 +8607,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2782
                 },
@@ -7042,7 +8618,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2783
                 },
@@ -7051,7 +8629,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2789
                 },
@@ -7060,7 +8640,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2790
                 },
@@ -7069,7 +8651,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2793
                 },
@@ -7078,7 +8662,9 @@
                     "token": "sigparsed",
                     "value": "sigparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2794
                 },
@@ -7087,7 +8673,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2803
                 },
@@ -7096,7 +8684,9 @@
                     "token": "styleid",
                     "value": "styleid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2804
                 },
@@ -7105,7 +8695,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2811
                 },
@@ -7114,7 +8706,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2812
                 },
@@ -7123,7 +8717,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2813
                 },
@@ -7132,7 +8728,9 @@
                     "token": "23",
                     "value": 23,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 2814
                 },
@@ -7141,7 +8739,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2816
                 },
@@ -7150,7 +8750,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2817
                 },
@@ -7159,7 +8761,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2820
                 },
@@ -7168,7 +8772,9 @@
                     "token": "sigparsed",
                     "value": "sigparsed",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2821
                 },
@@ -7177,7 +8783,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2830
                 },
@@ -7186,7 +8794,9 @@
                     "token": "languageid",
                     "value": "languageid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2831
                 },
@@ -7195,7 +8805,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2841
                 },
@@ -7204,7 +8816,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2842
                 },
@@ -7213,7 +8827,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2843
                 },
@@ -7222,7 +8838,9 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 2844
                 },
@@ -7231,7 +8849,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2845
                 },
@@ -7240,7 +8860,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2846
                 },
@@ -7249,7 +8871,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2847
                 },
@@ -7258,7 +8882,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2856
                 },
@@ -7267,7 +8893,9 @@
                     "token": "sigpic",
                     "value": "sigpic",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2857
                 },
@@ -7276,7 +8904,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2863
                 },
@@ -7285,7 +8915,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2864
                 },
@@ -7294,7 +8926,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2866
                 },
@@ -7303,7 +8937,9 @@
                     "token": "sigpic",
                     "value": "sigpic",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2867
                 },
@@ -7312,7 +8948,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2873
                 },
@@ -7321,7 +8959,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2874
                 },
@@ -7330,7 +8970,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2876
                 },
@@ -7339,7 +8981,9 @@
                     "token": "sigpic",
                     "value": "sigpic",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2877
                 },
@@ -7348,7 +8992,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2883
                 },
@@ -7357,7 +9003,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2884
                 },
@@ -7366,7 +9014,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2890
                 },
@@ -7375,7 +9025,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2891
                 },
@@ -7384,7 +9036,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2892
                 },
@@ -7393,7 +9047,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2893
                 },
@@ -7402,7 +9058,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2897
                 },
@@ -7411,7 +9069,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2898
                 },
@@ -7420,7 +9080,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2904
                 },
@@ -7429,7 +9091,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2905
                 },
@@ -7438,7 +9102,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2906
                 },
@@ -7447,7 +9113,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2915
                 },
@@ -7456,7 +9124,9 @@
                     "token": "vbppim_post_icon_list",
                     "value": "vbppim_post_icon_list",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2916
                 },
@@ -7465,7 +9135,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2937
                 },
@@ -7474,7 +9146,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2938
                 },
@@ -7483,7 +9157,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2940
                 },
@@ -7492,7 +9168,9 @@
                     "token": "post_icon_list",
                     "value": "post_icon_list",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2941
                 },
@@ -7501,7 +9179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2955
                 },
@@ -7510,7 +9190,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 2956
                 },
@@ -7519,7 +9201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2958
                 },
@@ -7528,7 +9212,9 @@
                     "token": "post_icon_list",
                     "value": "post_icon_list",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2959
                 },
@@ -7537,7 +9223,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2973
                 },
@@ -7546,7 +9234,9 @@
                     "token": "post_id",
                     "value": "post_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2974
                 },
@@ -7555,7 +9245,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 2981
                 },
@@ -7564,7 +9256,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2982
                 },
@@ -7573,7 +9267,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 2986
                 },
@@ -7582,7 +9278,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 2987
                 },
@@ -7591,7 +9289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 2993
                 },
@@ -7600,7 +9300,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 2994
                 },
@@ -7609,7 +9311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3003
                 },
@@ -7618,7 +9322,9 @@
                     "token": "vbpmal_log",
                     "value": "vbpmal_log",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3004
                 },
@@ -7627,7 +9333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3014
                 },
@@ -7636,7 +9344,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3015
                 },
@@ -7645,7 +9355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3017
                 },
@@ -7654,7 +9366,9 @@
                     "token": "approvedlog",
                     "value": "approvedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3018
                 },
@@ -7663,7 +9377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3029
                 },
@@ -7672,7 +9388,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3030
                 },
@@ -7681,7 +9399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3032
                 },
@@ -7690,7 +9410,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3033
                 },
@@ -7699,7 +9421,9 @@
                     "token": "approvedlog",
                     "value": "approvedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3034
                 },
@@ -7708,7 +9432,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3045
                 },
@@ -7717,7 +9443,9 @@
                     "token": "itemid",
                     "value": "itemid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3046
                 },
@@ -7726,7 +9454,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 3052
                 },
@@ -7735,7 +9465,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3053
                 },
@@ -7744,7 +9476,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3057
                 },
@@ -7753,7 +9487,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3058
                 },
@@ -7762,7 +9498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3064
                 },
@@ -7771,7 +9509,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3065
                 },
@@ -7780,7 +9520,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3068
                 },
@@ -7789,7 +9531,9 @@
                     "token": "approvedlog",
                     "value": "approvedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3069
                 },
@@ -7798,7 +9542,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3080
                 },
@@ -7807,7 +9553,9 @@
                     "token": "action",
                     "value": "action",
                     "keyword": "ACTION",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3081
                 },
@@ -7816,7 +9564,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 3087
                 },
@@ -7825,7 +9575,9 @@
                     "token": "'postapprove'",
                     "value": "postapprove",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@706"
+                    },
                     "flags": 1,
                     "position": 3088
                 },
@@ -7834,7 +9586,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3101
                 },
@@ -7843,7 +9597,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3102
                 },
@@ -7852,7 +9608,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 3103
                 },
@@ -7861,7 +9619,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3112
                 },
@@ -7870,7 +9630,9 @@
                     "token": "vbpmal_log",
                     "value": "vbpmal_log",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3113
                 },
@@ -7879,7 +9641,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3123
                 },
@@ -7888,7 +9652,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3124
                 },
@@ -7897,7 +9663,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3126
                 },
@@ -7906,7 +9674,9 @@
                     "token": "movedlog",
                     "value": "movedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3127
                 },
@@ -7915,7 +9685,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3135
                 },
@@ -7924,7 +9696,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3136
                 },
@@ -7933,7 +9707,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3138
                 },
@@ -7942,7 +9718,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3139
                 },
@@ -7951,7 +9729,9 @@
                     "token": "movedlog",
                     "value": "movedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3140
                 },
@@ -7960,7 +9740,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3148
                 },
@@ -7969,7 +9751,9 @@
                     "token": "itemid",
                     "value": "itemid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3149
                 },
@@ -7978,7 +9762,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 3155
                 },
@@ -7987,7 +9773,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3156
                 },
@@ -7996,7 +9784,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3160
                 },
@@ -8005,7 +9795,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3161
                 },
@@ -8014,7 +9806,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3167
                 },
@@ -8023,7 +9817,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3168
                 },
@@ -8032,7 +9828,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3171
                 },
@@ -8041,7 +9839,9 @@
                     "token": "movedlog",
                     "value": "movedlog",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3172
                 },
@@ -8050,7 +9850,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3180
                 },
@@ -8059,7 +9861,9 @@
                     "token": "action",
                     "value": "action",
                     "keyword": "ACTION",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3181
                 },
@@ -8068,7 +9872,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 3187
                 },
@@ -8077,7 +9883,9 @@
                     "token": "'postmove'",
                     "value": "postmove",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@706"
+                    },
                     "flags": 1,
                     "position": 3188
                 },
@@ -8086,7 +9894,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3198
                 },
@@ -8095,7 +9905,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3199
                 },
@@ -8104,7 +9916,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 3200
                 },
@@ -8113,7 +9927,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3209
                 },
@@ -8122,7 +9938,9 @@
                     "token": "vbpmal_scheduled_post_approval",
                     "value": "vbpmal_scheduled_post_approval",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3210
                 },
@@ -8131,7 +9949,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3240
                 },
@@ -8140,7 +9960,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3241
                 },
@@ -8149,7 +9971,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3243
                 },
@@ -8158,7 +9982,9 @@
                     "token": "scheduled_approval",
                     "value": "scheduled_approval",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3244
                 },
@@ -8167,7 +9993,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3262
                 },
@@ -8176,7 +10004,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3263
                 },
@@ -8185,7 +10015,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3265
                 },
@@ -8194,7 +10026,9 @@
                     "token": "scheduled_approval",
                     "value": "scheduled_approval",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3266
                 },
@@ -8203,7 +10037,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3284
                 },
@@ -8212,7 +10048,9 @@
                     "token": "post_id",
                     "value": "post_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3285
                 },
@@ -8221,7 +10059,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3292
                 },
@@ -8230,7 +10070,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 3293
                 },
@@ -8239,7 +10081,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3294
                 },
@@ -8248,7 +10092,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3295
                 },
@@ -8257,7 +10103,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3299
                 },
@@ -8266,7 +10114,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3300
                 },
@@ -8275,7 +10125,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3306
                 },
@@ -8284,7 +10136,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 3307
                 },
@@ -8293,7 +10147,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3316
                 },
@@ -8302,7 +10158,9 @@
                     "token": "vbpsmt_additional_user_data",
                     "value": "vbpsmt_additional_user_data",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3317
                 },
@@ -8311,7 +10169,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3344
                 },
@@ -8320,7 +10180,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3345
                 },
@@ -8329,7 +10191,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3347
                 },
@@ -8338,7 +10202,9 @@
                     "token": "additional_user_data",
                     "value": "additional_user_data",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3348
                 },
@@ -8347,7 +10213,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3368
                 },
@@ -8356,7 +10224,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3369
                 },
@@ -8365,7 +10235,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3371
                 },
@@ -8374,7 +10246,9 @@
                     "token": "additional_user_data",
                     "value": "additional_user_data",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3372
                 },
@@ -8383,7 +10257,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3392
                 },
@@ -8392,7 +10268,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3393
                 },
@@ -8401,7 +10279,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 3399
                 },
@@ -8410,7 +10290,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3400
                 },
@@ -8419,7 +10301,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3404
                 },
@@ -8428,7 +10312,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3405
                 },
@@ -8437,7 +10323,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3411
                 },
@@ -8446,7 +10334,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 3412
                 },
@@ -8455,7 +10345,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3421
                 },
@@ -8464,7 +10356,9 @@
                     "token": "market_pp_post_activation_mapping",
                     "value": "market_pp_post_activation_mapping",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3422
                 },
@@ -8473,7 +10367,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3455
                 },
@@ -8482,7 +10378,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3456
                 },
@@ -8491,7 +10389,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3458
                 },
@@ -8500,7 +10400,9 @@
                     "token": "paid_post_activation",
                     "value": "paid_post_activation",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3459
                 },
@@ -8509,7 +10411,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3479
                 },
@@ -8518,7 +10422,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3480
                 },
@@ -8527,7 +10433,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3482
                 },
@@ -8536,7 +10444,9 @@
                     "token": "paid_post_activation",
                     "value": "paid_post_activation",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3483
                 },
@@ -8545,7 +10455,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3503
                 },
@@ -8554,7 +10466,9 @@
                     "token": "post_id",
                     "value": "post_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3504
                 },
@@ -8563,7 +10477,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3511
                 },
@@ -8572,7 +10488,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 3512
                 },
@@ -8581,7 +10499,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3513
                 },
@@ -8590,7 +10510,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3514
                 },
@@ -8599,7 +10521,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3518
                 },
@@ -8608,7 +10532,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3519
                 },
@@ -8617,7 +10543,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3525
                 },
@@ -8626,7 +10554,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 3526
                 },
@@ -8635,7 +10565,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3535
                 },
@@ -8644,7 +10576,9 @@
                     "token": "alm_Model_UserData",
                     "value": "alm_Model_UserData",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3536
                 },
@@ -8653,7 +10587,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3554
                 },
@@ -8662,7 +10598,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3555
                 },
@@ -8671,7 +10609,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3557
                 },
@@ -8680,7 +10620,9 @@
                     "token": "alm_Model_UserData",
                     "value": "alm_Model_UserData",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3558
                 },
@@ -8689,7 +10631,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3576
                 },
@@ -8698,7 +10642,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3577
                 },
@@ -8707,7 +10653,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3579
                 },
@@ -8716,7 +10664,9 @@
                     "token": "alm_Model_UserData",
                     "value": "alm_Model_UserData",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3580
                 },
@@ -8725,7 +10675,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3598
                 },
@@ -8734,7 +10686,9 @@
                     "token": "user_id",
                     "value": "user_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3599
                 },
@@ -8743,7 +10697,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 3606
                 },
@@ -8752,7 +10708,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "user",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3607
                 },
@@ -8761,7 +10719,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3611
                 },
@@ -8770,7 +10730,9 @@
                     "token": "userid",
                     "value": "userid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3612
                 },
@@ -8779,7 +10741,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3618
                 },
@@ -8788,7 +10752,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 3619
                 },
@@ -8797,7 +10763,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3624
                 },
@@ -8806,7 +10774,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3625
                 },
@@ -8815,7 +10785,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3629
                 },
@@ -8824,7 +10796,9 @@
                     "token": "postid",
                     "value": "postid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3630
                 },
@@ -8833,7 +10807,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3636
                 },
@@ -8842,7 +10818,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 3637
                 },
@@ -8851,7 +10829,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3639
                 },
@@ -8860,7 +10840,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3640
                 },
@@ -8869,7 +10851,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3641
                 },
@@ -8878,7 +10862,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3642
                 },
@@ -8887,7 +10873,9 @@
                     "token": "3254399",
                     "value": 3254399,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3643
                 },
@@ -8896,7 +10884,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3650
                 },
@@ -8905,7 +10895,9 @@
                     "token": "3254508",
                     "value": 3254508,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3651
                 },
@@ -8914,7 +10906,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3658
                 },
@@ -8923,7 +10917,9 @@
                     "token": "3254743",
                     "value": 3254743,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3659
                 },
@@ -8932,7 +10928,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3666
                 },
@@ -8941,7 +10939,9 @@
                     "token": "3254817",
                     "value": 3254817,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3667
                 },
@@ -8950,7 +10950,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3674
                 },
@@ -8959,7 +10961,9 @@
                     "token": "3254969",
                     "value": 3254969,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3675
                 },
@@ -8968,7 +10972,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3682
                 },
@@ -8977,7 +10983,9 @@
                     "token": "3255328",
                     "value": 3255328,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3683
                 },
@@ -8986,7 +10994,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3690
                 },
@@ -8995,7 +11005,9 @@
                     "token": "3255582",
                     "value": 3255582,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3691
                 },
@@ -9004,7 +11016,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3698
                 },
@@ -9013,7 +11027,9 @@
                     "token": "3257603",
                     "value": 3257603,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3699
                 },
@@ -9022,7 +11038,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3706
                 },
@@ -9031,7 +11049,9 @@
                     "token": "3257873",
                     "value": 3257873,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3707
                 },
@@ -9040,7 +11060,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3714
                 },
@@ -9049,7 +11071,9 @@
                     "token": "3258126",
                     "value": 3258126,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3715
                 },
@@ -9058,7 +11082,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3722
                 },
@@ -9067,7 +11093,9 @@
                     "token": "3258150",
                     "value": 3258150,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3723
                 },
@@ -9076,7 +11104,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3730
                 },
@@ -9085,7 +11115,9 @@
                     "token": "3258254",
                     "value": 3258254,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3731
                 },
@@ -9094,7 +11126,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3738
                 },
@@ -9103,7 +11137,9 @@
                     "token": "3258272",
                     "value": 3258272,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3739
                 },
@@ -9112,7 +11148,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3746
                 },
@@ -9121,7 +11159,9 @@
                     "token": "3258311",
                     "value": 3258311,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3747
                 },
@@ -9130,7 +11170,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3754
                 },
@@ -9139,7 +11181,9 @@
                     "token": "3260767",
                     "value": 3260767,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3755
                 },
@@ -9148,7 +11192,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3762
                 },
@@ -9157,7 +11203,9 @@
                     "token": "3260770",
                     "value": 3260770,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3763
                 },
@@ -9166,7 +11214,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3770
                 },
@@ -9175,7 +11225,9 @@
                     "token": "3260776",
                     "value": 3260776,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3771
                 },
@@ -9184,7 +11236,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3778
                 },
@@ -9193,7 +11247,9 @@
                     "token": "3261180",
                     "value": 3261180,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3779
                 },
@@ -9202,7 +11258,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3786
                 },
@@ -9211,7 +11269,9 @@
                     "token": "3261263",
                     "value": 3261263,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3787
                 },
@@ -9220,7 +11280,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3794
                 },
@@ -9229,7 +11291,9 @@
                     "token": "3261317",
                     "value": 3261317,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3795
                 },
@@ -9238,7 +11302,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3802
                 },
@@ -9247,7 +11313,9 @@
                     "token": "3261318",
                     "value": 3261318,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@40"
+                    },
                     "flags": 0,
                     "position": 3803
                 },
@@ -9256,7 +11324,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3810
                 },
@@ -9265,7 +11335,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3811
                 },
@@ -9274,7 +11346,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 3812
                 },
@@ -9283,7 +11357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 3820
                 },
@@ -9292,7 +11368,9 @@
                     "token": "post",
                     "value": "post",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3821
                 },
@@ -9301,7 +11379,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 3825
                 },
@@ -9310,7 +11390,9 @@
                     "token": "dateline",
                     "value": "dateline",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 3826
                 },
@@ -9319,13 +11401,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 1035,
-            "idx": 1035
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect14.out
+++ b/tests/data/parser/parseSelect14.out
@@ -7,13 +7,19 @@
         "last": 34,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "tbl",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 10
                 },
@@ -49,7 +67,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -58,7 +78,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 13
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": "NOT",
                     "value": "NOT",
                     "keyword": "NOT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 15
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -94,7 +122,9 @@
                     "token": "tbl",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 22
                 },
@@ -112,7 +144,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -130,7 +166,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 26
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -148,7 +188,9 @@
                     "token": "tbl",
                     "value": "tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -157,13 +199,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect15.out
+++ b/tests/data/parser/parseSelect15.out
@@ -7,13 +7,19 @@
         "last": 26,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 9,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "``````",
                     "value": "``",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "``````",
                     "value": "``",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 19
                 },
@@ -76,7 +98,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -85,13 +111,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 9,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect16.out
+++ b/tests/data/parser/parseSelect16.out
@@ -7,13 +7,19 @@
         "last": 579,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 263,
+            "idx": 263,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 8
                 },
@@ -49,7 +67,9 @@
                     "token": "aa",
                     "value": "aa",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 11
                 },
@@ -67,7 +89,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -76,7 +100,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -85,7 +111,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 14
                 },
@@ -94,7 +122,9 @@
                     "token": "bb",
                     "value": "bb",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -103,7 +133,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 17
                 },
@@ -112,7 +144,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -121,7 +155,9 @@
                     "token": "CASE",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -130,7 +166,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -139,7 +177,9 @@
                     "token": "WHEN",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -157,7 +199,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -166,7 +210,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -175,7 +221,9 @@
                     "token": "cc",
                     "value": "cc",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -193,7 +243,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 34
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -211,7 +265,11 @@
                     "token": "'Y'",
                     "value": "Y",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 36
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -229,7 +289,9 @@
                     "token": "and",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -247,7 +311,9 @@
                     "token": "dd",
                     "value": "dd",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -265,7 +333,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 47
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -283,7 +355,9 @@
                     "token": "'Found'",
                     "value": "Found",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 49
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -301,7 +377,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 57
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -319,7 +399,9 @@
                     "token": "'99.99999'",
                     "value": "99.99999",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 62
                 },
@@ -328,7 +410,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -337,7 +421,9 @@
                     "token": "WHEN",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -346,7 +432,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -355,7 +443,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -364,7 +454,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 79
                 },
@@ -373,7 +465,9 @@
                     "token": "cc",
                     "value": "cc",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -382,7 +476,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -391,7 +487,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 83
                 },
@@ -400,7 +498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -409,7 +509,9 @@
                     "token": "''",
                     "value": "",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 85
                 },
@@ -418,7 +520,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -427,7 +531,9 @@
                     "token": "and",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 88
                 },
@@ -436,7 +542,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -445,7 +553,9 @@
                     "token": "dd",
                     "value": "dd",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -454,7 +564,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -463,7 +575,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 95
                 },
@@ -472,7 +586,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -481,7 +597,9 @@
                     "token": "'Found'",
                     "value": "Found",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 97
                 },
@@ -490,7 +608,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -499,7 +619,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 105
                 },
@@ -508,7 +630,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -517,7 +641,9 @@
                     "token": "'00.00000'",
                     "value": "00.00000",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 110
                 },
@@ -526,7 +652,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -535,7 +663,9 @@
                     "token": "ELSE",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 125
                 },
@@ -544,7 +674,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -553,7 +685,9 @@
                     "token": "'99.99999'",
                     "value": "99.99999",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 130
                 },
@@ -562,7 +696,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -571,7 +707,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 141
                 },
@@ -580,7 +718,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 144
                 },
@@ -589,7 +729,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 145
                 },
@@ -598,7 +740,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -607,7 +751,9 @@
                     "token": "RR",
                     "value": "RR",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -616,7 +762,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 150
                 },
@@ -625,7 +773,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 151
                 },
@@ -634,7 +784,9 @@
                     "token": "CASE",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 152
                 },
@@ -643,7 +795,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 156
                 },
@@ -652,7 +806,9 @@
                     "token": "WHEN",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 157
                 },
@@ -661,7 +817,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 161
                 },
@@ -670,7 +828,9 @@
                     "token": "dd",
                     "value": "dd",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 162
                 },
@@ -679,7 +839,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 164
                 },
@@ -688,7 +850,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 165
                 },
@@ -697,7 +861,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 166
                 },
@@ -706,7 +872,9 @@
                     "token": "'Found'",
                     "value": "Found",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 167
                 },
@@ -715,7 +883,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 174
                 },
@@ -724,7 +894,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 175
                 },
@@ -733,7 +905,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 179
                 },
@@ -742,7 +916,9 @@
                     "token": "'Y'",
                     "value": "Y",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 180
                 },
@@ -751,7 +927,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 183
                 },
@@ -760,7 +938,9 @@
                     "token": "ELSE",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 188
                 },
@@ -769,7 +949,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 192
                 },
@@ -778,7 +960,9 @@
                     "token": "'N'",
                     "value": "N",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 193
                 },
@@ -787,7 +971,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 196
                 },
@@ -796,7 +982,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 197
                 },
@@ -805,7 +993,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 200
                 },
@@ -814,7 +1004,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 201
                 },
@@ -823,7 +1015,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 203
                 },
@@ -832,7 +1026,9 @@
                     "token": "RRI",
                     "value": "RRI",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 204
                 },
@@ -841,7 +1037,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 207
                 },
@@ -850,7 +1048,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 208
                 },
@@ -859,7 +1059,9 @@
                     "token": "CASE",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 209
                 },
@@ -868,7 +1070,9 @@
                     "token": "\n\t",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 213
                 },
@@ -877,7 +1081,9 @@
                     "token": "WHEN",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 215
                 },
@@ -886,7 +1092,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 219
                 },
@@ -895,7 +1103,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 220
                 },
@@ -904,7 +1114,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 221
                 },
@@ -913,7 +1125,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 227
                 },
@@ -922,7 +1136,9 @@
                     "token": "MAX",
                     "value": "MAX",
                     "keyword": "MAX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 228
                 },
@@ -931,7 +1147,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 231
                 },
@@ -940,7 +1158,9 @@
                     "token": "cd",
                     "value": "cd",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 232
                 },
@@ -949,7 +1169,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 234
                 },
@@ -958,7 +1180,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 235
                 },
@@ -967,7 +1191,9 @@
                     "token": "from",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 236
                 },
@@ -976,7 +1202,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 240
                 },
@@ -985,7 +1213,9 @@
                     "token": "LSA",
                     "value": "LSA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 241
                 },
@@ -994,7 +1224,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 244
                 },
@@ -1003,7 +1235,9 @@
                     "token": "act",
                     "value": "act",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 245
                 },
@@ -1012,7 +1246,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 248
                 },
@@ -1021,7 +1257,9 @@
                     "token": "group by",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 249
                 },
@@ -1030,7 +1268,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 257
                 },
@@ -1039,7 +1279,9 @@
                     "token": "act",
                     "value": "act",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 258
                 },
@@ -1048,7 +1290,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 261
                 },
@@ -1057,7 +1301,9 @@
                     "token": "an",
                     "value": "an",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 262
                 },
@@ -1066,7 +1312,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 264
                 },
@@ -1075,7 +1323,9 @@
                     "token": "having",
                     "value": "HAVING",
                     "keyword": "HAVING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 265
                 },
@@ -1084,7 +1334,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 271
                 },
@@ -1093,7 +1345,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 272
                 },
@@ -1102,7 +1356,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 273
                 },
@@ -1111,7 +1367,9 @@
                     "token": "acn",
                     "value": "acn",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 274
                 },
@@ -1120,7 +1378,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 277
                 },
@@ -1129,7 +1389,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 278
                 },
@@ -1138,7 +1400,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 279
                 },
@@ -1147,7 +1411,9 @@
                     "token": "act",
                     "value": "act",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 280
                 },
@@ -1156,7 +1422,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 283
                 },
@@ -1165,7 +1433,9 @@
                     "token": "an",
                     "value": "an",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 284
                 },
@@ -1174,7 +1444,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 286
                 },
@@ -1183,7 +1455,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 287
                 },
@@ -1192,7 +1466,9 @@
                     "token": ">",
                     "value": ">",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 288
                 },
@@ -1201,7 +1477,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 289
                 },
@@ -1210,7 +1488,9 @@
                     "token": "'2021-01-28'",
                     "value": "2021-01-28",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 290
                 },
@@ -1219,7 +1499,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 302
                 },
@@ -1228,7 +1510,9 @@
                     "token": "THEN",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 303
                 },
@@ -1237,7 +1521,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 307
                 },
@@ -1246,7 +1532,9 @@
                     "token": "'06/30/2020'",
                     "value": "06/30/2020",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 308
                 },
@@ -1255,7 +1543,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 320
                 },
@@ -1264,7 +1554,9 @@
                     "token": "WHEN",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 325
                 },
@@ -1273,7 +1565,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 329
                 },
@@ -1282,7 +1576,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 330
                 },
@@ -1291,7 +1587,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 331
                 },
@@ -1300,7 +1598,9 @@
                     "token": "co",
                     "value": "co",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 332
                 },
@@ -1309,7 +1609,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 334
                 },
@@ -1318,7 +1620,9 @@
                     "token": "<",
                     "value": "<",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 335
                 },
@@ -1327,7 +1631,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 336
                 },
@@ -1336,7 +1642,9 @@
                     "token": "'2021-01-28'",
                     "value": "2021-01-28",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 337
                 },
@@ -1345,7 +1653,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 349
                 },
@@ -1354,7 +1664,9 @@
                     "token": "THEN",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 350
                 },
@@ -1363,7 +1675,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 354
                 },
@@ -1372,7 +1686,9 @@
                     "token": "'12/31/2019'",
                     "value": "12/31/2019",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 355
                 },
@@ -1381,7 +1697,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 367
                 },
@@ -1390,7 +1708,9 @@
                     "token": "ELSE",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 372
                 },
@@ -1399,7 +1719,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 376
                 },
@@ -1408,7 +1730,9 @@
                     "token": "'06/30/2020'",
                     "value": "06/30/2020",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 377
                 },
@@ -1417,7 +1741,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 389
                 },
@@ -1426,7 +1752,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 390
                 },
@@ -1435,7 +1763,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 393
                 },
@@ -1444,7 +1774,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 394
                 },
@@ -1453,7 +1785,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 396
                 },
@@ -1462,7 +1796,9 @@
                     "token": "DAOD",
                     "value": "DAOD",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 397
                 },
@@ -1471,7 +1807,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 401
                 },
@@ -1480,7 +1818,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 402
                 },
@@ -1489,7 +1829,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 406
                 },
@@ -1498,7 +1840,11 @@
                     "token": "`LTKP`",
                     "value": "LTKP",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 407
                 },
@@ -1507,7 +1853,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 413
                 },
@@ -1516,7 +1864,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 414
                 },
@@ -1525,7 +1875,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 415
                 },
@@ -1534,7 +1886,9 @@
                     "token": "left join",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 416
                 },
@@ -1543,7 +1897,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 425
                 },
@@ -1552,7 +1908,9 @@
                     "token": "`LQA`",
                     "value": "LQA",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@173"
+                    },
                     "flags": 2,
                     "position": 426
                 },
@@ -1561,7 +1919,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 431
                 },
@@ -1570,7 +1930,9 @@
                     "token": "qa",
                     "value": "qa",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 432
                 },
@@ -1579,7 +1941,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 434
                 },
@@ -1588,7 +1952,9 @@
                     "token": "on",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 435
                 },
@@ -1597,7 +1963,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 437
                 },
@@ -1606,7 +1974,9 @@
                     "token": "qa",
                     "value": "qa",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 438
                 },
@@ -1615,7 +1985,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 440
                 },
@@ -1624,7 +1996,9 @@
                     "token": "pi",
                     "value": "pi",
                     "keyword": "PI",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 441
                 },
@@ -1633,7 +2007,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 443
                 },
@@ -1642,7 +2018,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 444
                 },
@@ -1651,7 +2029,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 445
                 },
@@ -1660,7 +2040,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 446
                 },
@@ -1669,7 +2051,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 447
                 },
@@ -1678,7 +2062,9 @@
                     "token": "ID",
                     "value": "ID",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 448
                 },
@@ -1687,7 +2073,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 450
                 },
@@ -1696,7 +2084,9 @@
                     "token": "left join",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 451
                 },
@@ -1705,7 +2095,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 460
                 },
@@ -1714,7 +2106,9 @@
                     "token": "LSA",
                     "value": "LSA",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 461
                 },
@@ -1723,7 +2117,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 464
                 },
@@ -1732,7 +2128,9 @@
                     "token": "act",
                     "value": "act",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 465
                 },
@@ -1741,7 +2139,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 468
                 },
@@ -1750,7 +2150,9 @@
                     "token": "on",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 469
                 },
@@ -1759,7 +2161,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 471
                 },
@@ -1768,7 +2172,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 472
                 },
@@ -1777,7 +2183,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 473
                 },
@@ -1786,7 +2194,9 @@
                     "token": "acn",
                     "value": "acn",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 474
                 },
@@ -1795,7 +2205,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 477
                 },
@@ -1804,7 +2216,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 478
                 },
@@ -1813,7 +2227,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 479
                 },
@@ -1822,7 +2238,9 @@
                     "token": "act",
                     "value": "act",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 480
                 },
@@ -1831,7 +2249,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 483
                 },
@@ -1840,7 +2260,9 @@
                     "token": "an",
                     "value": "an",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 484
                 },
@@ -1849,7 +2271,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 486
                 },
@@ -1858,7 +2282,9 @@
                     "token": "where",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 487
                 },
@@ -1867,7 +2293,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 492
                 },
@@ -1876,7 +2304,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 494
                 },
@@ -1885,7 +2315,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 495
                 },
@@ -1894,7 +2326,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 496
                 },
@@ -1903,7 +2337,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 497
                 },
@@ -1912,7 +2348,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 498
                 },
@@ -1921,7 +2359,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 499
                 },
@@ -1930,7 +2372,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 500
                 },
@@ -1939,7 +2383,9 @@
                     "token": "and",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 501
                 },
@@ -1948,7 +2394,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 504
                 },
@@ -1957,7 +2405,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 505
                 },
@@ -1966,7 +2416,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 506
                 },
@@ -1975,7 +2427,9 @@
                     "token": "mr",
                     "value": "mr",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 507
                 },
@@ -1984,7 +2438,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 509
                 },
@@ -1993,7 +2449,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 510
                 },
@@ -2002,7 +2460,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 511
                 },
@@ -2011,7 +2471,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@221"
+                    },
                     "flags": 0,
                     "position": 512
                 },
@@ -2020,7 +2482,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 513
                 },
@@ -2029,7 +2493,9 @@
                     "token": "and",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 514
                 },
@@ -2038,7 +2504,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 517
                 },
@@ -2047,7 +2515,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 518
                 },
@@ -2056,7 +2526,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 519
                 },
@@ -2065,7 +2537,9 @@
                     "token": "sc",
                     "value": "sc",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 520
                 },
@@ -2074,7 +2548,9 @@
                     "token": "<>",
                     "value": "<>",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 522
                 },
@@ -2083,7 +2559,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 524
                 },
@@ -2092,7 +2570,9 @@
                     "token": "'23'",
                     "value": "23",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 525
                 },
@@ -2101,7 +2581,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 529
                 },
@@ -2110,7 +2592,9 @@
                     "token": "and",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 530
                 },
@@ -2119,7 +2603,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 533
                 },
@@ -2128,7 +2614,9 @@
                     "token": "qa",
                     "value": "qa",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 534
                 },
@@ -2137,7 +2625,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 536
                 },
@@ -2146,7 +2636,9 @@
                     "token": "qt",
                     "value": "qt",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 537
                 },
@@ -2155,7 +2647,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 539
                 },
@@ -2164,7 +2658,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 540
                 },
@@ -2173,7 +2669,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 541
                 },
@@ -2182,7 +2680,9 @@
                     "token": "'TEXT'",
                     "value": "TEXT",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 1,
                     "position": 542
                 },
@@ -2191,7 +2691,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 548
                 },
@@ -2200,7 +2702,9 @@
                     "token": "and",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 549
                 },
@@ -2209,7 +2713,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 552
                 },
@@ -2218,7 +2724,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 553
                 },
@@ -2227,7 +2735,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 554
                 },
@@ -2236,7 +2746,9 @@
                     "token": "tl",
                     "value": "tl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 555
                 },
@@ -2245,7 +2757,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 557
                 },
@@ -2254,7 +2768,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 558
                 },
@@ -2263,7 +2779,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 559
                 },
@@ -2272,7 +2790,9 @@
                     "token": "\"TEXT\"",
                     "value": "TEXT",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 2,
                     "position": 560
                 },
@@ -2281,7 +2801,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 566
                 },
@@ -2290,7 +2812,9 @@
                     "token": "and",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 567
                 },
@@ -2299,7 +2823,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 570
                 },
@@ -2308,7 +2834,9 @@
                     "token": "qa",
                     "value": "qa",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 571
                 },
@@ -2317,7 +2845,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 573
                 },
@@ -2326,7 +2856,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 574
                 },
@@ -2335,7 +2867,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 575
                 },
@@ -2344,7 +2878,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 576
                 },
@@ -2353,7 +2889,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 577
                 },
@@ -2362,7 +2900,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@221"
+                    },
                     "flags": 0,
                     "position": 578
                 },
@@ -2371,13 +2911,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 263,
-            "idx": 263
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect2.out
+++ b/tests/data/parser/parseSelect2.out
@@ -7,13 +7,19 @@
         "last": 67,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 33,
+            "idx": 33,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,11 @@
                     "token": "'foo'",
                     "value": "foo",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +89,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,11 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +124,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 25
                 },
@@ -103,7 +135,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -112,7 +146,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 27
                 },
@@ -121,7 +157,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 28
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -139,7 +179,9 @@
                     "token": "'baz'",
                     "value": "baz",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 35
                 },
@@ -148,7 +190,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -166,7 +212,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -184,7 +234,9 @@
                     "token": "qux",
                     "value": "qux",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -193,7 +245,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 48
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -211,7 +267,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -229,7 +289,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 52
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -247,7 +311,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -265,7 +333,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 57
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -283,7 +355,9 @@
                     "token": "tabl",
                     "value": "tabl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -292,7 +366,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -301,13 +379,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 33,
-            "idx": 33
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect3.out
+++ b/tests/data/parser/parseSelect3.out
@@ -7,13 +7,19 @@
         "last": 109,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 37,
+            "idx": 37,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "left_tbl",
                     "value": "left_tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 15
                 },
@@ -49,7 +67,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 16
                 },
@@ -58,7 +78,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +89,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,7 +111,9 @@
                     "token": "left_tbl",
                     "value": "left_tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +133,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -121,7 +155,9 @@
                     "token": "right_tbl",
                     "value": "right_tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -139,7 +177,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 52
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -157,7 +199,9 @@
                     "token": "left_tbl",
                     "value": "left_tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -166,7 +210,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 63
                 },
@@ -175,7 +221,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -193,7 +243,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 67
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -211,7 +265,9 @@
                     "token": "right_tbl",
                     "value": "right_tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -220,7 +276,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 78
                 },
@@ -229,7 +287,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -238,7 +298,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -247,7 +309,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -265,7 +331,9 @@
                     "token": "right_tbl",
                     "value": "right_tbl",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -274,7 +342,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 97
                 },
@@ -283,7 +353,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -292,7 +364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -301,7 +375,9 @@
                     "token": "IS",
                     "value": "IS",
                     "keyword": "IS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 101
                 },
@@ -310,7 +386,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -319,7 +397,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 104
                 },
@@ -328,7 +408,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -337,13 +421,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@42"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 37,
-            "idx": 37
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect4.out
+++ b/tests/data/parser/parseSelect4.out
@@ -7,13 +7,19 @@
         "last": 54,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 24,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "\n   ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,11 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -76,7 +100,9 @@
                     "token": "\n   ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +133,9 @@
                     "token": "RIGHT",
                     "value": "RIGHT",
                     "keyword": "RIGHT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 31
                 },
@@ -112,7 +144,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 36
                 },
@@ -121,7 +155,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 37
                 },
@@ -130,7 +166,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -148,7 +188,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -157,7 +201,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 44
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +223,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 46
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -193,7 +245,11 @@
                     "token": "'AB'",
                     "value": "AB",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 48
                 },
@@ -202,7 +258,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -211,7 +271,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -220,13 +282,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@30"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 24
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect5.out
+++ b/tests/data/parser/parseSelect5.out
@@ -7,13 +7,19 @@
         "last": 123,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 48,
+            "idx": 48,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "c1",
                     "value": "c1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 9
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -58,7 +78,9 @@
                     "token": "c2",
                     "value": "c2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -67,7 +89,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 13
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -85,7 +111,9 @@
                     "token": "c3",
                     "value": "c3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -94,7 +122,9 @@
                     "token": "\n   ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -103,7 +133,11 @@
                     "token": "/* Subquery in FROM list */",
                     "value": "/* Subquery in FROM list */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 21
                 },
@@ -112,7 +146,9 @@
                     "token": "\n   ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -121,7 +157,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 52
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -139,7 +179,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 57
                 },
@@ -148,7 +190,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 58
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -166,7 +212,9 @@
                     "token": "C1",
                     "value": "C1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -175,7 +223,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 67
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -193,7 +245,9 @@
                     "token": "c2",
                     "value": "c2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -202,7 +256,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -220,7 +278,9 @@
                     "token": "c3",
                     "value": "c3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -238,7 +300,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 76
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -256,7 +322,9 @@
                     "token": "test2",
                     "value": "test2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -265,7 +333,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -292,7 +366,9 @@
                     "token": "\n   ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -301,7 +377,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 94
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -319,7 +399,9 @@
                     "token": "RIGHT",
                     "value": "RIGHT",
                     "keyword": "RIGHT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 100
                 },
@@ -328,7 +410,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 105
                 },
@@ -337,7 +421,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 106
                 },
@@ -346,7 +432,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 110
                 },
@@ -355,7 +443,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -364,7 +454,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -373,7 +467,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 113
                 },
@@ -382,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -391,7 +489,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 115
                 },
@@ -400,7 +500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -409,7 +511,11 @@
                     "token": "'AB'",
                     "value": "AB",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 117
                 },
@@ -418,7 +524,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -427,7 +537,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -436,13 +548,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@55"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 48,
-            "idx": 48
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect6.out
+++ b/tests/data/parser/parseSelect6.out
@@ -7,13 +7,19 @@
         "last": 100,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 53,
+            "idx": 53,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -85,7 +111,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 17
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -121,7 +155,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -139,7 +177,9 @@
                     "token": "t3",
                     "value": "t3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -148,7 +188,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 34
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -166,7 +210,9 @@
                     "token": "t4",
                     "value": "t4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -175,7 +221,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -184,7 +232,9 @@
                     "token": "\n                 ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -193,7 +243,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 57
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -211,7 +265,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 60
                 },
@@ -220,7 +276,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -229,7 +287,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 63
                 },
@@ -238,7 +298,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -247,7 +309,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 65
                 },
@@ -256,7 +320,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -265,7 +331,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 68
                 },
@@ -274,7 +342,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -283,7 +353,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -292,7 +364,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 71
                 },
@@ -301,7 +375,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -310,7 +386,9 @@
                     "token": "t3",
                     "value": "t3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -319,7 +397,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -328,7 +408,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -337,7 +419,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 79
                 },
@@ -346,7 +430,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -355,7 +441,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 82
                 },
@@ -364,7 +452,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -373,7 +463,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -382,7 +474,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 85
                 },
@@ -391,7 +485,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -400,7 +496,9 @@
                     "token": "t4",
                     "value": "t4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -409,7 +507,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 91
                 },
@@ -418,7 +518,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -427,7 +529,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 93
                 },
@@ -436,7 +540,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -445,7 +551,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 96
                 },
@@ -454,7 +562,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -463,7 +573,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 98
                 },
@@ -472,7 +584,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -481,13 +595,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 53,
-            "idx": 53
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect7.out
+++ b/tests/data/parser/parseSelect7.out
@@ -7,13 +7,19 @@
         "last": 119,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 54,
+            "idx": 54,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -85,7 +111,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 17
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -130,7 +166,9 @@
                     "token": "CROSS JOIN",
                     "value": "CROSS JOIN",
                     "keyword": "CROSS JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 31
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +188,9 @@
                     "token": "t3",
                     "value": "t3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,9 @@
                     "token": "CROSS JOIN",
                     "value": "CROSS JOIN",
                     "keyword": "CROSS JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 45
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -184,7 +232,9 @@
                     "token": "t4",
                     "value": "t4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -193,7 +243,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 58
                 },
@@ -202,7 +254,9 @@
                     "token": "\n                 ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -211,7 +265,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 77
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -229,7 +287,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -238,7 +298,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -247,7 +309,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 83
                 },
@@ -256,7 +320,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -265,7 +331,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 85
                 },
@@ -274,7 +342,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -283,7 +353,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 88
                 },
@@ -292,7 +364,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -301,7 +375,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -310,7 +386,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 91
                 },
@@ -319,7 +397,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -328,7 +408,9 @@
                     "token": "t3",
                     "value": "t3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -337,7 +419,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 97
                 },
@@ -346,7 +430,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -355,7 +441,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 99
                 },
@@ -364,7 +452,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -373,7 +463,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 102
                 },
@@ -382,7 +474,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -391,7 +485,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -400,7 +496,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 105
                 },
@@ -409,7 +507,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -418,7 +518,9 @@
                     "token": "t4",
                     "value": "t4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -427,7 +529,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 111
                 },
@@ -436,7 +540,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -445,7 +551,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 113
                 },
@@ -454,7 +562,9 @@
                     "token": "t1",
                     "value": "t1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -463,7 +573,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 116
                 },
@@ -472,7 +584,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -481,7 +595,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 118
                 },
@@ -490,13 +606,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 54,
-            "idx": 54
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect8.out
+++ b/tests/data/parser/parseSelect8.out
@@ -7,13 +7,19 @@
         "last": 68,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 34,
+            "idx": 34,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 14
                 },
@@ -76,7 +98,9 @@
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 15
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -94,7 +120,11 @@
                     "token": "Pop",
                     "value": "Pop",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -112,7 +144,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 26
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -130,7 +166,9 @@
                     "token": "MyTable",
                     "value": "MyTable",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -139,7 +177,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -157,7 +199,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -175,7 +221,9 @@
                     "token": "join",
                     "value": "JOIN",
                     "keyword": "JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -193,7 +243,9 @@
                     "token": "tadaa",
                     "value": "tadaa",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -211,7 +265,9 @@
                     "token": "t",
                     "value": "t",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -229,7 +287,9 @@
                     "token": "where",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 55
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -247,7 +309,9 @@
                     "token": "p",
                     "value": "p",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -256,7 +320,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 62
                 },
@@ -265,7 +331,9 @@
                     "token": "x",
                     "value": "x",
                     "keyword": "X",
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -274,7 +342,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 64
                 },
@@ -283,7 +353,9 @@
                     "token": "t",
                     "value": "t",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -292,7 +364,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 66
                 },
@@ -301,7 +375,9 @@
                     "token": "y",
                     "value": "y",
                     "keyword": "Y",
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -310,13 +386,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 34,
-            "idx": 34
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelect9.out
+++ b/tests/data/parser/parseSelect9.out
@@ -7,13 +7,19 @@
         "last": 296,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 70,
+            "idx": 70,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "casein_pipe",
                     "value": "casein_pipe",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 18
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -58,7 +78,9 @@
                     "token": "email_cp",
                     "value": "email_cp",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +89,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 28
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -85,7 +111,9 @@
                     "token": "name_first_cp",
                     "value": "name_first_cp",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -94,7 +122,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -112,7 +144,9 @@
                     "token": "name_last_cp",
                     "value": "name_last_cp",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -121,7 +155,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 57
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -139,7 +177,9 @@
                     "token": "purpose_pipe",
                     "value": "purpose_pipe",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -148,7 +188,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -157,7 +199,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 72
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -175,7 +221,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -184,7 +232,9 @@
                     "token": "tbl_comp_person",
                     "value": "tbl_comp_person",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -202,7 +254,9 @@
                     "token": "INNER JOIN",
                     "value": "INNER JOIN",
                     "keyword": "INNER JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 94
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -220,7 +276,11 @@
                     "token": "`tbl_pipelist`",
                     "value": "tbl_pipelist",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 105
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -238,7 +300,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 120
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -256,7 +322,9 @@
                     "token": "tbl_comp_person",
                     "value": "tbl_comp_person",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -265,7 +333,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 138
                 },
@@ -274,7 +344,9 @@
                     "token": "IDp",
                     "value": "IDp",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -292,7 +366,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 143
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 144
                 },
@@ -310,7 +388,9 @@
                     "token": "tbl_pipelist",
                     "value": "tbl_pipelist",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 145
                 },
@@ -319,7 +399,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 157
                 },
@@ -328,7 +410,9 @@
                     "token": "IDp",
                     "value": "IDp",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -337,7 +421,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 161
                 },
@@ -346,7 +432,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 162
                 },
@@ -355,7 +443,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 163
                 },
@@ -364,7 +454,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 168
                 },
@@ -373,7 +465,9 @@
                     "token": "casein_pipe",
                     "value": "casein_pipe",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 169
                 },
@@ -382,7 +476,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 180
                 },
@@ -391,7 +487,9 @@
                     "token": ">",
                     "value": ">",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 181
                 },
@@ -400,7 +498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 182
                 },
@@ -409,7 +509,11 @@
                     "token": "'2016-03-01'",
                     "value": "2016-03-01",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 183
                 },
@@ -418,7 +522,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 195
                 },
@@ -427,7 +533,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 196
                 },
@@ -436,7 +544,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 199
                 },
@@ -445,7 +555,9 @@
                     "token": "`campaign_id_pipe`",
                     "value": "campaign_id_pipe",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@30"
+                    },
                     "flags": 2,
                     "position": 201
                 },
@@ -454,7 +566,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 219
                 },
@@ -463,7 +577,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 220
                 },
@@ -472,7 +588,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 221
                 },
@@ -481,7 +599,11 @@
                     "token": "24569",
                     "value": 24569,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 222
                 },
@@ -490,7 +612,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 227
                 },
@@ -499,7 +623,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 228
                 },
@@ -508,7 +634,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 231
                 },
@@ -517,7 +645,9 @@
                     "token": "`weeksonlist_pipe`",
                     "value": "weeksonlist_pipe",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@30"
+                    },
                     "flags": 2,
                     "position": 232
                 },
@@ -526,7 +656,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 250
                 },
@@ -535,7 +667,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 251
                 },
@@ -544,7 +678,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 252
                 },
@@ -553,7 +689,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@61"
+                    },
                     "flags": 0,
                     "position": 253
                 },
@@ -562,7 +700,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 254
                 },
@@ -571,7 +711,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 255
                 },
@@ -580,7 +722,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 263
                 },
@@ -589,7 +733,9 @@
                     "token": "`tbl_pipelist`",
                     "value": "tbl_pipelist",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@30"
+                    },
                     "flags": 2,
                     "position": 264
                 },
@@ -598,7 +744,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 278
                 },
@@ -607,7 +755,9 @@
                     "token": "`casein_pipe`",
                     "value": "casein_pipe",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@30"
+                    },
                     "flags": 2,
                     "position": 279
                 },
@@ -616,7 +766,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 292
                 },
@@ -625,7 +777,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 293
                 },
@@ -634,13 +788,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 70,
-            "idx": 70
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectAggregateWithPartitionAndAlias.out
+++ b/tests/data/parser/parseSelectAggregateWithPartitionAndAlias.out
@@ -7,13 +7,19 @@
         "last": 87,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 26,
+            "idx": 26,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": "COUNT",
                     "value": "COUNT",
                     "keyword": "COUNT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 10
                 },
@@ -67,7 +87,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 15
                 },
@@ -76,7 +98,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 16
                 },
@@ -85,7 +109,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 17
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -103,7 +131,11 @@
                     "token": "OVER",
                     "value": "OVER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -112,7 +144,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 23
                 },
@@ -121,7 +155,9 @@
                     "token": "PARTITION BY",
                     "value": "PARTITION BY",
                     "keyword": "PARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 24
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -139,7 +177,11 @@
                     "token": "`REGION`",
                     "value": "REGION",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 37
                 },
@@ -148,7 +190,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 45
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -166,7 +212,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 47
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -184,7 +234,11 @@
                     "token": "\"count(REGION)\"",
                     "value": "count(REGION)",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 50
                 },
@@ -193,7 +247,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -202,7 +258,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 66
                 },
@@ -211,7 +269,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -220,7 +280,9 @@
                     "token": "`world_borders`",
                     "value": "world_borders",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 71
                 },
@@ -229,7 +291,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -238,13 +302,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 26,
-            "idx": 26
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectCase1.out
+++ b/tests/data/parser/parseSelectCase1.out
@@ -7,13 +7,19 @@
         "last": 132,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 50,
+            "idx": 50,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -292,7 +366,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 89
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -310,7 +388,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -328,7 +410,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -346,7 +432,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -364,7 +456,9 @@
                     "token": "else",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -382,7 +478,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 2,
                     "position": 113
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -400,7 +500,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 121
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -418,7 +522,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 125
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -436,7 +544,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -445,7 +555,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -454,13 +568,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@57"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 50,
-            "idx": 50
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectCase2.out
+++ b/tests/data/parser/parseSelectCase2.out
@@ -7,13 +7,19 @@
         "last": 138,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 52,
+            "idx": 52,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,11 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 87
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -292,7 +368,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 93
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -310,7 +390,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -319,7 +401,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 99
                 },
@@ -328,7 +412,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -346,7 +434,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 102
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -364,7 +456,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 107
                 },
@@ -373,7 +469,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -382,7 +480,9 @@
                     "token": "else",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 114
                 },
@@ -391,7 +491,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -400,7 +502,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 119
                 },
@@ -409,7 +513,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -418,7 +524,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 127
                 },
@@ -427,7 +535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -436,7 +546,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 131
                 },
@@ -445,7 +557,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -454,7 +568,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 136
                 },
@@ -463,7 +579,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 137
                 },
@@ -472,13 +592,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@60"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 52,
-            "idx": 52
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectCase3.out
+++ b/tests/data/parser/parseSelectCase3.out
@@ -7,13 +7,19 @@
         "last": 147,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 58,
+            "idx": 58,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,11 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 87
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -292,7 +368,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 93
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -310,7 +390,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -319,7 +401,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 99
                 },
@@ -328,7 +412,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -346,7 +434,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 102
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -364,7 +456,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 107
                 },
@@ -373,7 +469,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -382,7 +480,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 114
                 },
@@ -391,7 +491,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -400,7 +502,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -409,7 +513,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 120
                 },
@@ -418,7 +524,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -427,7 +535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -436,7 +546,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 123
                 },
@@ -445,7 +557,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -454,7 +568,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 128
                 },
@@ -463,7 +579,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -472,7 +590,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 136
                 },
@@ -481,7 +601,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -490,7 +612,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 140
                 },
@@ -499,7 +623,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 144
                 },
@@ -508,7 +634,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 145
                 },
@@ -517,7 +645,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 146
                 },
@@ -526,13 +658,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@66"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 58,
-            "idx": 58
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectCase4.out
+++ b/tests/data/parser/parseSelectCase4.out
@@ -7,13 +7,19 @@
         "last": 145,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 56,
+            "idx": 56,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -292,7 +366,11 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 89
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -310,7 +390,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 95
                 },
@@ -319,7 +401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -328,7 +412,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -346,7 +434,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 102
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -364,7 +456,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 107
                 },
@@ -373,7 +469,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -382,7 +480,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 114
                 },
@@ -391,7 +491,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -400,7 +502,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -409,7 +513,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -418,7 +524,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 121
                 },
@@ -427,7 +535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -436,7 +546,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 126
                 },
@@ -445,7 +557,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -454,7 +568,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 134
                 },
@@ -463,7 +579,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 137
                 },
@@ -472,7 +590,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 138
                 },
@@ -481,7 +601,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -490,7 +612,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -499,7 +623,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 144
                 },
@@ -508,13 +636,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@64"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 56,
-            "idx": 56
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectCase5.out
+++ b/tests/data/parser/parseSelectCase5.out
@@ -7,13 +7,19 @@
         "last": 150,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 58,
+            "idx": 58,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -292,7 +366,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -310,7 +388,11 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 94
                 },
@@ -319,7 +401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -328,7 +412,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 100
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -346,7 +434,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -364,7 +456,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 107
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -382,7 +478,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 112
                 },
@@ -391,7 +491,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -400,7 +502,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 119
                 },
@@ -409,7 +513,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -418,7 +524,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -427,7 +535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -436,7 +546,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 126
                 },
@@ -445,7 +557,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -454,7 +568,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@50"
+                    },
                     "flags": 2,
                     "position": 131
                 },
@@ -463,7 +579,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -472,7 +590,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 139
                 },
@@ -481,7 +601,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -490,7 +612,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 143
                 },
@@ -499,7 +623,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -508,7 +634,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -517,7 +645,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -526,13 +658,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@66"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 58,
-            "idx": 58
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectCaseAlias1.out
+++ b/tests/data/parser/parseSelectCaseAlias1.out
@@ -7,13 +7,19 @@
         "last": 166,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 66,
+            "idx": 66,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,11 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 87
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -292,7 +368,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 93
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -310,7 +390,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -319,7 +401,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 99
                 },
@@ -328,7 +412,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -346,7 +434,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 102
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -364,7 +456,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 107
                 },
@@ -373,7 +469,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -382,7 +480,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 114
                 },
@@ -391,7 +491,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -400,7 +502,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -409,7 +513,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 120
                 },
@@ -418,7 +524,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -427,7 +535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -436,7 +546,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 123
                 },
@@ -445,7 +557,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -454,7 +568,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 128
                 },
@@ -463,7 +579,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -472,7 +590,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 136
                 },
@@ -481,7 +601,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -490,7 +612,9 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 2,
                     "position": 140
                 },
@@ -499,7 +623,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 145
                 },
@@ -508,7 +634,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 146
                 },
@@ -517,7 +645,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -526,7 +656,9 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 2,
                     "position": 149
                 },
@@ -535,7 +667,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -544,7 +678,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 155
                 },
@@ -553,7 +689,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -562,7 +700,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 159
                 },
@@ -571,7 +711,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 163
                 },
@@ -580,7 +722,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 164
                 },
@@ -589,7 +733,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 165
                 },
@@ -598,13 +746,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@74"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 66,
-            "idx": 66
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectCaseAlias2.out
+++ b/tests/data/parser/parseSelectCaseAlias2.out
@@ -7,13 +7,19 @@
         "last": 157,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 62,
+            "idx": 62,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,11 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 87
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -292,7 +368,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 93
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -310,7 +390,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -319,7 +401,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 99
                 },
@@ -328,7 +412,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -346,7 +434,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 102
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -364,7 +456,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 107
                 },
@@ -373,7 +469,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -382,7 +480,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 114
                 },
@@ -391,7 +491,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -400,7 +502,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -409,7 +513,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 120
                 },
@@ -418,7 +524,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -427,7 +535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -436,7 +546,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 123
                 },
@@ -445,7 +557,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -454,7 +568,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@48"
+                    },
                     "flags": 2,
                     "position": 128
                 },
@@ -463,7 +579,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -472,7 +590,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 136
                 },
@@ -481,7 +601,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -490,7 +612,9 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 2,
                     "position": 140
                 },
@@ -499,7 +623,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 145
                 },
@@ -508,7 +634,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 146
                 },
@@ -517,7 +645,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -526,7 +656,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 150
                 },
@@ -535,7 +667,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -544,7 +678,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 155
                 },
@@ -553,7 +689,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 156
                 },
@@ -562,13 +702,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@70"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 62,
-            "idx": 62
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectCaseAlias3.out
+++ b/tests/data/parser/parseSelectCaseAlias3.out
@@ -7,13 +7,19 @@
         "last": 169,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 66,
+            "idx": 66,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -292,7 +366,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -310,7 +388,11 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 94
                 },
@@ -319,7 +401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -328,7 +412,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 100
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -346,7 +434,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -364,7 +456,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 107
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -382,7 +478,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 112
                 },
@@ -391,7 +491,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -400,7 +502,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 119
                 },
@@ -409,7 +513,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -418,7 +524,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -427,7 +535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -436,7 +546,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 126
                 },
@@ -445,7 +557,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -454,7 +568,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@50"
+                    },
                     "flags": 2,
                     "position": 131
                 },
@@ -463,7 +579,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -472,7 +590,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 139
                 },
@@ -481,7 +601,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -490,7 +612,9 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@41"
+                    },
                     "flags": 2,
                     "position": 143
                 },
@@ -499,7 +623,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -508,7 +634,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 149
                 },
@@ -517,7 +645,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 151
                 },
@@ -526,7 +656,9 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@41"
+                    },
                     "flags": 2,
                     "position": 152
                 },
@@ -535,7 +667,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -544,7 +678,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -553,7 +689,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 161
                 },
@@ -562,7 +700,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 162
                 },
@@ -571,7 +711,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 166
                 },
@@ -580,7 +722,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 167
                 },
@@ -589,7 +733,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 168
                 },
@@ -598,13 +746,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@74"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 66,
-            "idx": 66
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectCaseAlias4.out
+++ b/tests/data/parser/parseSelectCaseAlias4.out
@@ -7,13 +7,19 @@
         "last": 160,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 62,
+            "idx": 62,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -292,7 +366,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -310,7 +388,11 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 94
                 },
@@ -319,7 +401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -328,7 +412,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 100
                 },
@@ -337,7 +423,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -346,7 +434,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -364,7 +456,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 107
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -382,7 +478,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 112
                 },
@@ -391,7 +491,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -400,7 +502,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 119
                 },
@@ -409,7 +513,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -418,7 +524,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -427,7 +535,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -436,7 +546,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 126
                 },
@@ -445,7 +557,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -454,7 +568,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@50"
+                    },
                     "flags": 2,
                     "position": 131
                 },
@@ -463,7 +579,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -472,7 +590,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 139
                 },
@@ -481,7 +601,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -490,7 +612,9 @@
                     "token": "/* */",
                     "value": "/* */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@41"
+                    },
                     "flags": 2,
                     "position": 143
                 },
@@ -499,7 +623,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -508,7 +634,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -517,7 +645,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -526,7 +656,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 153
                 },
@@ -535,7 +667,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 157
                 },
@@ -544,7 +678,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -553,7 +689,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 159
                 },
@@ -562,13 +702,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@70"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 62,
-            "idx": 62
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectCaseAlias5.out
+++ b/tests/data/parser/parseSelectCaseAlias5.out
@@ -7,13 +7,19 @@
         "last": 150,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 54,
+            "idx": 54,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -292,7 +366,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 89
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -310,7 +388,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -328,7 +410,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -346,7 +432,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -364,7 +456,9 @@
                     "token": "else",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -382,7 +478,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 2,
                     "position": 113
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -400,7 +500,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 121
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -418,7 +522,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 125
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -436,7 +544,9 @@
                     "token": "\"string value\"",
                     "value": "string value",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 2,
                     "position": 128
                 },
@@ -445,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -454,7 +566,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 143
                 },
@@ -463,7 +577,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -472,7 +588,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -481,7 +599,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -490,13 +612,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@61"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 54,
-            "idx": 54
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectCaseAlias6.out
+++ b/tests/data/parser/parseSelectCaseAlias6.out
@@ -7,13 +7,19 @@
         "last": 150,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 54,
+            "idx": 54,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -292,7 +366,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 89
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -310,7 +388,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -328,7 +410,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -346,7 +432,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -364,7 +456,9 @@
                     "token": "else",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -382,7 +478,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 2,
                     "position": 113
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -400,7 +500,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 121
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -418,7 +522,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 125
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -436,7 +544,11 @@
                     "token": "`symbol_value`",
                     "value": "symbol_value",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 128
                 },
@@ -445,7 +557,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -454,7 +568,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 143
                 },
@@ -463,7 +579,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -472,7 +590,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -481,7 +601,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -490,13 +614,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 54,
-            "idx": 54
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectCaseAliasErr1.out
+++ b/tests/data/parser/parseSelectCaseAliasErr1.out
@@ -7,13 +7,19 @@
         "last": 142,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 56,
+            "idx": 56,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -292,7 +366,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 89
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -310,7 +388,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -328,7 +410,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -346,7 +432,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -364,7 +456,9 @@
                     "token": "else",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -382,7 +478,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 2,
                     "position": 113
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -400,7 +500,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 121
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -418,7 +522,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 125
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -436,7 +544,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 128
                 },
@@ -445,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -454,7 +566,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -463,7 +577,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 134
                 },
@@ -472,7 +588,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 135
                 },
@@ -481,7 +599,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -490,7 +610,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -499,7 +621,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -508,13 +634,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@63"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 56,
-            "idx": 56
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -634,28 +760,28 @@
             [
                 "Potential duplicate alias of CASE expression.",
                 {
-                    "@type": "@49"
+                    "@type": "@55"
                 },
                 0
             ],
             [
                 "An alias was expected after AS.",
                 {
-                    "@type": "@48"
+                    "@type": "@54"
                 },
                 0
             ],
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@49"
+                    "@type": "@55"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@51"
+                    "@type": "@57"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectCaseAliasErr2.out
+++ b/tests/data/parser/parseSelectCaseAliasErr2.out
@@ -7,13 +7,19 @@
         "last": 135,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 52,
+            "idx": 52,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -292,7 +366,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 89
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -310,7 +388,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -328,7 +410,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -346,7 +432,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -364,7 +456,9 @@
                     "token": "else",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -382,7 +478,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 2,
                     "position": 113
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -400,7 +500,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 121
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -418,7 +522,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 125
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -436,7 +544,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 128
                 },
@@ -445,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -454,7 +566,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -463,7 +577,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 134
                 },
@@ -472,13 +590,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@59"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 52,
-            "idx": 52
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -598,7 +716,7 @@
             [
                 "An alias expected after AS but got FROM",
                 {
-                    "@type": "@49"
+                    "@type": "@55"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectCaseAliasErr3.out
+++ b/tests/data/parser/parseSelectCaseAliasErr3.out
@@ -7,13 +7,19 @@
         "last": 143,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 56,
+            "idx": 56,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -292,7 +366,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 89
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -310,7 +388,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -328,7 +410,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -346,7 +432,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -364,7 +456,9 @@
                     "token": "else",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -382,7 +478,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 2,
                     "position": 113
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -400,7 +500,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 121
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -418,7 +522,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 125
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -436,7 +544,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 128
                 },
@@ -445,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -454,7 +566,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -463,7 +577,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -472,7 +588,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 136
                 },
@@ -481,7 +599,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -490,7 +610,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -499,7 +621,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -508,13 +634,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@63"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 56,
-            "idx": 56
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -634,14 +760,14 @@
             [
                 "An alias was previously found.",
                 {
-                    "@type": "@51"
+                    "@type": "@57"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@51"
+                    "@type": "@57"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectCaseAliasErr4.out
+++ b/tests/data/parser/parseSelectCaseAliasErr4.out
@@ -7,13 +7,19 @@
         "last": 76,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 26,
+            "idx": 26,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "CASE",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,9 @@
                     "token": "WHEN",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 12
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +85,11 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -85,7 +109,9 @@
                     "token": "IS",
                     "value": "IS",
                     "keyword": "IS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -103,7 +131,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -121,7 +153,9 @@
                     "token": "THEN",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -139,7 +175,11 @@
                     "token": "\"this is true\"",
                     "value": "this is true",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 32
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -157,7 +199,9 @@
                     "token": "ELSE",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 47
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -175,7 +221,9 @@
                     "token": "\"this is false\"",
                     "value": "this is false",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 2,
                     "position": 52
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -193,7 +243,9 @@
                     "token": "END",
                     "value": "END",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 68
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -211,7 +265,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 72
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -229,7 +287,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -238,13 +300,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 26,
-            "idx": 26
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -332,7 +394,7 @@
             [
                 "An alias was expected after AS.",
                 {
-                    "@type": "@25"
+                    "@type": "@29"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectCaseErr1.out
+++ b/tests/data/parser/parseSelectCaseErr1.out
@@ -7,13 +7,19 @@
         "last": 132,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 50,
+            "idx": 50,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -292,7 +366,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 89
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -310,7 +388,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -328,7 +410,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -346,7 +432,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -364,7 +456,9 @@
                     "token": "else",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -382,7 +478,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 2,
                     "position": 113
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -400,7 +500,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 121
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -418,7 +522,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 125
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -436,7 +544,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -445,7 +555,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -454,13 +568,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@57"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 50,
-            "idx": 50
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -549,63 +663,63 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@33"
+                    "@type": "@38"
                 },
                 0
             ],
             [
                 "Unexpected end of CASE expression",
                 {
-                    "@type": "@32"
-                },
-                0
-            ],
-            [
-                "Unrecognized keyword.",
-                {
-                    "@type": "@33"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
-                    "@type": "@35"
-                },
-                0
-            ],
-            [
-                "Unrecognized keyword.",
-                {
                     "@type": "@37"
                 },
                 0
             ],
             [
-                "Unexpected token.",
-                {
-                    "@type": "@39"
-                },
-                0
-            ],
-            [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@41"
+                    "@type": "@38"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@43"
+                    "@type": "@40"
                 },
                 0
             ],
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@45"
+                    "@type": "@42"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@44"
+                },
+                0
+            ],
+            [
+                "Unrecognized keyword.",
+                {
+                    "@type": "@47"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@49"
+                },
+                0
+            ],
+            [
+                "Unrecognized keyword.",
+                {
+                    "@type": "@51"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectCaseErr2.out
+++ b/tests/data/parser/parseSelectCaseErr2.out
@@ -7,13 +7,19 @@
         "last": 132,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 50,
+            "idx": 50,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -292,7 +366,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -301,7 +377,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 93
                 },
@@ -310,7 +388,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -328,7 +410,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -346,7 +432,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -364,7 +456,9 @@
                     "token": "else",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -382,7 +478,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 2,
                     "position": 113
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -400,7 +500,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 121
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -418,7 +522,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 125
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -436,7 +544,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -445,7 +555,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -454,13 +568,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@57"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 50,
-            "idx": 50
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -540,40 +654,12 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@31"
+                    "@type": "@36"
                 },
                 0
             ],
             [
                 "Unexpected end of CASE expression",
-                {
-                    "@type": "@30"
-                },
-                0
-            ],
-            [
-                "Unrecognized keyword.",
-                {
-                    "@type": "@31"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
-                    "@type": "@33"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
-                    "@type": "@34"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
                 {
                     "@type": "@35"
                 },
@@ -582,7 +668,14 @@
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@37"
+                    "@type": "@36"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@38"
                 },
                 0
             ],
@@ -594,23 +687,44 @@
                 0
             ],
             [
+                "Unexpected token.",
+                {
+                    "@type": "@40"
+                },
+                0
+            ],
+            [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@41"
+                    "@type": "@42"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@43"
+                    "@type": "@44"
                 },
                 0
             ],
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@45"
+                    "@type": "@47"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@49"
+                },
+                0
+            ],
+            [
+                "Unrecognized keyword.",
+                {
+                    "@type": "@51"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectCaseErr3.out
+++ b/tests/data/parser/parseSelectCaseErr3.out
@@ -7,13 +7,19 @@
         "last": 132,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 50,
+            "idx": 50,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -292,7 +366,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -301,7 +377,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 93
                 },
@@ -310,7 +388,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -328,7 +410,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -346,7 +432,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -364,7 +456,9 @@
                     "token": "else",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -382,7 +478,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 2,
                     "position": 113
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -400,7 +500,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 121
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -418,7 +522,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 125
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -436,7 +544,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -445,7 +555,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -454,13 +568,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@57"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 50,
-            "idx": 50
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -549,49 +663,49 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@37"
+                    "@type": "@42"
                 },
                 0
             ],
             [
                 "Unexpected end of CASE expression",
                 {
-                    "@type": "@36"
-                },
-                0
-            ],
-            [
-                "Unrecognized keyword.",
-                {
-                    "@type": "@37"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
-                    "@type": "@39"
-                },
-                0
-            ],
-            [
-                "Unrecognized keyword.",
-                {
                     "@type": "@41"
                 },
                 0
             ],
             [
+                "Unrecognized keyword.",
+                {
+                    "@type": "@42"
+                },
+                0
+            ],
+            [
                 "Unexpected token.",
                 {
-                    "@type": "@43"
+                    "@type": "@44"
                 },
                 0
             ],
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@45"
+                    "@type": "@47"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@49"
+                },
+                0
+            ],
+            [
+                "Unrecognized keyword.",
+                {
+                    "@type": "@51"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectCaseErr4.out
+++ b/tests/data/parser/parseSelectCaseErr4.out
@@ -7,13 +7,19 @@
         "last": 132,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 50,
+            "idx": 50,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -292,7 +366,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 89
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -310,7 +388,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -328,7 +410,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -346,7 +432,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -364,7 +456,9 @@
                     "token": "else",
                     "value": "ELSE",
                     "keyword": "ELSE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -382,7 +478,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 2,
                     "position": 113
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 120
                 },
@@ -400,7 +500,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 121
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -418,7 +522,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 125
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -436,7 +544,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 130
                 },
@@ -445,7 +555,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -454,13 +568,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@57"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 50,
-            "idx": 50
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -549,63 +663,63 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@33"
+                    "@type": "@38"
                 },
                 0
             ],
             [
                 "Unexpected end of CASE expression",
                 {
-                    "@type": "@32"
-                },
-                0
-            ],
-            [
-                "Unrecognized keyword.",
-                {
-                    "@type": "@33"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
-                    "@type": "@35"
-                },
-                0
-            ],
-            [
-                "Unrecognized keyword.",
-                {
                     "@type": "@37"
                 },
                 0
             ],
             [
-                "Unexpected token.",
-                {
-                    "@type": "@39"
-                },
-                0
-            ],
-            [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@41"
+                    "@type": "@38"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@43"
+                    "@type": "@40"
                 },
                 0
             ],
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@45"
+                    "@type": "@42"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@44"
+                },
+                0
+            ],
+            [
+                "Unrecognized keyword.",
+                {
+                    "@type": "@47"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@49"
+                },
+                0
+            ],
+            [
+                "Unrecognized keyword.",
+                {
+                    "@type": "@51"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectCaseErr5.out
+++ b/tests/data/parser/parseSelectCaseErr5.out
@@ -7,13 +7,19 @@
         "last": 139,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 54,
+            "idx": 54,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -85,7 +109,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,11 @@
                     "token": "mysql",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -103,7 +133,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -112,7 +144,9 @@
                     "token": "help_category",
                     "value": "help_category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": "help_category_id",
                     "value": "help_category_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -166,7 +210,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 68
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +267,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +289,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 76
                 },
@@ -238,7 +300,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -247,7 +311,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +322,9 @@
                     "token": "case",
                     "value": "CASE",
                     "keyword": "CASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -274,7 +344,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -292,7 +366,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 89
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -310,7 +388,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -328,7 +410,9 @@
                     "token": "then",
                     "value": "THEN",
                     "keyword": "THEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 96
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -346,7 +432,11 @@
                     "token": "\"Some\"",
                     "value": "Some",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -364,7 +456,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -373,7 +467,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -382,7 +478,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -400,7 +500,9 @@
                     "token": "when",
                     "value": "WHEN",
                     "keyword": "WHEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 115
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -418,7 +522,9 @@
                     "token": "\"Other\"",
                     "value": "Other",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 2,
                     "position": 120
                 },
@@ -427,7 +533,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -436,7 +544,9 @@
                     "token": "end",
                     "value": "end",
                     "keyword": "END",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 128
                 },
@@ -445,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -454,7 +566,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 132
                 },
@@ -463,7 +577,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 136
                 },
@@ -472,7 +588,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 137
                 },
@@ -481,7 +599,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -490,13 +612,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@61"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 54,
-            "idx": 54
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -617,35 +739,35 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@45"
+                    "@type": "@51"
                 },
                 0
             ],
             [
                 "Unexpected end of CASE expression",
                 {
-                    "@type": "@44"
+                    "@type": "@50"
                 },
                 0
             ],
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@45"
+                    "@type": "@51"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@47"
+                    "@type": "@53"
                 },
                 0
             ],
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@49"
+                    "@type": "@55"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectEndOptions1.out
+++ b/tests/data/parser/parseSelectEndOptions1.out
@@ -7,13 +7,19 @@
         "last": 86,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 23,
+            "idx": 23,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "pid",
                     "value": "pid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 10
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -58,7 +78,9 @@
                     "token": "name2",
                     "value": "name2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -76,7 +100,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": "tablename",
                     "value": "tablename",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -130,7 +166,9 @@
                     "token": "pid",
                     "value": "pid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -148,7 +188,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 43
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,11 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -184,7 +234,11 @@
                     "token": "/* FOR UPDATE end_option */",
                     "value": "/* FOR UPDATE end_option */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 48
                 },
@@ -193,7 +247,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -202,7 +258,9 @@
                     "token": "FOR UPDATE",
                     "value": "FOR UPDATE",
                     "keyword": "FOR UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 76
                 },
@@ -211,13 +269,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 23,
-            "idx": 23
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectEndOptions2.out
+++ b/tests/data/parser/parseSelectEndOptions2.out
@@ -7,13 +7,19 @@
         "last": 102,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 23,
+            "idx": 23,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "pid",
                     "value": "pid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 10
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -58,7 +78,9 @@
                     "token": "name2",
                     "value": "name2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -76,7 +100,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": "tablename",
                     "value": "tablename",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -130,7 +166,9 @@
                     "token": "pid",
                     "value": "pid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -148,7 +188,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 43
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,11 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +223,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -184,7 +234,11 @@
                     "token": "/* LOCK IN SHARE MODE end_option */",
                     "value": "/* LOCK IN SHARE MODE end_option */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 48
                 },
@@ -193,7 +247,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -202,7 +258,9 @@
                     "token": "LOCK IN SHARE MODE",
                     "value": "LOCK IN SHARE MODE",
                     "keyword": "LOCK IN SHARE MODE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 84
                 },
@@ -211,13 +269,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 23,
-            "idx": 23
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectEndOptionsErr.out
+++ b/tests/data/parser/parseSelectEndOptionsErr.out
@@ -7,13 +7,19 @@
         "last": 116,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 25,
+            "idx": 25,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "pid",
                     "value": "pid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 10
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -58,7 +78,9 @@
                     "token": "name2",
                     "value": "name2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -76,7 +100,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": "tablename",
                     "value": "tablename",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -130,7 +166,9 @@
                     "token": "pid",
                     "value": "pid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -148,7 +188,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 43
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,11 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +223,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -184,7 +234,11 @@
                     "token": "/* USE both end_option, gives error */",
                     "value": "/* USE both end_option, gives error */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 48
                 },
@@ -193,7 +247,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -202,7 +258,9 @@
                     "token": "FOR UPDATE",
                     "value": "FOR UPDATE",
                     "keyword": "FOR UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 87
                 },
@@ -211,7 +269,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -220,7 +280,9 @@
                     "token": "LOCK IN SHARE MODE",
                     "value": "LOCK IN SHARE MODE",
                     "keyword": "LOCK IN SHARE MODE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 98
                 },
@@ -229,13 +291,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 25,
-            "idx": 25
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -330,7 +394,7 @@
             [
                 "This option conflicts with \"FOR UPDATE\".",
                 {
-                    "@type": "@25"
+                    "@type": "@31"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectErr1.out
+++ b/tests/data/parser/parseSelectErr1.out
@@ -7,13 +7,19 @@
         "last": 220,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 77,
+            "idx": 77,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "ALL",
                     "value": "ALL",
                     "keyword": "ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 11
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +85,9 @@
                     "token": "MAX_STATEMENT_TIME",
                     "value": "MAX_STATEMENT_TIME",
                     "keyword": "MAX_STATEMENT_TIME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 20
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -85,7 +107,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 39
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -103,7 +131,11 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -112,7 +144,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -121,7 +155,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -139,7 +177,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -175,7 +221,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 54
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -193,7 +243,11 @@
                     "token": "result",
                     "value": "result",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -202,7 +256,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 63
                 },
@@ -211,7 +267,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -220,7 +278,11 @@
                     "token": "@idx",
                     "value": "idx",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 69
                 },
@@ -229,7 +291,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 73
                 },
@@ -238,7 +302,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -247,7 +313,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -256,7 +324,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 81
                 },
@@ -265,7 +335,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -274,7 +346,9 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -283,7 +357,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 91
                 },
@@ -292,7 +368,9 @@
                     "token": "`users`",
                     "value": "users",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 2,
                     "position": 92
                 },
@@ -301,7 +379,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 99
                 },
@@ -310,7 +390,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -319,7 +401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -328,7 +412,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 109
                 },
@@ -337,7 +423,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -346,7 +434,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 112
                 },
@@ -355,7 +445,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -364,7 +456,9 @@
                     "token": "`test`",
                     "value": "test",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 2,
                     "position": 121
                 },
@@ -373,7 +467,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 127
                 },
@@ -382,7 +478,9 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 128
                 },
@@ -391,7 +489,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -400,7 +500,9 @@
                     "token": "PARTITION",
                     "value": "PARTITION",
                     "keyword": "PARTITION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 138
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -418,7 +522,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 148
                 },
@@ -427,7 +533,9 @@
                     "token": "p1",
                     "value": "p1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -436,7 +544,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 151
                 },
@@ -445,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -454,7 +566,9 @@
                     "token": "p2",
                     "value": "p2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 153
                 },
@@ -463,7 +577,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 155
                 },
@@ -472,7 +588,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 156
                 },
@@ -481,7 +599,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 157
                 },
@@ -490,7 +610,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 162
                 },
@@ -499,7 +621,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 167
                 },
@@ -508,7 +632,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 169
                 },
@@ -517,7 +643,9 @@
                     "token": ">",
                     "value": ">",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 170
                 },
@@ -526,7 +654,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 171
                 },
@@ -535,7 +665,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 172
                 },
@@ -544,7 +676,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 173
                 },
@@ -553,7 +687,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 174
                 },
@@ -562,7 +698,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 182
                 },
@@ -571,7 +709,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 187
                 },
@@ -580,7 +720,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 195
                 },
@@ -589,7 +731,9 @@
                     "token": "DESC",
                     "value": "DESC",
                     "keyword": "DESC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 196
                 },
@@ -598,7 +742,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 200
                 },
@@ -607,7 +753,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 201
                 },
@@ -616,7 +764,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 206
                 },
@@ -625,7 +775,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 208
                 },
@@ -634,7 +786,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 209
                 },
@@ -643,7 +797,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 214
                 },
@@ -652,7 +808,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 215
                 },
@@ -661,7 +819,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 216
                 },
@@ -670,7 +830,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 217
                 },
@@ -679,7 +841,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 0,
                     "position": 218
                 },
@@ -688,7 +852,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 219
                 },
@@ -697,13 +865,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@84"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 77,
-            "idx": 77
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -864,14 +1032,14 @@
             [
                 "This option conflicts with \"ALL\".",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ],
             [
                 "An alias was expected.",
                 {
-                    "@type": "@38"
+                    "@type": "@44"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectErr2.out
+++ b/tests/data/parser/parseSelectErr2.out
@@ -7,13 +7,19 @@
         "last": 35,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 16,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "from",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "foobar",
                     "value": "foobar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +111,9 @@
                     "token": "where",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -121,7 +155,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 31
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -139,7 +177,11 @@
                     "token": "@",
                     "value": "",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 33
                 },
@@ -148,13 +190,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 16
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectExists.out
+++ b/tests/data/parser/parseSelectExists.out
@@ -7,13 +7,19 @@
         "last": 24,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "EXISTS",
                     "value": "EXISTS",
                     "keyword": "EXISTS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 7
                 },
@@ -40,7 +52,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 13
                 },
@@ -49,7 +65,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 14
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -76,7 +100,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 16,
                     "position": 22
                 },
@@ -85,7 +111,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -94,13 +122,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectGroupBy.out
+++ b/tests/data/parser/parseSelectGroupBy.out
@@ -7,13 +7,19 @@
         "last": 294,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 107,
+            "idx": 107,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "movie",
                     "value": "movie",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +111,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 20
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -103,7 +133,9 @@
                     "token": "title",
                     "value": "title",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -112,7 +144,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -121,7 +157,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -130,7 +168,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 36
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -148,7 +190,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +212,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -184,7 +234,9 @@
                     "token": "movie",
                     "value": "movie",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -202,7 +256,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 56
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -220,7 +278,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -229,7 +291,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -238,7 +302,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -247,7 +313,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 68
                 },
@@ -256,7 +324,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -265,7 +335,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 75
                 },
@@ -274,7 +346,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -283,7 +357,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 77
                 },
@@ -292,7 +368,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -301,7 +379,9 @@
                     "token": "movie",
                     "value": "movie",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -310,7 +390,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -319,7 +401,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 88
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -337,7 +423,9 @@
                     "token": "year",
                     "value": "year",
                     "keyword": "YEAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 97
                 },
@@ -346,7 +434,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 101
                 },
@@ -355,7 +445,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -364,7 +456,9 @@
                     "token": "title",
                     "value": "title",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -373,7 +467,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -382,7 +478,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -391,7 +489,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 110
                 },
@@ -400,7 +500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 116
                 },
@@ -409,7 +511,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 117
                 },
@@ -418,7 +522,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -427,7 +533,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 119
                 },
@@ -436,7 +544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -445,7 +555,9 @@
                     "token": "movie",
                     "value": "movie",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -454,7 +566,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -463,7 +577,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 130
                 },
@@ -472,7 +588,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -481,7 +599,9 @@
                     "token": "year",
                     "value": "year",
                     "keyword": "YEAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 139
                 },
@@ -490,7 +610,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -499,7 +621,9 @@
                     "token": "WITH ROLLUP",
                     "value": "WITH ROLLUP",
                     "keyword": "WITH ROLLUP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 144
                 },
@@ -508,7 +632,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 155
                 },
@@ -517,7 +643,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 156
                 },
@@ -526,7 +654,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 157
                 },
@@ -535,7 +665,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 163
                 },
@@ -544,7 +676,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 164
                 },
@@ -553,7 +687,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 165
                 },
@@ -562,7 +698,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 166
                 },
@@ -571,7 +709,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 170
                 },
@@ -580,7 +720,9 @@
                     "token": "movie",
                     "value": "movie",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 171
                 },
@@ -589,7 +731,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -598,7 +742,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 177
                 },
@@ -607,7 +753,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 185
                 },
@@ -616,7 +764,9 @@
                     "token": "year",
                     "value": "year",
                     "keyword": "YEAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 186
                 },
@@ -625,7 +775,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 190
                 },
@@ -634,7 +786,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 191
                 },
@@ -643,7 +797,9 @@
                     "token": "title",
                     "value": "title",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 192
                 },
@@ -652,7 +808,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 197
                 },
@@ -661,7 +819,9 @@
                     "token": "WITH ROLLUP",
                     "value": "WITH ROLLUP",
                     "keyword": "WITH ROLLUP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 198
                 },
@@ -670,7 +830,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 209
                 },
@@ -679,7 +841,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 210
                 },
@@ -688,7 +852,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 211
                 },
@@ -697,7 +863,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 217
                 },
@@ -706,7 +874,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 218
                 },
@@ -715,7 +885,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 219
                 },
@@ -724,7 +896,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 220
                 },
@@ -733,7 +907,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 224
                 },
@@ -742,7 +918,9 @@
                     "token": "movie",
                     "value": "movie",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 225
                 },
@@ -751,7 +929,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 230
                 },
@@ -760,7 +940,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 231
                 },
@@ -769,7 +951,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 239
                 },
@@ -778,7 +962,9 @@
                     "token": "year",
                     "value": "year",
                     "keyword": "YEAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 240
                 },
@@ -787,7 +973,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 244
                 },
@@ -796,7 +984,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 245
                 },
@@ -805,7 +995,9 @@
                     "token": "title",
                     "value": "title",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 246
                 },
@@ -814,7 +1006,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 251
                 },
@@ -823,7 +1017,9 @@
                     "token": "WITH ROLLUP",
                     "value": "WITH ROLLUP",
                     "keyword": "WITH ROLLUP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 252
                 },
@@ -832,7 +1028,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 263
                 },
@@ -841,7 +1039,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 264
                 },
@@ -850,7 +1050,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 272
                 },
@@ -859,7 +1061,9 @@
                     "token": "year",
                     "value": "year",
                     "keyword": "YEAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 273
                 },
@@ -868,7 +1072,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 277
                 },
@@ -877,7 +1083,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 278
                 },
@@ -886,7 +1094,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 281
                 },
@@ -895,7 +1105,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 282
                 },
@@ -904,7 +1116,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 287
                 },
@@ -913,7 +1127,9 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 288
                 },
@@ -922,7 +1138,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 289
                 },
@@ -931,7 +1149,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 290
                 },
@@ -940,7 +1160,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 291
                 },
@@ -949,7 +1171,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": 292
                 },
@@ -958,7 +1182,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 293
                 },
@@ -967,13 +1193,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 107,
-            "idx": 107
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectGroupByErr.out
+++ b/tests/data/parser/parseSelectGroupByErr.out
@@ -7,13 +7,19 @@
         "last": 66,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "movie",
                     "value": "movie",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +111,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 20
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -103,7 +133,9 @@
                     "token": "title",
                     "value": "title",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -121,7 +155,9 @@
                     "token": "WITH ROLLUP",
                     "value": "WITH ROLLUP",
                     "keyword": "WITH ROLLUP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 35
                 },
@@ -130,7 +166,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 46
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -148,7 +188,9 @@
                     "token": "year",
                     "value": "year",
                     "keyword": "YEAR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 41,
                     "position": 48
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -166,7 +210,9 @@
                     "token": "WITH ROLLUP",
                     "value": "WITH ROLLUP",
                     "keyword": "WITH ROLLUP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 53
                 },
@@ -175,7 +221,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -184,7 +234,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -193,13 +245,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -289,14 +341,14 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@15"
+                    "@type": "@19"
                 },
                 0
             ],
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@17"
+                    "@type": "@21"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectGroupByWithComments.out
+++ b/tests/data/parser/parseSelectGroupByWithComments.out
@@ -7,13 +7,19 @@
         "last": 75,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 24,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 9
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -58,7 +78,9 @@
                     "token": "title",
                     "value": "title",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -76,7 +100,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -94,7 +122,9 @@
                     "token": "movie",
                     "value": "movie",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 28
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -130,7 +166,9 @@
                     "token": "movie",
                     "value": "movie",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -139,7 +177,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -148,7 +188,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -157,7 +199,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 45
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -175,7 +221,11 @@
                     "token": "/* removed_field, */",
                     "value": "/* removed_field, */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 47
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -193,7 +245,9 @@
                     "token": "title",
                     "value": "title",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -202,7 +256,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -211,7 +269,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -220,13 +280,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 24
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectIndexHint1.out
+++ b/tests/data/parser/parseSelectIndexHint1.out
@@ -7,13 +7,19 @@
         "last": 101,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 40,
+            "idx": 40,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 8
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -67,7 +87,11 @@
                     "token": "address",
                     "value": "address",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,7 +111,9 @@
                     "token": "FORCE",
                     "value": "FORCE",
                     "keyword": "FORCE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 23
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -103,7 +133,9 @@
                     "token": "INDEX",
                     "value": "INDEX",
                     "keyword": "INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 29
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -121,7 +155,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -130,7 +166,9 @@
                     "token": "idx_fk_city_id",
                     "value": "idx_fk_city_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -139,7 +177,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": "IGNORE",
                     "value": "IGNORE",
                     "keyword": "IGNORE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 52
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -175,7 +221,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 59
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -193,7 +243,9 @@
                     "token": "FOR",
                     "value": "FOR",
                     "keyword": "FOR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 63
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -211,7 +265,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 67
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -229,7 +287,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 76
                 },
@@ -238,7 +298,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -247,7 +309,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 78
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -265,7 +331,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -274,7 +342,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 81
                 },
@@ -283,7 +353,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -292,7 +364,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 83
                 },
@@ -301,7 +375,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -310,7 +386,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 85
                 },
@@ -319,7 +397,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -328,7 +408,9 @@
                     "token": "city_id",
                     "value": "city_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -337,7 +419,9 @@
                     "token": "<",
                     "value": "<",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 98
                 },
@@ -346,7 +430,11 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -355,7 +443,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -364,13 +456,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@46"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 40,
-            "idx": 40
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectIndexHint2.out
+++ b/tests/data/parser/parseSelectIndexHint2.out
@@ -7,13 +7,19 @@
         "last": 97,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 39,
+            "idx": 39,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 8
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -67,7 +87,11 @@
                     "token": "address",
                     "value": "address",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,7 +111,9 @@
                     "token": "USE",
                     "value": "USE",
                     "keyword": "USE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 23
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "INDEX",
                     "value": "INDEX",
                     "keyword": "INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -121,7 +155,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -130,7 +166,9 @@
                     "token": "idx_fk_city_id",
                     "value": "idx_fk_city_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -139,7 +177,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 48
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -157,7 +199,9 @@
                     "token": "FORCE",
                     "value": "FORCE",
                     "keyword": "FORCE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 50
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -175,7 +221,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 56
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -193,7 +243,9 @@
                     "token": "FOR",
                     "value": "FOR",
                     "keyword": "FOR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 60
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -211,7 +265,9 @@
                     "token": "GROUP BY",
                     "value": "GROUP BY",
                     "keyword": "GROUP BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 64
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -229,7 +287,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 73
                 },
@@ -238,7 +298,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -247,7 +309,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 75
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -265,7 +331,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -274,7 +342,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 78
                 },
@@ -283,7 +353,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -292,7 +364,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -301,7 +375,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -310,7 +386,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -319,7 +397,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -328,7 +408,9 @@
                     "token": "city_id",
                     "value": "city_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -337,7 +419,9 @@
                     "token": "<",
                     "value": "<",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 95
                 },
@@ -346,7 +430,11 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -355,13 +443,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 39,
-            "idx": 39
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectIndexHintErr1.out
+++ b/tests/data/parser/parseSelectIndexHintErr1.out
@@ -7,13 +7,19 @@
         "last": 49,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "address",
                     "value": "address",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": "FORCE",
                     "value": "FORCE",
                     "keyword": "FORCE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +133,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 28
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -130,7 +166,9 @@
                     "token": "idx_fk_city_id",
                     "value": "idx_fk_city_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -139,7 +177,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 47
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -157,13 +201,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -253,7 +297,7 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@12"
+                    "@type": "@16"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectIndexHintErr2.out
+++ b/tests/data/parser/parseSelectIndexHintErr2.out
@@ -7,13 +7,19 @@
         "last": 49,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "address",
                     "value": "address",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": "FORCE",
                     "value": "FORCE",
                     "keyword": "FORCE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +133,9 @@
                     "token": "abc",
                     "value": "abc",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -121,7 +155,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -130,7 +166,9 @@
                     "token": "idx_fk_city_id",
                     "value": "idx_fk_city_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -139,7 +177,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 47
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -157,13 +201,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -234,28 +278,28 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@12"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
-                    "@type": "@14"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
-                    "@type": "@15"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
                     "@type": "@16"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@18"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@19"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@20"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectIndexHintErr3.out
+++ b/tests/data/parser/parseSelectIndexHintErr3.out
@@ -7,13 +7,19 @@
         "last": 59,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "address",
                     "value": "address",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": "FORCE",
                     "value": "FORCE",
                     "keyword": "FORCE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +133,9 @@
                     "token": "INDEX",
                     "value": "INDEX",
                     "keyword": "INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 28
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": "FOR",
                     "value": "FOR",
                     "keyword": "FOR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -139,7 +177,9 @@
                     "token": "abc",
                     "value": "abc",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -157,7 +199,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -166,7 +210,9 @@
                     "token": "idx_fk_city_id",
                     "value": "idx_fk_city_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -175,7 +221,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 57
                 },
@@ -184,7 +232,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -193,13 +245,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -270,28 +322,28 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@16"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
-                    "@type": "@18"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
-                    "@type": "@19"
-                },
-                0
-            ],
-            [
-                "Unexpected token.",
-                {
                     "@type": "@20"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@22"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@23"
+                },
+                0
+            ],
+            [
+                "Unexpected token.",
+                {
+                    "@type": "@24"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectIndexHintErr4.out
+++ b/tests/data/parser/parseSelectIndexHintErr4.out
@@ -7,13 +7,19 @@
         "last": 59,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 21,
+            "idx": 21,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "address",
                     "value": "address",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": "FORCE",
                     "value": "FORCE",
                     "keyword": "FORCE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +133,9 @@
                     "token": "INDEX",
                     "value": "INDEX",
                     "keyword": "INDEX",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 28
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": "FOR",
                     "value": "FOR",
                     "keyword": "FOR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -139,7 +177,9 @@
                     "token": "INT",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 38
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -157,7 +199,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -166,7 +210,9 @@
                     "token": "idx_fk_city_id",
                     "value": "idx_fk_city_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -175,7 +221,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 57
                 },
@@ -184,7 +232,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -193,13 +245,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 21,
-            "idx": 21
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -289,7 +341,7 @@
             [
                 "Unexpected keyword.",
                 {
-                    "@type": "@16"
+                    "@type": "@20"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectIntoOptions1.out
+++ b/tests/data/parser/parseSelectIntoOptions1.out
@@ -7,13 +7,19 @@
         "last": 152,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 39,
+            "idx": 39,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 8
                 },
@@ -49,7 +67,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 10
                 },
@@ -67,7 +89,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -76,7 +100,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 12
                 },
@@ -85,7 +111,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -103,7 +133,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 15
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -121,7 +155,9 @@
                     "token": "OUTFILE",
                     "value": "OUTFILE",
                     "keyword": "OUTFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -139,7 +177,11 @@
                     "token": "'/tmp/result.txt'",
                     "value": "/tmp/result.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 28
                 },
@@ -148,7 +190,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -157,7 +201,9 @@
                     "token": "FIELDS",
                     "value": "FIELDS",
                     "keyword": "FIELDS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -175,7 +223,9 @@
                     "token": "TERMINATED BY",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 57
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +245,9 @@
                     "token": "','",
                     "value": ",",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 1,
                     "position": 71
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -211,7 +267,9 @@
                     "token": "OPTIONALLY",
                     "value": "OPTIONALLY",
                     "keyword": "OPTIONALLY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 75
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -229,7 +289,9 @@
                     "token": "ENCLOSED BY",
                     "value": "ENCLOSED BY",
                     "keyword": "ENCLOSED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 86
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -247,7 +311,9 @@
                     "token": "'\\\"'",
                     "value": "\"",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 1,
                     "position": 98
                 },
@@ -256,7 +322,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -265,7 +333,9 @@
                     "token": "LINES",
                     "value": "LINES",
                     "keyword": "LINES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 107
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -283,7 +355,9 @@
                     "token": "TERMINATED BY",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 113
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -301,7 +377,9 @@
                     "token": "'\\n'",
                     "value": "\n",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 1,
                     "position": 127
                 },
@@ -310,7 +388,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -319,7 +399,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 136
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -337,7 +421,9 @@
                     "token": "test_table",
                     "value": "test_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -346,7 +432,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 151
                 },
@@ -355,13 +445,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 39,
-            "idx": 39
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectIntoOptions2.out
+++ b/tests/data/parser/parseSelectIntoOptions2.out
@@ -7,13 +7,19 @@
         "last": 153,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 39,
+            "idx": 39,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 8
                 },
@@ -49,7 +67,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 10
                 },
@@ -67,7 +89,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -76,7 +100,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 12
                 },
@@ -85,7 +111,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -103,7 +133,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 15
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -121,7 +155,9 @@
                     "token": "OUTFILE",
                     "value": "OUTFILE",
                     "keyword": "OUTFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -139,7 +177,11 @@
                     "token": "'/tmp/result.txt'",
                     "value": "/tmp/result.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 28
                 },
@@ -148,7 +190,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -157,7 +201,9 @@
                     "token": "COLUMNS",
                     "value": "COLUMNS",
                     "keyword": "COLUMNS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -175,7 +223,9 @@
                     "token": "TERMINATED BY",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 58
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -193,7 +245,9 @@
                     "token": "','",
                     "value": ",",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 1,
                     "position": 72
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -211,7 +267,9 @@
                     "token": "OPTIONALLY",
                     "value": "OPTIONALLY",
                     "keyword": "OPTIONALLY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 76
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -229,7 +289,9 @@
                     "token": "ENCLOSED BY",
                     "value": "ENCLOSED BY",
                     "keyword": "ENCLOSED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 87
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -247,7 +311,9 @@
                     "token": "'\\\"'",
                     "value": "\"",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 1,
                     "position": 99
                 },
@@ -256,7 +322,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -265,7 +333,9 @@
                     "token": "LINES",
                     "value": "LINES",
                     "keyword": "LINES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -283,7 +355,9 @@
                     "token": "TERMINATED BY",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 114
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -301,7 +377,9 @@
                     "token": "'\\n'",
                     "value": "\n",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 1,
                     "position": 128
                 },
@@ -310,7 +388,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -319,7 +399,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 137
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -337,7 +421,9 @@
                     "token": "test_table",
                     "value": "test_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -346,7 +432,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -355,13 +445,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@45"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 39,
-            "idx": 39
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectIntoOptions3.out
+++ b/tests/data/parser/parseSelectIntoOptions3.out
@@ -7,13 +7,19 @@
         "last": 124,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 33,
+            "idx": 33,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 8
                 },
@@ -49,7 +67,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 10
                 },
@@ -67,7 +89,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -76,7 +100,9 @@
                     "token": "+",
                     "value": "+",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 12
                 },
@@ -85,7 +111,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -103,7 +133,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 15
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -121,7 +155,9 @@
                     "token": "OUTFILE",
                     "value": "OUTFILE",
                     "keyword": "OUTFILE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -139,7 +177,11 @@
                     "token": "'/tmp/result.txt'",
                     "value": "/tmp/result.txt",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 28
                 },
@@ -148,7 +190,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -157,7 +201,9 @@
                     "token": "COLUMNS",
                     "value": "COLUMNS",
                     "keyword": "COLUMNS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 50
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -175,7 +223,9 @@
                     "token": "TERMINATED BY",
                     "value": "TERMINATED BY",
                     "keyword": "TERMINATED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 58
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -193,7 +245,9 @@
                     "token": "','",
                     "value": ",",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 1,
                     "position": 72
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -211,7 +267,9 @@
                     "token": "OPTIONALLY",
                     "value": "OPTIONALLY",
                     "keyword": "OPTIONALLY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 76
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -229,7 +289,9 @@
                     "token": "ENCLOSED BY",
                     "value": "ENCLOSED BY",
                     "keyword": "ENCLOSED BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 87
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -247,7 +311,9 @@
                     "token": "'\\\"'",
                     "value": "\"",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 1,
                     "position": 99
                 },
@@ -256,7 +322,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -265,7 +333,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 108
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -283,7 +355,9 @@
                     "token": "test_table",
                     "value": "test_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -292,7 +366,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -301,13 +379,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 33,
-            "idx": 33
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectJoinCross.out
+++ b/tests/data/parser/parseSelectJoinCross.out
@@ -7,13 +7,19 @@
         "last": 110,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 31,
+            "idx": 31,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "table112",
                     "value": "table112",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 15
                 },
@@ -49,7 +67,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -58,7 +78,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 18
                 },
@@ -67,7 +89,9 @@
                     "token": "table112",
                     "value": "table112",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -76,7 +100,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 27
                 },
@@ -85,7 +111,9 @@
                     "token": "bval1",
                     "value": "bval1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -94,7 +122,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -103,7 +133,9 @@
                     "token": "table112",
                     "value": "table112",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -112,7 +144,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -121,7 +155,9 @@
                     "token": "bval2",
                     "value": "bval2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -130,7 +166,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 48
                 },
@@ -139,7 +177,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -148,7 +188,9 @@
                     "token": "table111",
                     "value": "table111",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -157,7 +199,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 58
                 },
@@ -166,7 +210,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -175,7 +221,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 61
                 },
@@ -184,7 +232,9 @@
                     "token": "table111",
                     "value": "table111",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -193,7 +243,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 70
                 },
@@ -202,7 +254,9 @@
                     "token": "aval1",
                     "value": "aval1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -211,7 +265,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -220,7 +276,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 77
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -238,7 +298,9 @@
                     "token": "table112",
                     "value": "table112",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -247,7 +309,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -256,7 +320,9 @@
                     "token": "CROSS JOIN",
                     "value": "CROSS JOIN",
                     "keyword": "CROSS JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 91
                 },
@@ -265,7 +331,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -274,7 +342,9 @@
                     "token": "table111",
                     "value": "table111",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -283,13 +353,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 31,
-            "idx": 31
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectJoinMultiple.out
+++ b/tests/data/parser/parseSelectJoinMultiple.out
@@ -7,13 +7,19 @@
         "last": 92,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 23,
+            "idx": 23,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "Orders",
                     "value": "Orders",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +111,9 @@
                     "token": "NATURAL JOIN",
                     "value": "NATURAL JOIN",
                     "keyword": "NATURAL JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -103,7 +133,9 @@
                     "token": "Items_Orders",
                     "value": "Items_Orders",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -121,7 +155,9 @@
                     "token": "NATURAL JOIN",
                     "value": "NATURAL JOIN",
                     "keyword": "NATURAL JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 47
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -139,7 +177,9 @@
                     "token": "Items",
                     "value": "Items",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -148,7 +188,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -157,7 +199,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 66
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -175,7 +221,9 @@
                     "token": "customer",
                     "value": "customer",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -184,7 +232,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 80
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -202,7 +254,11 @@
                     "token": "'username'",
                     "value": "username",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 82
                 },
@@ -211,13 +267,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 23,
-            "idx": 23
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectJoinMultiple2.out
+++ b/tests/data/parser/parseSelectJoinMultiple2.out
@@ -7,13 +7,19 @@
         "last": 118,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 35,
+            "idx": 35,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "orders",
                     "value": "orders",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -85,7 +111,9 @@
                     "token": "NATURAL JOIN",
                     "value": "NATURAL JOIN",
                     "keyword": "NATURAL JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 21
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -103,7 +133,9 @@
                     "token": "Items_Orders",
                     "value": "Items_Orders",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -121,7 +155,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 47
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -139,7 +177,9 @@
                     "token": "items",
                     "value": "items",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -157,7 +199,9 @@
                     "token": "on",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 63
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -175,7 +221,9 @@
                     "token": "orders",
                     "value": "orders",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -184,7 +232,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 72
                 },
@@ -193,7 +243,9 @@
                     "token": "item_id",
                     "value": "item_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -211,7 +265,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 81
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -229,7 +287,9 @@
                     "token": "items",
                     "value": "items",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -238,7 +298,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 88
                 },
@@ -247,7 +309,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -256,7 +320,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -265,7 +331,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 92
                 },
@@ -274,7 +342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -283,7 +353,9 @@
                     "token": "customer",
                     "value": "customer",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -292,7 +364,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 106
                 },
@@ -301,7 +375,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -310,7 +386,11 @@
                     "token": "'username'",
                     "value": "username",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 108
                 },
@@ -319,13 +399,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 35,
-            "idx": 35
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectJoinNatural.out
+++ b/tests/data/parser/parseSelectJoinNatural.out
@@ -7,13 +7,19 @@
         "last": 57,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 16,
+            "idx": 16,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 9
                 },
@@ -49,7 +67,9 @@
                     "token": "aval1",
                     "value": "aval1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -58,7 +78,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 15
                 },
@@ -67,7 +89,9 @@
                     "token": "cval1",
                     "value": "cval1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -76,7 +100,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "table111",
                     "value": "table111",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -121,7 +155,9 @@
                     "token": "NATURAL JOIN",
                     "value": "NATURAL JOIN",
                     "keyword": "NATURAL JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 36
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -139,7 +177,9 @@
                     "token": "table113",
                     "value": "table113",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -148,13 +188,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 16,
-            "idx": 16
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectJoinNaturalLeft.out
+++ b/tests/data/parser/parseSelectJoinNaturalLeft.out
@@ -7,13 +7,19 @@
         "last": 88,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 33,
+            "idx": 33,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "C",
                     "value": "C",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 8
                 },
@@ -49,7 +67,9 @@
                     "token": "First_Name",
                     "value": "First_Name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": "C",
                     "value": "C",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": "Last_Name",
                     "value": "Last_Name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -103,7 +133,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": "O",
                     "value": "O",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -139,7 +177,9 @@
                     "token": "title",
                     "value": "title",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -148,7 +188,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -157,7 +199,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -175,7 +221,9 @@
                     "token": "Employee",
                     "value": "Employee",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -193,7 +243,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 56
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -211,7 +265,9 @@
                     "token": "C",
                     "value": "C",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -220,7 +276,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -229,7 +287,9 @@
                     "token": "NATURAL LEFT JOIN",
                     "value": "NATURAL LEFT JOIN",
                     "keyword": "NATURAL LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 61
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -247,7 +309,9 @@
                     "token": "JOb",
                     "value": "JOb",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -265,7 +331,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 83
                 },
@@ -274,7 +342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -283,7 +353,9 @@
                     "token": "O",
                     "value": "O",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -292,7 +364,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -301,13 +377,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@38"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 33,
-            "idx": 33
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectJoinNaturalLeftOuter.out
+++ b/tests/data/parser/parseSelectJoinNaturalLeftOuter.out
@@ -7,13 +7,19 @@
         "last": 55,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 13,
+            "idx": 13,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "actor",
                     "value": "actor",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +111,9 @@
                     "token": "NATURAL LEFT OUTER JOIN",
                     "value": "NATURAL LEFT OUTER JOIN",
                     "keyword": "NATURAL LEFT OUTER JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 20
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -103,7 +133,9 @@
                     "token": "film_actor",
                     "value": "film_actor",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -112,7 +144,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -121,13 +157,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 13,
-            "idx": 13
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectJoinNaturalRight.out
+++ b/tests/data/parser/parseSelectJoinNaturalRight.out
@@ -7,13 +7,19 @@
         "last": 51,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 14,
+            "idx": 14,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "actor",
                     "value": "actor",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +111,9 @@
                     "token": "NATURAL RIGHT JOIN",
                     "value": "NATURAL RIGHT JOIN",
                     "keyword": "NATURAL RIGHT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 20
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -103,7 +133,9 @@
                     "token": "film_actor",
                     "value": "film_actor",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -112,7 +144,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -121,7 +157,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -130,13 +168,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 14,
-            "idx": 14
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectJoinNaturalRightOuter.out
+++ b/tests/data/parser/parseSelectJoinNaturalRightOuter.out
@@ -7,13 +7,19 @@
         "last": 56,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 13,
+            "idx": 13,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "actor",
                     "value": "actor",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -85,7 +111,9 @@
                     "token": "NATURAL RIGHT OUTER JOIN",
                     "value": "NATURAL RIGHT OUTER JOIN",
                     "keyword": "NATURAL RIGHT OUTER JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 20
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -103,7 +133,9 @@
                     "token": "film_actor",
                     "value": "film_actor",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -112,7 +144,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -121,13 +157,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 13,
-            "idx": 13
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectJoinStraight.out
+++ b/tests/data/parser/parseSelectJoinStraight.out
@@ -7,13 +7,19 @@
         "last": 85,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 28,
+            "idx": 28,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 9
                 },
@@ -49,7 +67,9 @@
                     "token": "aval1",
                     "value": "aval1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -58,7 +78,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 15
                 },
@@ -67,7 +89,9 @@
                     "token": "cval1",
                     "value": "cval1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -76,7 +100,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": "table111",
                     "value": "table111",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -112,7 +144,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -121,7 +155,9 @@
                     "token": "STRAIGHT_JOIN",
                     "value": "STRAIGHT_JOIN",
                     "keyword": "STRAIGHT_JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 36
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -139,7 +177,9 @@
                     "token": "table113",
                     "value": "table113",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -157,7 +199,9 @@
                     "token": "on",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 59
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -175,7 +221,9 @@
                     "token": "table111",
                     "value": "table111",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -184,7 +232,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 70
                 },
@@ -193,7 +243,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -211,7 +265,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 73
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -229,7 +287,9 @@
                     "token": "table113",
                     "value": "table113",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -238,7 +298,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 83
                 },
@@ -247,7 +309,9 @@
                     "token": "b",
                     "value": "b",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -256,13 +320,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 28,
-            "idx": 28
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectNested.out
+++ b/tests/data/parser/parseSelectNested.out
@@ -7,13 +7,19 @@
         "last": 52,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 24,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,11 @@
                     "token": "'foo'",
                     "value": "foo",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 15
                 },
@@ -67,7 +89,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 20
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -85,7 +111,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -103,7 +133,11 @@
                     "token": "Bar",
                     "value": "Bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -112,7 +146,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 28
                 },
@@ -121,7 +157,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -130,7 +168,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -139,7 +179,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 31
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -157,7 +201,9 @@
                     "token": "'baz'",
                     "value": "baz",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 38
                 },
@@ -166,7 +212,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -184,7 +234,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -202,7 +256,9 @@
                     "token": "fOo",
                     "value": "fOo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -211,7 +267,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -220,13 +280,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@30"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 24
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectOrderByComment.out
+++ b/tests/data/parser/parseSelectOrderByComment.out
@@ -7,13 +7,19 @@
         "last": 144,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 20,
+            "idx": 20,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "`one space`",
                     "value": "one space",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -49,7 +65,11 @@
                     "token": "-- this is the SELECT",
                     "value": "-- this is the SELECT",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 20
                 },
@@ -58,7 +78,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -67,7 +89,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 46
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -85,7 +111,9 @@
                     "token": "`Une table espace`",
                     "value": "Une table espace",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 51
                 },
@@ -94,7 +122,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -103,7 +133,9 @@
                     "token": "-- this is the FROM",
                     "value": "-- this is the FROM",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 4,
                     "position": 71
                 },
@@ -112,7 +144,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -121,7 +155,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 95
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -139,7 +177,9 @@
                     "token": "`one space`",
                     "value": "one space",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 104
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -157,7 +199,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 116
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -175,7 +221,9 @@
                     "token": "-- this is the order by",
                     "value": "-- this is the order by",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 4,
                     "position": 120
                 },
@@ -184,13 +232,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 20,
-            "idx": 20
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectOrderByIsNull.out
+++ b/tests/data/parser/parseSelectOrderByIsNull.out
@@ -7,13 +7,19 @@
         "last": 51,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "some_table",
                     "value": "some_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -103,7 +133,9 @@
                     "token": "some_col",
                     "value": "some_col",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -121,7 +155,9 @@
                     "token": "IS",
                     "value": "IS",
                     "keyword": "IS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 43
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 46
                 },
@@ -148,7 +188,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -157,13 +201,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectOverAlias_mariadb_100600.out
+++ b/tests/data/parser/parseSelectOverAlias_mariadb_100600.out
@@ -7,13 +7,19 @@
         "last": 171,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 51,
+            "idx": 51,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "select",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "`products`",
                     "value": "products",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 17
                 },
@@ -49,7 +67,9 @@
                     "token": "`pid`",
                     "value": "pid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 18
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +89,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,7 +111,9 @@
                     "token": "`pid`",
                     "value": "pid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -94,7 +122,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": "`products`",
                     "value": "products",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 34
                 },
@@ -121,7 +155,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "`pname`",
                     "value": "pname",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -148,7 +188,9 @@
                     "token": "as",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 53
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -166,7 +210,9 @@
                     "token": "`name`",
                     "value": "name",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 56
                 },
@@ -175,7 +221,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 62
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -193,7 +243,11 @@
                     "token": "rank",
                     "value": "rank",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -202,7 +256,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 68
                 },
@@ -211,7 +267,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 69
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -229,7 +289,9 @@
                     "token": "over",
                     "value": "OVER",
                     "keyword": "OVER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 71
                 },
@@ -238,7 +300,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 75
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -256,7 +322,9 @@
                     "token": "partition by",
                     "value": "PARTITION BY",
                     "keyword": "PARTITION BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 77
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -274,7 +344,9 @@
                     "token": "`products`",
                     "value": "products",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 90
                 },
@@ -283,7 +355,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 100
                 },
@@ -292,7 +366,9 @@
                     "token": "`pvalue`",
                     "value": "pvalue",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -310,7 +388,9 @@
                     "token": "order by",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 110
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -328,7 +410,9 @@
                     "token": "`products`",
                     "value": "products",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 119
                 },
@@ -337,7 +421,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 129
                 },
@@ -346,7 +432,9 @@
                     "token": "`pid`",
                     "value": "pid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 130
                 },
@@ -355,7 +443,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -364,7 +454,9 @@
                     "token": "desc",
                     "value": "DESC",
                     "keyword": "DESC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 136
                 },
@@ -373,7 +465,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 140
                 },
@@ -382,7 +476,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -391,7 +487,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 142
                 },
@@ -400,7 +498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 144
                 },
@@ -409,7 +509,9 @@
                     "token": "`myrank`",
                     "value": "myrank",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 145
                 },
@@ -418,7 +520,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 153
                 },
@@ -427,7 +531,9 @@
                     "token": "from",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 154
                 },
@@ -436,7 +542,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -445,7 +553,9 @@
                     "token": "`products`",
                     "value": "products",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 159
                 },
@@ -454,7 +564,9 @@
                     "token": " \n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 169
                 },
@@ -463,13 +575,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 51,
-            "idx": 51
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectUnion.out
+++ b/tests/data/parser/parseSelectUnion.out
@@ -7,13 +7,19 @@
         "last": 62,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 35,
+            "idx": 35,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 1
                 },
@@ -31,7 +41,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": "t",
                     "value": "t",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -94,7 +122,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -112,7 +144,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -121,7 +155,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 2,
                     "position": 24
                 },
@@ -130,7 +166,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -139,7 +179,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 26
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -157,7 +201,9 @@
                     "token": "UNION",
                     "value": "UNION",
                     "keyword": "UNION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 28
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -175,7 +223,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 34
                 },
@@ -184,7 +234,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 35
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -202,7 +256,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -220,7 +278,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -238,7 +300,9 @@
                     "token": "t",
                     "value": "t",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -256,7 +322,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 51
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -274,7 +344,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -283,7 +355,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 2,
                     "position": 58
                 },
@@ -292,7 +366,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -301,7 +377,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 60
                 },
@@ -310,7 +388,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -319,13 +399,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 35,
-            "idx": 35
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectUnion2.out
+++ b/tests/data/parser/parseSelectUnion2.out
@@ -7,13 +7,19 @@
         "last": 344,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 109,
+            "idx": 109,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 1
                 },
@@ -31,7 +41,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -58,7 +76,11 @@
                     "token": "`User`",
                     "value": "User",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 17
                 },
@@ -67,7 +89,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 23
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": "`Host`",
                     "value": "Host",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +133,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -121,7 +155,9 @@
                     "token": "`mysql`",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 37
                 },
@@ -130,7 +166,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 44
                 },
@@ -139,7 +177,9 @@
                     "token": "`user`",
                     "value": "user",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 45
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +199,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 52
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -175,7 +221,9 @@
                     "token": "UNION",
                     "value": "UNION",
                     "keyword": "UNION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 54
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -193,7 +243,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 60
                 },
@@ -202,7 +254,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 61
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -220,7 +276,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 68
                 },
@@ -229,7 +287,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -238,7 +298,9 @@
                     "token": "`User`",
                     "value": "User",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 77
                 },
@@ -247,7 +309,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 83
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -265,7 +331,9 @@
                     "token": "`Host`",
                     "value": "Host",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 85
                 },
@@ -274,7 +342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -283,7 +353,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 92
                 },
@@ -292,7 +364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -301,7 +375,9 @@
                     "token": "`mysql`",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 97
                 },
@@ -310,7 +386,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 104
                 },
@@ -319,7 +397,9 @@
                     "token": "`db`",
                     "value": "db",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 105
                 },
@@ -328,7 +408,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -337,7 +419,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 110
                 },
@@ -346,7 +430,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -355,7 +441,9 @@
                     "token": "UNION",
                     "value": "UNION",
                     "keyword": "UNION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 112
                 },
@@ -364,7 +452,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -373,7 +463,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 118
                 },
@@ -382,7 +474,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 119
                 },
@@ -391,7 +485,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -400,7 +496,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 126
                 },
@@ -409,7 +507,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 134
                 },
@@ -418,7 +518,9 @@
                     "token": "`User`",
                     "value": "User",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 135
                 },
@@ -427,7 +529,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 141
                 },
@@ -436,7 +540,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 142
                 },
@@ -445,7 +551,9 @@
                     "token": "`Host`",
                     "value": "Host",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 143
                 },
@@ -454,7 +562,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -463,7 +573,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 150
                 },
@@ -472,7 +584,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 154
                 },
@@ -481,7 +595,9 @@
                     "token": "`mysql`",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 155
                 },
@@ -490,7 +606,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 162
                 },
@@ -499,7 +617,9 @@
                     "token": "`tables_priv`",
                     "value": "tables_priv",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 163
                 },
@@ -508,7 +628,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -517,7 +639,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 177
                 },
@@ -526,7 +650,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 178
                 },
@@ -535,7 +661,9 @@
                     "token": "UNION",
                     "value": "UNION",
                     "keyword": "UNION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 179
                 },
@@ -544,7 +672,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 184
                 },
@@ -553,7 +683,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 185
                 },
@@ -562,7 +694,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 186
                 },
@@ -571,7 +705,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 192
                 },
@@ -580,7 +716,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 193
                 },
@@ -589,7 +727,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 201
                 },
@@ -598,7 +738,9 @@
                     "token": "`User`",
                     "value": "User",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 202
                 },
@@ -607,7 +749,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 208
                 },
@@ -616,7 +760,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 209
                 },
@@ -625,7 +771,9 @@
                     "token": "`Host`",
                     "value": "Host",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 210
                 },
@@ -634,7 +782,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 216
                 },
@@ -643,7 +793,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 217
                 },
@@ -652,7 +804,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 221
                 },
@@ -661,7 +815,9 @@
                     "token": "`mysql`",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 222
                 },
@@ -670,7 +826,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 229
                 },
@@ -679,7 +837,9 @@
                     "token": "`columns_priv`",
                     "value": "columns_priv",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 230
                 },
@@ -688,7 +848,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 244
                 },
@@ -697,7 +859,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 245
                 },
@@ -706,7 +870,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 246
                 },
@@ -715,7 +881,9 @@
                     "token": "UNION",
                     "value": "UNION",
                     "keyword": "UNION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 247
                 },
@@ -724,7 +892,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 252
                 },
@@ -733,7 +903,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 253
                 },
@@ -742,7 +914,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 254
                 },
@@ -751,7 +925,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 260
                 },
@@ -760,7 +936,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 261
                 },
@@ -769,7 +947,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 269
                 },
@@ -778,7 +958,9 @@
                     "token": "`User`",
                     "value": "User",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 270
                 },
@@ -787,7 +969,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 276
                 },
@@ -796,7 +980,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 277
                 },
@@ -805,7 +991,9 @@
                     "token": "`Host`",
                     "value": "Host",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 278
                 },
@@ -814,7 +1002,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 284
                 },
@@ -823,7 +1013,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 285
                 },
@@ -832,7 +1024,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 289
                 },
@@ -841,7 +1035,9 @@
                     "token": "`mysql`",
                     "value": "mysql",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 290
                 },
@@ -850,7 +1046,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 297
                 },
@@ -859,7 +1057,9 @@
                     "token": "`procs_priv`",
                     "value": "procs_priv",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 298
                 },
@@ -868,7 +1068,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 310
                 },
@@ -877,7 +1079,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 311
                 },
@@ -886,7 +1090,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 312
                 },
@@ -895,7 +1101,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 7,
                     "position": 313
                 },
@@ -904,7 +1112,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 321
                 },
@@ -913,7 +1123,9 @@
                     "token": "`User`",
                     "value": "User",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 322
                 },
@@ -922,7 +1134,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 328
                 },
@@ -931,7 +1145,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 329
                 },
@@ -940,7 +1156,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 332
                 },
@@ -949,7 +1167,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 333
                 },
@@ -958,7 +1178,9 @@
                     "token": "`Host`",
                     "value": "Host",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 334
                 },
@@ -967,7 +1189,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 340
                 },
@@ -976,7 +1200,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 341
                 },
@@ -985,13 +1211,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 109,
-            "idx": 109
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectWhere.out
+++ b/tests/data/parser/parseSelectWhere.out
@@ -7,13 +7,19 @@
         "last": 808,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 336,
+            "idx": 336,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 9
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,11 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -85,7 +111,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -103,7 +133,9 @@
                     "token": "film_id",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -121,7 +155,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 33
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -139,7 +177,11 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -157,7 +201,9 @@
                     "token": "OR",
                     "value": "OR",
                     "keyword": "OR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 38
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -175,7 +223,9 @@
                     "token": "film_id",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -193,7 +245,9 @@
                     "token": ">=",
                     "value": ">=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 49
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -211,7 +267,9 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -220,7 +278,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -229,7 +291,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -238,7 +302,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 56
                 },
@@ -247,7 +313,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -256,7 +324,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 63
                 },
@@ -265,7 +335,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -274,7 +346,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 65
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -292,7 +368,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -301,7 +379,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -310,7 +390,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 75
                 },
@@ -319,7 +401,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -328,7 +412,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 81
                 },
@@ -337,7 +423,9 @@
                     "token": "film_id",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -346,7 +434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -355,7 +445,9 @@
                     "token": "<",
                     "value": "<",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 90
                 },
@@ -364,7 +456,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -373,7 +467,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -382,7 +478,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 94
                 },
@@ -391,7 +489,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -400,7 +500,9 @@
                     "token": "||",
                     "value": "||",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 96
                 },
@@ -409,7 +511,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -418,7 +522,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 99
                 },
@@ -427,7 +533,9 @@
                     "token": "film_id",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -436,7 +544,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 107
                 },
@@ -445,7 +555,9 @@
                     "token": ">",
                     "value": ">",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 108
                 },
@@ -454,7 +566,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -463,7 +577,9 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -472,7 +588,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 112
                 },
@@ -481,7 +599,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -490,7 +610,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -499,7 +621,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 115
                 },
@@ -508,7 +632,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 121
                 },
@@ -517,7 +643,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 122
                 },
@@ -526,7 +654,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -535,7 +665,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 124
                 },
@@ -544,7 +676,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 128
                 },
@@ -553,7 +687,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 129
                 },
@@ -562,7 +698,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -571,7 +709,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 134
                 },
@@ -580,7 +720,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -589,7 +731,11 @@
                     "token": "`film_id`",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 140
                 },
@@ -598,7 +744,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -607,7 +755,9 @@
                     "token": "!=",
                     "value": "!=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 150
                 },
@@ -616,7 +766,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -625,7 +777,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 153
                 },
@@ -634,7 +788,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 155
                 },
@@ -643,7 +799,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 156
                 },
@@ -652,7 +810,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 159
                 },
@@ -661,7 +821,9 @@
                     "token": "`film_id`",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@73"
+                    },
                     "flags": 2,
                     "position": 160
                 },
@@ -670,7 +832,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 169
                 },
@@ -679,7 +843,9 @@
                     "token": "<=",
                     "value": "<=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 170
                 },
@@ -688,7 +854,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 172
                 },
@@ -697,7 +865,9 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 173
                 },
@@ -706,7 +876,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 175
                 },
@@ -715,7 +887,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 176
                 },
@@ -724,7 +898,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 177
                 },
@@ -733,7 +909,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 183
                 },
@@ -742,7 +920,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 184
                 },
@@ -751,7 +931,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 185
                 },
@@ -760,7 +942,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 186
                 },
@@ -769,7 +953,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 190
                 },
@@ -778,7 +964,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 191
                 },
@@ -787,7 +975,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 195
                 },
@@ -796,7 +986,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 196
                 },
@@ -805,7 +997,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 201
                 },
@@ -814,7 +1008,9 @@
                     "token": "`film`",
                     "value": "film",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@73"
+                    },
                     "flags": 2,
                     "position": 202
                 },
@@ -823,7 +1019,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 208
                 },
@@ -832,7 +1030,9 @@
                     "token": "`film_id`",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@73"
+                    },
                     "flags": 2,
                     "position": 209
                 },
@@ -841,7 +1041,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 218
                 },
@@ -850,7 +1052,9 @@
                     "token": "<>",
                     "value": "<>",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 219
                 },
@@ -859,7 +1063,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 221
                 },
@@ -868,7 +1074,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 222
                 },
@@ -877,7 +1085,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 224
                 },
@@ -886,7 +1096,9 @@
                     "token": "&&",
                     "value": "&&",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 225
                 },
@@ -895,7 +1107,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 227
                 },
@@ -904,7 +1118,9 @@
                     "token": "`film`",
                     "value": "film",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@73"
+                    },
                     "flags": 2,
                     "position": 228
                 },
@@ -913,7 +1129,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 234
                 },
@@ -922,7 +1140,9 @@
                     "token": "`film_id`",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@73"
+                    },
                     "flags": 2,
                     "position": 235
                 },
@@ -931,7 +1151,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 244
                 },
@@ -940,7 +1162,9 @@
                     "token": "<=",
                     "value": "<=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 245
                 },
@@ -949,7 +1173,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 247
                 },
@@ -958,7 +1184,9 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 248
                 },
@@ -967,7 +1195,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 250
                 },
@@ -976,7 +1206,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 251
                 },
@@ -985,7 +1217,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 252
                 },
@@ -994,7 +1228,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 258
                 },
@@ -1003,7 +1239,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 259
                 },
@@ -1012,7 +1250,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 260
                 },
@@ -1021,7 +1261,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 261
                 },
@@ -1030,7 +1272,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 265
                 },
@@ -1039,7 +1283,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 266
                 },
@@ -1048,7 +1294,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 270
                 },
@@ -1057,7 +1305,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 271
                 },
@@ -1066,7 +1316,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 276
                 },
@@ -1075,7 +1327,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 277
                 },
@@ -1084,7 +1338,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 281
                 },
@@ -1093,7 +1349,9 @@
                     "token": "film_id",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 282
                 },
@@ -1102,7 +1360,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 289
                 },
@@ -1111,7 +1371,9 @@
                     "token": "<",
                     "value": "<",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 290
                 },
@@ -1120,7 +1382,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 291
                 },
@@ -1129,7 +1393,9 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 292
                 },
@@ -1138,7 +1404,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 294
                 },
@@ -1147,7 +1415,9 @@
                     "token": "XOR",
                     "value": "XOR",
                     "keyword": "XOR",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 295
                 },
@@ -1156,7 +1426,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 298
                 },
@@ -1165,7 +1437,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 299
                 },
@@ -1174,7 +1448,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 303
                 },
@@ -1183,7 +1459,9 @@
                     "token": "rating",
                     "value": "rating",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 304
                 },
@@ -1192,7 +1470,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 310
                 },
@@ -1201,7 +1481,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 311
                 },
@@ -1210,7 +1492,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 312
                 },
@@ -1219,7 +1503,11 @@
                     "token": "'PG-13'",
                     "value": "PG-13",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 313
                 },
@@ -1228,7 +1516,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 320
                 },
@@ -1237,7 +1527,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 321
                 },
@@ -1246,7 +1538,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 322
                 },
@@ -1255,7 +1549,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 328
                 },
@@ -1264,7 +1560,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 329
                 },
@@ -1273,7 +1571,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 330
                 },
@@ -1282,7 +1582,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 331
                 },
@@ -1291,7 +1593,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 335
                 },
@@ -1300,7 +1604,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 336
                 },
@@ -1309,7 +1615,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 340
                 },
@@ -1318,7 +1626,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 341
                 },
@@ -1327,7 +1637,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 346
                 },
@@ -1336,7 +1648,11 @@
                     "token": "/* film_id = */",
                     "value": "/* film_id = */",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 2,
                     "position": 347
                 },
@@ -1345,7 +1661,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 362
                 },
@@ -1354,7 +1672,9 @@
                     "token": "film_id",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 363
                 },
@@ -1363,7 +1683,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 370
                 },
@@ -1372,7 +1694,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 371
                 },
@@ -1381,7 +1705,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 372
                 },
@@ -1390,7 +1716,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 373
                 },
@@ -1399,7 +1727,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 375
                 },
@@ -1408,7 +1738,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 376
                 },
@@ -1417,7 +1749,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 377
                 },
@@ -1426,7 +1760,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 383
                 },
@@ -1435,7 +1771,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 384
                 },
@@ -1444,7 +1782,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 385
                 },
@@ -1453,7 +1793,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 386
                 },
@@ -1462,7 +1804,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 390
                 },
@@ -1471,7 +1815,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 391
                 },
@@ -1480,7 +1826,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 395
                 },
@@ -1489,7 +1837,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 396
                 },
@@ -1498,7 +1848,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 401
                 },
@@ -1507,7 +1859,9 @@
                     "token": "NOT",
                     "value": "NOT",
                     "keyword": "NOT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 402
                 },
@@ -1516,7 +1870,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 405
                 },
@@ -1525,7 +1881,9 @@
                     "token": "film_id",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 406
                 },
@@ -1534,7 +1892,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 413
                 },
@@ -1543,7 +1903,9 @@
                     "token": ">",
                     "value": ">",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 414
                 },
@@ -1552,7 +1914,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 415
                 },
@@ -1561,7 +1925,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 416
                 },
@@ -1570,7 +1936,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 418
                 },
@@ -1579,7 +1947,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 419
                 },
@@ -1588,7 +1958,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 420
                 },
@@ -1597,7 +1969,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 426
                 },
@@ -1606,7 +1980,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 427
                 },
@@ -1615,7 +1991,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 428
                 },
@@ -1624,7 +2002,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 429
                 },
@@ -1633,7 +2013,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 433
                 },
@@ -1642,7 +2024,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 434
                 },
@@ -1651,7 +2035,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 438
                 },
@@ -1660,7 +2046,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 439
                 },
@@ -1669,7 +2057,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 444
                 },
@@ -1678,7 +2068,9 @@
                     "token": "!",
                     "value": "!",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 445
                 },
@@ -1687,7 +2079,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 446
                 },
@@ -1696,7 +2090,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 447
                 },
@@ -1705,7 +2101,9 @@
                     "token": "film_id",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 448
                 },
@@ -1714,7 +2112,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 455
                 },
@@ -1723,7 +2123,9 @@
                     "token": ">",
                     "value": ">",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 456
                 },
@@ -1732,7 +2134,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 457
                 },
@@ -1741,7 +2145,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 458
                 },
@@ -1750,7 +2156,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 460
                 },
@@ -1759,7 +2167,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 461
                 },
@@ -1768,7 +2178,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 462
                 },
@@ -1777,7 +2189,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 463
                 },
@@ -1786,7 +2200,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 469
                 },
@@ -1795,7 +2211,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 470
                 },
@@ -1804,7 +2222,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 471
                 },
@@ -1813,7 +2233,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 472
                 },
@@ -1822,7 +2244,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 476
                 },
@@ -1831,7 +2255,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 477
                 },
@@ -1840,7 +2266,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 481
                 },
@@ -1849,7 +2277,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 482
                 },
@@ -1858,7 +2288,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 487
                 },
@@ -1867,7 +2299,9 @@
                     "token": "description",
                     "value": "description",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 488
                 },
@@ -1876,7 +2310,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 499
                 },
@@ -1885,7 +2321,9 @@
                     "token": "IS",
                     "value": "IS",
                     "keyword": "IS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 500
                 },
@@ -1894,7 +2332,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 502
                 },
@@ -1903,7 +2343,9 @@
                     "token": "NULL",
                     "value": "NULL",
                     "keyword": "NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 503
                 },
@@ -1912,7 +2354,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 507
                 },
@@ -1921,7 +2365,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 508
                 },
@@ -1930,7 +2376,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 509
                 },
@@ -1939,7 +2387,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 515
                 },
@@ -1948,7 +2398,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 516
                 },
@@ -1957,7 +2409,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 517
                 },
@@ -1966,7 +2420,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 518
                 },
@@ -1975,7 +2431,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 522
                 },
@@ -1984,7 +2442,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 523
                 },
@@ -1993,7 +2453,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 527
                 },
@@ -2002,7 +2464,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 528
                 },
@@ -2011,7 +2475,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 533
                 },
@@ -2020,7 +2486,9 @@
                     "token": "description",
                     "value": "description",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 534
                 },
@@ -2029,7 +2497,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 545
                 },
@@ -2038,7 +2508,9 @@
                     "token": "IS",
                     "value": "IS",
                     "keyword": "IS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 546
                 },
@@ -2047,7 +2519,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 548
                 },
@@ -2056,7 +2530,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 549
                 },
@@ -2065,7 +2541,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 557
                 },
@@ -2074,7 +2552,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 558
                 },
@@ -2083,7 +2563,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 559
                 },
@@ -2092,7 +2574,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 565
                 },
@@ -2101,7 +2585,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 566
                 },
@@ -2110,7 +2596,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 567
                 },
@@ -2119,7 +2607,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 568
                 },
@@ -2128,7 +2618,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 572
                 },
@@ -2137,7 +2629,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 573
                 },
@@ -2146,7 +2640,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 577
                 },
@@ -2155,7 +2651,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 578
                 },
@@ -2164,7 +2662,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 583
                 },
@@ -2173,7 +2673,9 @@
                     "token": "film_id",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 584
                 },
@@ -2182,7 +2684,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 591
                 },
@@ -2191,7 +2695,9 @@
                     "token": "BETWEEN",
                     "value": "BETWEEN",
                     "keyword": "BETWEEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 592
                 },
@@ -2200,7 +2706,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 599
                 },
@@ -2209,7 +2717,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 600
                 },
@@ -2218,7 +2728,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 602
                 },
@@ -2227,7 +2739,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 603
                 },
@@ -2236,7 +2750,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 606
                 },
@@ -2245,7 +2761,9 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 607
                 },
@@ -2254,7 +2772,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 609
                 },
@@ -2263,7 +2783,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 610
                 },
@@ -2272,7 +2794,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 611
                 },
@@ -2281,7 +2805,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 617
                 },
@@ -2290,7 +2816,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 618
                 },
@@ -2299,7 +2827,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 619
                 },
@@ -2308,7 +2838,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 620
                 },
@@ -2317,7 +2849,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 624
                 },
@@ -2326,7 +2860,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 625
                 },
@@ -2335,7 +2871,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 629
                 },
@@ -2344,7 +2882,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 630
                 },
@@ -2353,7 +2893,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 635
                 },
@@ -2362,7 +2904,9 @@
                     "token": "film_id",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 636
                 },
@@ -2371,7 +2915,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 643
                 },
@@ -2380,7 +2926,9 @@
                     "token": "NOT",
                     "value": "NOT",
                     "keyword": "NOT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 644
                 },
@@ -2389,7 +2937,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 647
                 },
@@ -2398,7 +2948,9 @@
                     "token": "BETWEEN",
                     "value": "BETWEEN",
                     "keyword": "BETWEEN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 648
                 },
@@ -2407,7 +2959,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 655
                 },
@@ -2416,7 +2970,9 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 656
                 },
@@ -2425,7 +2981,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 658
                 },
@@ -2434,7 +2992,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 659
                 },
@@ -2443,7 +3003,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 662
                 },
@@ -2452,7 +3014,9 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 663
                 },
@@ -2461,7 +3025,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 665
                 },
@@ -2470,7 +3036,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 666
                 },
@@ -2479,7 +3047,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 667
                 },
@@ -2488,7 +3058,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 673
                 },
@@ -2497,7 +3069,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 674
                 },
@@ -2506,7 +3080,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 675
                 },
@@ -2515,7 +3091,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 676
                 },
@@ -2524,7 +3102,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 680
                 },
@@ -2533,7 +3113,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 681
                 },
@@ -2542,7 +3124,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 685
                 },
@@ -2551,7 +3135,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 686
                 },
@@ -2560,7 +3146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 691
                 },
@@ -2569,7 +3157,9 @@
                     "token": "film_id",
                     "value": "film_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 692
                 },
@@ -2578,7 +3168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 699
                 },
@@ -2587,7 +3179,9 @@
                     "token": "IN",
                     "value": "IN",
                     "keyword": "IN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 700
                 },
@@ -2596,7 +3190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 702
                 },
@@ -2605,7 +3201,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 703
                 },
@@ -2614,7 +3212,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 704
                 },
@@ -2623,7 +3223,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 705
                 },
@@ -2632,7 +3234,9 @@
                     "token": "5",
                     "value": 5,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 706
                 },
@@ -2641,7 +3245,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 707
                 },
@@ -2650,7 +3256,9 @@
                     "token": "7",
                     "value": 7,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 708
                 },
@@ -2659,7 +3267,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 709
                 },
@@ -2668,7 +3278,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 710
                 },
@@ -2677,7 +3289,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 711
                 },
@@ -2686,7 +3300,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 712
                 },
@@ -2695,7 +3311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 718
                 },
@@ -2704,7 +3322,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 719
                 },
@@ -2713,7 +3333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 720
                 },
@@ -2722,7 +3344,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 721
                 },
@@ -2731,7 +3355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 725
                 },
@@ -2740,7 +3366,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 726
                 },
@@ -2749,7 +3377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 730
                 },
@@ -2758,7 +3388,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 731
                 },
@@ -2767,7 +3399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 736
                 },
@@ -2776,7 +3410,9 @@
                     "token": "rating",
                     "value": "rating",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 737
                 },
@@ -2785,7 +3421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 743
                 },
@@ -2794,7 +3432,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 744
                 },
@@ -2803,7 +3443,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 745
                 },
@@ -2812,7 +3454,9 @@
                     "token": "UPPER",
                     "value": "UPPER",
                     "keyword": "UPPER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 746
                 },
@@ -2821,7 +3465,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 751
                 },
@@ -2830,7 +3476,9 @@
                     "token": "'pg'",
                     "value": "pg",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@144"
+                    },
                     "flags": 1,
                     "position": 752
                 },
@@ -2839,7 +3487,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 756
                 },
@@ -2848,7 +3498,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 757
                 },
@@ -2857,7 +3509,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 758
                 },
@@ -2866,7 +3520,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 759
                 },
@@ -2875,7 +3531,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 765
                 },
@@ -2884,7 +3542,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 16,
                     "position": 766
                 },
@@ -2893,7 +3553,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 767
                 },
@@ -2902,7 +3564,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 768
                 },
@@ -2911,7 +3575,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 772
                 },
@@ -2920,7 +3586,9 @@
                     "token": "film",
                     "value": "film",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 773
                 },
@@ -2929,7 +3597,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 777
                 },
@@ -2938,7 +3608,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 778
                 },
@@ -2947,7 +3619,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 783
                 },
@@ -2956,7 +3630,9 @@
                     "token": "rating",
                     "value": "rating",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 784
                 },
@@ -2965,7 +3641,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 790
                 },
@@ -2974,7 +3652,9 @@
                     "token": "SOUNDS",
                     "value": "SOUNDS",
                     "keyword": "SOUNDS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 791
                 },
@@ -2983,7 +3663,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 797
                 },
@@ -2992,7 +3674,9 @@
                     "token": "LIKE",
                     "value": "LIKE",
                     "keyword": "LIKE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 798
                 },
@@ -3001,7 +3685,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 802
                 },
@@ -3010,7 +3696,9 @@
                     "token": "'PG'",
                     "value": "PG",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@144"
+                    },
                     "flags": 1,
                     "position": 803
                 },
@@ -3019,7 +3707,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 807
                 },
@@ -3028,13 +3718,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 336,
-            "idx": 336
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectWhereCollate.out
+++ b/tests/data/parser/parseSelectWhereCollate.out
@@ -7,13 +7,19 @@
         "last": 96,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 29,
+            "idx": 29,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -49,7 +65,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 10
                 },
@@ -58,7 +76,9 @@
                     "token": "   ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -67,7 +87,11 @@
                     "token": "my_table",
                     "value": "my_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -85,7 +111,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 26
                 },
@@ -94,7 +122,9 @@
                     "token": "   ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +133,9 @@
                     "token": "first_col",
                     "value": "first_col",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -121,7 +155,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 44
                 },
@@ -130,7 +168,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -139,7 +179,11 @@
                     "token": "'foo'",
                     "value": "foo",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 46
                 },
@@ -148,7 +192,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -157,7 +203,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 52
                 },
@@ -166,7 +214,9 @@
                     "token": "     ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -175,7 +225,9 @@
                     "token": "second_col",
                     "value": "second_col",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -184,7 +236,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -193,7 +247,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 71
                 },
@@ -202,7 +258,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -211,7 +269,9 @@
                     "token": "utf8_bin",
                     "value": "utf8_bin",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@12"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -220,7 +280,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -229,7 +291,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 2,
                     "position": 88
                 },
@@ -238,7 +302,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -247,7 +313,9 @@
                     "token": "'bar'",
                     "value": "bar",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 90
                 },
@@ -256,7 +324,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -265,13 +337,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@36"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 29,
-            "idx": 29
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectWithParenthesis.out
+++ b/tests/data/parser/parseSelectWithParenthesis.out
@@ -7,13 +7,19 @@
         "last": 43,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 17,
+            "idx": 17,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 1
                 },
@@ -31,7 +41,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": "first_name",
                     "value": "first_name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -58,7 +78,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -76,7 +100,11 @@
                     "token": "`actor`",
                     "value": "actor",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 24
                 },
@@ -85,7 +113,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -94,7 +124,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 3,
                     "position": 32
                 },
@@ -103,7 +135,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -112,7 +146,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -121,7 +159,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 39
                 },
@@ -130,7 +170,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -139,7 +181,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@19"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +192,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -157,13 +203,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 17,
-            "idx": 17
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSelectWrongOrder.out
+++ b/tests/data/parser/parseSelectWrongOrder.out
@@ -7,13 +7,19 @@
         "last": 56,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 23,
+            "idx": 23,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "pid",
                     "value": "pid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 10
                 },
@@ -49,7 +67,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -58,7 +78,9 @@
                     "token": "name2",
                     "value": "name2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -76,7 +100,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": "tablename",
                     "value": "tablename",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -130,7 +166,11 @@
                     "token": "10",
                     "value": 10,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +179,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -148,7 +190,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -157,7 +201,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -166,7 +212,9 @@
                     "token": "pid",
                     "value": "pid",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -175,7 +223,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -184,7 +234,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 52
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -202,7 +256,9 @@
                     "token": "20",
                     "value": 20,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -211,13 +267,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 23,
-            "idx": 23
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -310,7 +368,7 @@
             [
                 "Unexpected ordering of clauses.",
                 {
-                    "@type": "@13"
+                    "@type": "@17"
                 },
                 0
             ]

--- a/tests/data/parser/parseSelectWrongOrder2.out
+++ b/tests/data/parser/parseSelectWrongOrder2.out
@@ -7,13 +7,19 @@
         "last": 86,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 33,
+            "idx": 33,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "DISTINCT",
                     "value": "DISTINCT",
                     "keyword": "DISTINCT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -49,7 +63,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 16
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,7 +87,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -85,7 +109,11 @@
                     "token": "tbl1",
                     "value": "tbl1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -103,7 +133,9 @@
                     "token": "INNER JOIN",
                     "value": "INNER JOIN",
                     "keyword": "INNER JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 28
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -121,7 +155,9 @@
                     "token": "tbl2",
                     "value": "tbl2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -139,7 +177,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -157,7 +199,9 @@
                     "token": "id1",
                     "value": "id1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -175,7 +221,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 51
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -193,7 +243,9 @@
                     "token": "id2",
                     "value": "id2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -211,7 +265,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 57
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -229,7 +287,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -238,7 +300,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 64
                 },
@@ -247,7 +311,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -265,7 +333,9 @@
                     "token": "LEFT OUTER JOIN",
                     "value": "LEFT OUTER JOIN",
                     "keyword": "LEFT OUTER JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 67
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -283,7 +355,9 @@
                     "token": "l3",
                     "value": "l3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -292,7 +366,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -301,13 +379,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@39"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 33,
-            "idx": 33
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -403,7 +481,7 @@
             [
                 "Unexpected ordering of clauses.",
                 {
-                    "@type": "@24"
+                    "@type": "@28"
                 },
                 0
             ]

--- a/tests/data/parser/parseSetCharacterSet.out
+++ b/tests/data/parser/parseSetCharacterSet.out
@@ -7,13 +7,19 @@
         "last": 24,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 6,
+            "idx": 6,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,9 @@
                     "token": "CHARACTER SET",
                     "value": "CHARACTER SET",
                     "keyword": "CHARACTER SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 4
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -49,7 +63,11 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 18
                 },
@@ -58,13 +76,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 6,
-            "idx": 6
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSetCharacterSetError.out
+++ b/tests/data/parser/parseSetCharacterSetError.out
@@ -7,13 +7,19 @@
         "last": 18,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 5,
+            "idx": 5,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,9 @@
                     "token": "CHARACTER SET",
                     "value": "CHARACTER SET",
                     "keyword": "CHARACTER SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 4
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -49,13 +63,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 5,
-            "idx": 5
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -97,7 +113,7 @@
             [
                 "Value/Expression for the option CHARACTER SET was expected.",
                 {
-                    "@type": "@5"
+                    "@type": "@7"
                 },
                 0
             ]

--- a/tests/data/parser/parseSetCharset.out
+++ b/tests/data/parser/parseSetCharset.out
@@ -7,13 +7,19 @@
         "last": 18,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 6,
+            "idx": 6,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,9 @@
                     "token": "CHARSET",
                     "value": "CHARSET",
                     "keyword": "CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 4
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 12
                 },
@@ -58,13 +76,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 6,
-            "idx": 6
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSetCharsetError.out
+++ b/tests/data/parser/parseSetCharsetError.out
@@ -7,13 +7,19 @@
         "last": 12,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 5,
+            "idx": 5,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,11 @@
                     "token": "CHARSET",
                     "value": "CHARSET",
                     "keyword": "CHARSET",
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,13 +65,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 5,
-            "idx": 5
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -97,7 +115,7 @@
             [
                 "Value/Expression for the option CHARSET was expected.",
                 {
-                    "@type": "@5"
+                    "@type": "@8"
                 },
                 0
             ]

--- a/tests/data/parser/parseSetError1.out
+++ b/tests/data/parser/parseSetError1.out
@@ -7,13 +7,19 @@
         "last": 39,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,9 @@
                     "token": "CHARSET",
                     "value": "CHARSET",
                     "keyword": "CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 4
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": "CHARACTER SET",
                     "value": "CHARACTER SET",
                     "keyword": "CHARACTER SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 19
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -85,7 +109,9 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 33
                 },
@@ -94,13 +120,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -148,7 +176,7 @@
             [
                 "This option conflicts with \"CHARSET\".",
                 {
-                    "@type": "@8"
+                    "@type": "@11"
                 },
                 0
             ]

--- a/tests/data/parser/parseSetGlobalVariable.out
+++ b/tests/data/parser/parseSetGlobalVariable.out
@@ -7,13 +7,19 @@
         "last": 30,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,9 @@
                     "token": "GLOBAL",
                     "value": "GLOBAL",
                     "keyword": "GLOBAL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +63,11 @@
                     "token": "max_connections",
                     "value": "max_connections",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -67,7 +87,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 27
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +111,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -94,13 +124,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSetNames.out
+++ b/tests/data/parser/parseSetNames.out
@@ -7,13 +7,19 @@
         "last": 16,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 6,
+            "idx": 6,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,9 @@
                     "token": "NAMES",
                     "value": "NAMES",
                     "keyword": "NAMES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -49,7 +63,11 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 10
                 },
@@ -58,13 +76,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 6,
-            "idx": 6
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSetNames2.out
+++ b/tests/data/parser/parseSetNames2.out
@@ -7,13 +7,19 @@
         "last": 42,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,9 @@
                     "token": "NAMES",
                     "value": "NAMES",
                     "keyword": "NAMES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -49,7 +63,11 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 10
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "'utf8_general_ci'",
                     "value": "utf8_general_ci",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 25
                 },
@@ -94,13 +120,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSetNames3.out
+++ b/tests/data/parser/parseSetNames3.out
@@ -7,13 +7,19 @@
         "last": 25,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 9,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,9 @@
                     "token": "NAMES",
                     "value": "NAMES",
                     "keyword": "NAMES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -49,7 +63,11 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 10
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 17
                 },
@@ -76,7 +98,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,13 +111,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 9,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSetNamesError.out
+++ b/tests/data/parser/parseSetNamesError.out
@@ -7,13 +7,19 @@
         "last": 10,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 5,
+            "idx": 5,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,9 @@
                     "token": "NAMES",
                     "value": "NAMES",
                     "keyword": "NAMES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -49,13 +63,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 5,
-            "idx": 5
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -97,7 +113,7 @@
             [
                 "Value/Expression for the option NAMES was expected.",
                 {
-                    "@type": "@5"
+                    "@type": "@7"
                 },
                 0
             ]

--- a/tests/data/parser/parseSetNamesError2.out
+++ b/tests/data/parser/parseSetNamesError2.out
@@ -7,13 +7,19 @@
         "last": 42,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 10,
+            "idx": 10,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,9 @@
                     "token": "NAMES",
                     "value": "NAMES",
                     "keyword": "NAMES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -49,7 +63,11 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 10
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 17
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "'utf8_general_ci'",
                     "value": "utf8_general_ci",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 1,
                     "position": 25
                 },
@@ -94,13 +120,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 10,
-            "idx": 10
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -147,7 +175,7 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@10"
+                    "@type": "@13"
                 },
                 0
             ]

--- a/tests/data/parser/parseSetNamesError3.out
+++ b/tests/data/parser/parseSetNamesError3.out
@@ -7,13 +7,19 @@
         "last": 24,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 8,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,9 @@
                     "token": "NAMES",
                     "value": "NAMES",
                     "keyword": "NAMES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 4
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 9
                 },
@@ -49,7 +63,11 @@
                     "token": "'utf8'",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 10
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -67,7 +87,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 17
                 },
@@ -76,13 +98,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 8
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -134,7 +158,7 @@
             [
                 "Value/Expression for the option COLLATE was expected.",
                 {
-                    "@type": "@8"
+                    "@type": "@11"
                 },
                 0
             ]

--- a/tests/data/parser/parseSetVariable.out
+++ b/tests/data/parser/parseSetVariable.out
@@ -7,13 +7,19 @@
         "last": 12,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 8,
+            "idx": 8,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,11 @@
                     "token": "@foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 4
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -67,7 +89,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -76,13 +102,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 8,
-            "idx": 8
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseSetVariable2.out
+++ b/tests/data/parser/parseSetVariable2.out
@@ -7,13 +7,19 @@
         "last": 14,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 9,
+            "idx": 9,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 3
                 },
@@ -31,7 +41,11 @@
                     "token": "@foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 4
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,11 @@
                     "token": ":=",
                     "value": ":=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 8,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -67,7 +89,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -76,7 +102,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -85,13 +113,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 9,
-            "idx": 9
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseTable1.out
+++ b/tests/data/parser/parseTable1.out
@@ -7,13 +7,19 @@
         "last": 36,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 13,
+            "idx": 13,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,11 @@
                     "token": "`fo`",
                     "value": "fo",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 6
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +65,9 @@
                     "token": "ORDER BY",
                     "value": "ORDER BY",
                     "keyword": "ORDER BY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -67,7 +87,9 @@
                     "token": "`fo`",
                     "value": "fo",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 20
                 },
@@ -76,7 +98,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 24
                 },
@@ -85,7 +111,9 @@
                     "token": "`uuid`",
                     "value": "uuid",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 2,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +133,9 @@
                     "token": "ASC",
                     "value": "ASC",
                     "keyword": "ASC",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 32
                 },
@@ -112,7 +144,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -121,13 +157,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 13,
-            "idx": 13
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseTransaction.out
+++ b/tests/data/parser/parseTransaction.out
@@ -7,13 +7,19 @@
         "last": 118,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 43,
+            "idx": 43,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "START TRANSACTION",
                     "value": "START TRANSACTION",
                     "keyword": "START TRANSACTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -31,7 +41,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -58,7 +76,11 @@
                     "token": "@A",
                     "value": "A",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 26
                 },
@@ -67,7 +89,11 @@
                     "token": ":=",
                     "value": ":=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 8,
                     "position": 28
                 },
@@ -76,7 +102,9 @@
                     "token": "SUM",
                     "value": "SUM",
                     "keyword": "SUM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 30
                 },
@@ -85,7 +113,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -94,7 +124,11 @@
                     "token": "salary",
                     "value": "salary",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -103,7 +137,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -112,7 +148,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -121,7 +159,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -130,7 +170,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -139,7 +181,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -148,7 +192,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -157,7 +203,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 54
                 },
@@ -166,7 +214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -175,7 +225,9 @@
                     "token": "type",
                     "value": "type",
                     "keyword": "TYPE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 60
                 },
@@ -184,7 +236,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 64
                 },
@@ -193,7 +247,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -202,7 +260,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -211,7 +271,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -220,7 +282,9 @@
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 68
                 },
@@ -229,7 +293,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -238,7 +304,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -247,7 +315,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +326,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 82
                 },
@@ -265,7 +337,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -274,7 +348,9 @@
                     "token": "summary",
                     "value": "summary",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -283,7 +359,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 93
                 },
@@ -292,7 +370,9 @@
                     "token": "@A",
                     "value": "A",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 94
                 },
@@ -301,7 +381,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -310,7 +392,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 97
                 },
@@ -319,7 +403,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -328,7 +414,9 @@
                     "token": "type",
                     "value": "type",
                     "keyword": "TYPE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 103
                 },
@@ -337,7 +425,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 107
                 },
@@ -346,7 +436,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -355,7 +447,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -364,7 +458,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -373,7 +469,9 @@
                     "token": "COMMIT",
                     "value": "COMMIT",
                     "keyword": "COMMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 111
                 },
@@ -382,7 +480,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -391,13 +491,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 43,
-            "idx": 43
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseTransaction2.out
+++ b/tests/data/parser/parseTransaction2.out
@@ -7,13 +7,19 @@
         "last": 120,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 43,
+            "idx": 43,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "START TRANSACTION",
                     "value": "START TRANSACTION",
                     "keyword": "START TRANSACTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -31,7 +41,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 19
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -58,7 +76,11 @@
                     "token": "@A",
                     "value": "A",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 26
                 },
@@ -67,7 +89,11 @@
                     "token": ":=",
                     "value": ":=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 8,
                     "position": 28
                 },
@@ -76,7 +102,9 @@
                     "token": "SUM",
                     "value": "SUM",
                     "keyword": "SUM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 30
                 },
@@ -85,7 +113,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -94,7 +124,11 @@
                     "token": "salary",
                     "value": "salary",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -103,7 +137,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -112,7 +148,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -121,7 +159,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -130,7 +170,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -139,7 +181,9 @@
                     "token": "table1",
                     "value": "table1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -148,7 +192,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -157,7 +203,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 54
                 },
@@ -166,7 +214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -175,7 +225,9 @@
                     "token": "type",
                     "value": "type",
                     "keyword": "TYPE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 60
                 },
@@ -184,7 +236,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 64
                 },
@@ -193,7 +247,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -202,7 +260,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -211,7 +271,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -220,7 +282,9 @@
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 68
                 },
@@ -229,7 +293,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -238,7 +304,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -247,7 +315,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -256,7 +326,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 82
                 },
@@ -265,7 +337,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -274,7 +348,9 @@
                     "token": "summary",
                     "value": "summary",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -283,7 +359,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 93
                 },
@@ -292,7 +370,9 @@
                     "token": "@A",
                     "value": "A",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 1,
                     "position": 94
                 },
@@ -301,7 +381,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -310,7 +392,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 97
                 },
@@ -319,7 +403,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -328,7 +414,9 @@
                     "token": "type",
                     "value": "type",
                     "keyword": "TYPE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 103
                 },
@@ -337,7 +425,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 2,
                     "position": 107
                 },
@@ -346,7 +436,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -355,7 +447,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -364,7 +458,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -373,7 +469,9 @@
                     "token": "ROLLBACK",
                     "value": "ROLLBACK",
                     "keyword": "ROLLBACK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 111
                 },
@@ -382,7 +480,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -391,13 +491,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 43,
-            "idx": 43
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseTransaction3.out
+++ b/tests/data/parser/parseTransaction3.out
@@ -7,13 +7,19 @@
         "last": 41,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 15,
+            "idx": 15,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "begin",
                     "value": "begin",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 1,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -40,7 +54,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -58,7 +76,11 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 14
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -76,7 +100,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 16
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -94,7 +122,11 @@
                     "token": "`tablename`",
                     "value": "tablename",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 2,
                     "position": 21
                 },
@@ -103,7 +135,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +146,9 @@
                     "token": "commit",
                     "value": "commit",
                     "keyword": "COMMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 33
                 },
@@ -121,7 +157,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -130,7 +168,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -139,13 +179,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 15,
-            "idx": 15
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -215,7 +255,7 @@
             [
                 "A new statement was found, but no delimiter between it and the previous one.",
                 {
-                    "@type": "@13"
+                    "@type": "@18"
                 },
                 0
             ]

--- a/tests/data/parser/parseTransaction4.out
+++ b/tests/data/parser/parseTransaction4.out
@@ -7,13 +7,19 @@
         "last": 46,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 14,
+            "idx": 14,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "START TRANSACTION",
                     "value": "START TRANSACTION",
                     "keyword": "START TRANSACTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 7,
                     "position": 1
                 },
@@ -31,7 +41,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -40,7 +54,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -49,7 +65,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 11,
                     "position": 20
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +87,11 @@
                     "token": "time_zone",
                     "value": "time_zone",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -85,7 +111,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 34
                 },
@@ -94,7 +124,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -103,7 +135,11 @@
                     "token": "\"+00:00\"",
                     "value": "+00:00",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 36
                 },
@@ -112,7 +148,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -121,7 +159,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -130,13 +170,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 14,
-            "idx": 14
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseTransaction5.out
+++ b/tests/data/parser/parseTransaction5.out
@@ -7,13 +7,19 @@
         "last": 140,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 44,
+            "idx": 44,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 1,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,11 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -40,7 +54,9 @@
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 11
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -76,7 +98,11 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +144,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -121,7 +157,11 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -130,7 +170,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -139,7 +181,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -148,7 +192,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -157,7 +203,9 @@
                     "token": "SAVEPOINT",
                     "value": "SAVEPOINT",
                     "keyword": "SAVEPOINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 42
                 },
@@ -166,7 +214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -175,7 +225,9 @@
                     "token": "my_savepoint",
                     "value": "my_savepoint",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -184,7 +236,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -193,7 +247,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -202,7 +258,9 @@
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 70
                 },
@@ -211,7 +269,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -220,7 +280,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 77
                 },
@@ -229,7 +291,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -238,7 +302,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -247,7 +313,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -256,7 +324,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 85
                 },
@@ -265,7 +335,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -274,7 +346,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 92
                 },
@@ -283,7 +357,9 @@
                     "token": "4",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -292,7 +368,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 94
                 },
@@ -301,7 +379,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -310,7 +390,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -319,7 +401,9 @@
                     "token": "RELEASE",
                     "value": "RELEASE",
                     "keyword": "RELEASE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 101
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -337,7 +423,9 @@
                     "token": "SAVEPOINT",
                     "value": "SAVEPOINT",
                     "keyword": "SAVEPOINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 109
                 },
@@ -346,7 +434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -355,7 +445,9 @@
                     "token": "my_savepoint",
                     "value": "my_savepoint",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -364,7 +456,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -373,7 +467,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 132
                 },
@@ -382,7 +478,9 @@
                     "token": "COMMIT",
                     "value": "COMMIT",
                     "keyword": "COMMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 133
                 },
@@ -391,7 +489,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 139
                 },
@@ -400,13 +500,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 44,
-            "idx": 44
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -544,14 +644,14 @@
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@18"
+                    "@type": "@24"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@36"
+                    "@type": "@42"
                 },
                 0
             ]

--- a/tests/data/parser/parseTransaction6.out
+++ b/tests/data/parser/parseTransaction6.out
@@ -7,13 +7,19 @@
         "last": 149,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 48,
+            "idx": 48,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 1,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,11 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -40,7 +54,9 @@
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 11
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -76,7 +98,11 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +144,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -121,7 +157,11 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -130,7 +170,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -139,7 +181,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -148,7 +192,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -157,7 +203,9 @@
                     "token": "SAVEPOINT",
                     "value": "SAVEPOINT",
                     "keyword": "SAVEPOINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 42
                 },
@@ -166,7 +214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -175,7 +225,9 @@
                     "token": "my_savepoint",
                     "value": "my_savepoint",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -184,7 +236,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -193,7 +247,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -202,7 +258,9 @@
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 70
                 },
@@ -211,7 +269,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -220,7 +280,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 77
                 },
@@ -229,7 +291,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -238,7 +302,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -247,7 +313,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -256,7 +324,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 85
                 },
@@ -265,7 +335,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -274,7 +346,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 92
                 },
@@ -283,7 +357,9 @@
                     "token": "4",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -292,7 +368,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 94
                 },
@@ -301,7 +379,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -310,7 +390,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -319,7 +401,9 @@
                     "token": "ROLLBACK",
                     "value": "ROLLBACK",
                     "keyword": "ROLLBACK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 101
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -337,7 +423,9 @@
                     "token": "WORK",
                     "value": "WORK",
                     "keyword": "WORK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 110
                 },
@@ -346,7 +434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -355,7 +445,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 115
                 },
@@ -364,7 +456,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 117
                 },
@@ -373,7 +467,9 @@
                     "token": "SAVEPOINT",
                     "value": "SAVEPOINT",
                     "keyword": "SAVEPOINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 118
                 },
@@ -382,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -391,7 +489,9 @@
                     "token": "my_savepoint",
                     "value": "my_savepoint",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 128
                 },
@@ -400,7 +500,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -409,7 +511,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -418,7 +522,9 @@
                     "token": "COMMIT",
                     "value": "COMMIT",
                     "keyword": "COMMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 142
                 },
@@ -427,7 +533,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -436,13 +544,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 48,
-            "idx": 48
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -595,35 +703,35 @@
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@18"
+                    "@type": "@24"
                 },
                 0
             ],
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@40"
+                    "@type": "@46"
                 },
                 0
             ],
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@42"
+                    "@type": "@48"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@44"
+                    "@type": "@50"
                 },
                 0
             ],
             [
                 "No transaction was previously started.",
                 {
-                    "@type": "@47"
+                    "@type": "@53"
                 },
                 0
             ]

--- a/tests/data/parser/parseTransaction7.out
+++ b/tests/data/parser/parseTransaction7.out
@@ -7,13 +7,19 @@
         "last": 144,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 46,
+            "idx": 46,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "BEGIN",
                     "value": "BEGIN",
                     "keyword": "BEGIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 1,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -31,7 +41,11 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -40,7 +54,9 @@
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 11
                 },
@@ -49,7 +65,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 18
                 },
@@ -67,7 +87,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -76,7 +98,11 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -94,7 +122,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 26
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +144,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -121,7 +157,11 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -130,7 +170,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -139,7 +181,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -148,7 +192,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -157,7 +203,9 @@
                     "token": "SAVEPOINT",
                     "value": "SAVEPOINT",
                     "keyword": "SAVEPOINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 42
                 },
@@ -166,7 +214,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -175,7 +225,9 @@
                     "token": "my_savepoint",
                     "value": "my_savepoint",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -184,7 +236,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -193,7 +247,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -202,7 +258,9 @@
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 70
                 },
@@ -211,7 +269,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -220,7 +280,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 77
                 },
@@ -229,7 +291,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -238,7 +302,9 @@
                     "token": "t2",
                     "value": "t2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -247,7 +313,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -256,7 +324,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 85
                 },
@@ -265,7 +335,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -274,7 +346,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 92
                 },
@@ -283,7 +357,9 @@
                     "token": "4",
                     "value": 4,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@20"
+                    },
                     "flags": 0,
                     "position": 93
                 },
@@ -292,7 +368,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 94
                 },
@@ -301,7 +379,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -310,7 +390,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -319,7 +401,9 @@
                     "token": "ROLLBACK",
                     "value": "ROLLBACK",
                     "keyword": "ROLLBACK",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 101
                 },
@@ -328,7 +412,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 109
                 },
@@ -337,7 +423,9 @@
                     "token": "TO",
                     "value": "TO",
                     "keyword": "TO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 110
                 },
@@ -346,7 +434,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -355,7 +445,9 @@
                     "token": "SAVEPOINT",
                     "value": "SAVEPOINT",
                     "keyword": "SAVEPOINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 113
                 },
@@ -364,7 +456,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 122
                 },
@@ -373,7 +467,9 @@
                     "token": "my_savepoint",
                     "value": "my_savepoint",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 123
                 },
@@ -382,7 +478,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -391,7 +489,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 136
                 },
@@ -400,7 +500,9 @@
                     "token": "COMMIT",
                     "value": "COMMIT",
                     "keyword": "COMMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 137
                 },
@@ -409,7 +511,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 143
                 },
@@ -418,13 +522,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 46,
-            "idx": 46
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -576,35 +680,35 @@
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@18"
+                    "@type": "@24"
                 },
                 0
             ],
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@38"
+                    "@type": "@44"
                 },
                 0
             ],
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@40"
+                    "@type": "@46"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@42"
+                    "@type": "@48"
                 },
                 0
             ],
             [
                 "No transaction was previously started.",
                 {
-                    "@type": "@45"
+                    "@type": "@51"
                 },
                 0
             ]

--- a/tests/data/parser/parseTransactionErr1.out
+++ b/tests/data/parser/parseTransactionErr1.out
@@ -7,13 +7,19 @@
         "last": 7,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 3,
+            "idx": 3,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "COMMIT",
                     "value": "COMMIT",
                     "keyword": "COMMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 1,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,13 +41,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 3,
-            "idx": 3
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseUnlock1.out
+++ b/tests/data/parser/parseUnlock1.out
@@ -7,13 +7,19 @@
         "last": 14,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 5,
+            "idx": 5,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "UNLOCK",
                     "value": "UNLOCK",
                     "keyword": "UNLOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,13 +65,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@8"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 5,
-            "idx": 5
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseUnlockErr1.out
+++ b/tests/data/parser/parseUnlockErr1.out
@@ -7,13 +7,19 @@
         "last": 18,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 7,
+            "idx": 7,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "UNLOCK",
                     "value": "UNLOCK",
                     "keyword": "UNLOCK",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "TABLES",
                     "value": "TABLES",
                     "keyword": "TABLES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -49,7 +63,11 @@
                     "token": "abc",
                     "value": "abc",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -58,7 +76,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -67,13 +89,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 7,
-            "idx": 7
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -105,7 +127,7 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@6"
+                    "@type": "@8"
                 },
                 0
             ]

--- a/tests/data/parser/parseUpdate1.out
+++ b/tests/data/parser/parseUpdate1.out
@@ -7,13 +7,19 @@
         "last": 54,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 18,
+            "idx": 18,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -40,7 +54,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +65,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -85,7 +109,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 34
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -103,7 +133,11 @@
                     "token": "\"Dan\"",
                     "value": "Dan",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 36
                 },
@@ -112,7 +146,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -121,7 +157,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -130,7 +168,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -139,7 +179,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 49
                 },
@@ -148,7 +190,11 @@
                     "token": "155",
                     "value": 155,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -157,7 +203,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -166,13 +216,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 18,
-            "idx": 18
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseUpdate2.out
+++ b/tests/data/parser/parseUpdate2.out
@@ -7,13 +7,19 @@
         "last": 99,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 34,
+            "idx": 34,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -40,7 +54,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -49,7 +65,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 17
                 },
@@ -58,7 +76,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -67,7 +87,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 25
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -85,7 +109,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 34
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -103,7 +133,11 @@
                     "token": "\"Dan\"",
                     "value": "Dan",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 36
                 },
@@ -112,7 +146,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -121,7 +157,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -130,7 +168,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -139,7 +179,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 49
                 },
@@ -148,7 +190,11 @@
                     "token": "155",
                     "value": 155,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -157,7 +203,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -166,7 +214,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 54
                 },
@@ -175,7 +225,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -184,7 +236,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -193,7 +247,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -202,7 +258,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 73
                 },
@@ -211,7 +269,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -220,7 +280,9 @@
                     "token": "\"Paul\"",
                     "value": "Paul",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 75
                 },
@@ -229,7 +291,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -238,7 +302,9 @@
                     "token": "LIMIT",
                     "value": "LIMIT",
                     "keyword": "LIMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 82
                 },
@@ -247,7 +313,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 87
                 },
@@ -256,7 +324,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -265,7 +335,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -274,7 +346,9 @@
                     "token": "OFFSET",
                     "value": "OFFSET",
                     "keyword": "OFFSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 90
                 },
@@ -283,7 +357,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -292,7 +368,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@23"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -301,7 +379,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 98
                 },
@@ -310,13 +392,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@41"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 34,
-            "idx": 34
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseUpdate3.out
+++ b/tests/data/parser/parseUpdate3.out
@@ -7,13 +7,19 @@
         "last": 36,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 19,
+            "idx": 19,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -49,7 +65,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 11
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -67,7 +87,9 @@
                     "token": "bar",
                     "value": "bar",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -85,7 +109,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 19
                 },
@@ -94,7 +122,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -103,7 +133,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -121,7 +155,9 @@
                     "token": "baz",
                     "value": "baz",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -139,7 +177,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@14"
+                    },
                     "flags": 2,
                     "position": 32
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -157,7 +199,11 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -166,7 +212,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -175,13 +223,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 19,
-            "idx": 19
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -240,7 +290,7 @@
             [
                 "Missing expression.",
                 {
-                    "@type": "@12"
+                    "@type": "@16"
                 },
                 0
             ]

--- a/tests/data/parser/parseUpdate4.out
+++ b/tests/data/parser/parseUpdate4.out
@@ -7,13 +7,19 @@
         "last": 70,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 32,
+            "idx": 32,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "Country",
                     "value": "Country",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 14
                 },
@@ -49,7 +65,9 @@
                     "token": "x",
                     "value": "x",
                     "keyword": "x",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -58,7 +76,11 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 16
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 17
                 },
@@ -76,7 +100,9 @@
                     "token": "City",
                     "value": "City",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -85,7 +111,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -94,7 +122,9 @@
                     "token": "y",
                     "value": "y",
                     "keyword": "y",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -103,7 +133,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -112,7 +144,9 @@
                     "token": "set",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 25
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -130,7 +166,9 @@
                     "token": "x",
                     "value": "x",
                     "keyword": "x",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -139,7 +177,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -148,7 +188,9 @@
                     "token": "Name",
                     "value": "Name",
                     "keyword": "NAME",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -157,7 +199,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 35
                 },
@@ -166,7 +210,9 @@
                     "token": "x",
                     "value": "x",
                     "keyword": "x",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -175,7 +221,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 37
                 },
@@ -184,7 +232,9 @@
                     "token": "Name",
                     "value": "Name",
                     "keyword": "NAME",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -202,7 +254,9 @@
                     "token": "where",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 43
                 },
@@ -211,7 +265,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -220,7 +276,9 @@
                     "token": "x",
                     "value": "x",
                     "keyword": "x",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -229,7 +287,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 50
                 },
@@ -238,7 +298,9 @@
                     "token": "Code",
                     "value": "Code",
                     "keyword": "CODE",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -247,7 +309,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 2,
                     "position": 55
                 },
@@ -256,7 +320,9 @@
                     "token": "y",
                     "value": "y",
                     "keyword": "y",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -265,7 +331,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@11"
+                    },
                     "flags": 16,
                     "position": 57
                 },
@@ -274,7 +342,9 @@
                     "token": "CountryCode",
                     "value": "CountryCode",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -283,7 +353,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -292,13 +366,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 32,
-            "idx": 32
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseUpdate5.out
+++ b/tests/data/parser/parseUpdate5.out
@@ -7,13 +7,19 @@
         "last": 90,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 43,
+            "idx": 43,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "update",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "user",
                     "value": "user",
                     "keyword": "USER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 33,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "u",
                     "value": "u",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 13
                 },
@@ -67,7 +87,9 @@
                     "token": "left join",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 14
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -85,7 +109,9 @@
                     "token": "user_detail",
                     "value": "user_detail",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -103,7 +131,9 @@
                     "token": "ud",
                     "value": "ud",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -121,7 +153,9 @@
                     "token": "on",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 39
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -139,7 +175,9 @@
                     "token": "u",
                     "value": "u",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -148,7 +186,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -157,7 +199,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -175,7 +221,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 47
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -193,7 +243,9 @@
                     "token": "ud",
                     "value": "ud",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -202,7 +254,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 51
                 },
@@ -211,7 +265,9 @@
                     "token": "user_id",
                     "value": "user_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -229,7 +287,9 @@
                     "token": "set",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 60
                 },
@@ -238,7 +298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -247,7 +309,9 @@
                     "token": "ud",
                     "value": "ud",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -256,7 +320,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 66
                 },
@@ -265,7 +331,9 @@
                     "token": "ip",
                     "value": "ip",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -274,7 +342,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -283,7 +353,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 70
                 },
@@ -292,7 +364,11 @@
                     "token": "'33'",
                     "value": "33",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 71
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -310,7 +388,9 @@
                     "token": "where",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 76
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -328,7 +410,9 @@
                     "token": "u",
                     "value": "u",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -337,7 +421,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 83
                 },
@@ -346,7 +432,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -355,7 +443,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -364,7 +454,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 87
                 },
@@ -373,7 +465,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -382,7 +476,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -391,13 +489,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 43,
-            "idx": 43
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseUpdate6.out
+++ b/tests/data/parser/parseUpdate6.out
@@ -7,13 +7,19 @@
         "last": 193,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 63,
+            "idx": 63,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "customer_table",
                     "value": "customer_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -49,7 +65,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -58,7 +76,9 @@
                     "token": "\n\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +87,9 @@
                     "token": "JOIN",
                     "value": "JOIN",
                     "keyword": "JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -76,7 +98,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -85,7 +109,9 @@
                     "token": "employee_table",
                     "value": "employee_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -103,7 +131,9 @@
                     "token": "e",
                     "value": "e",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -112,7 +142,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -121,7 +153,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 61
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -139,7 +175,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -148,7 +186,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 65
                 },
@@ -157,7 +199,9 @@
                     "token": "city_id",
                     "value": "city_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -175,7 +221,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 74
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -193,7 +243,9 @@
                     "token": "e",
                     "value": "e",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -202,7 +254,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -211,7 +265,9 @@
                     "token": "city_id",
                     "value": "city_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -220,7 +276,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -229,7 +287,9 @@
                     "token": "JOIN",
                     "value": "JOIN",
                     "keyword": "JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 88
                 },
@@ -238,7 +298,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -247,7 +309,9 @@
                     "token": "anyother_table",
                     "value": "anyother_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -265,7 +331,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 114
                 },
@@ -274,7 +342,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -283,7 +353,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 122
                 },
@@ -292,7 +364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -301,7 +375,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -310,7 +386,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 126
                 },
@@ -319,7 +397,9 @@
                     "token": "someID",
                     "value": "someID",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -328,7 +408,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 133
                 },
@@ -337,7 +419,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 134
                 },
@@ -346,7 +430,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -355,7 +441,9 @@
                     "token": "e",
                     "value": "e",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 136
                 },
@@ -364,7 +452,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 137
                 },
@@ -373,7 +463,9 @@
                     "token": "someID",
                     "value": "someID",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -382,7 +474,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 144
                 },
@@ -391,7 +485,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 146
                 },
@@ -400,7 +496,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -409,7 +507,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 150
                 },
@@ -418,7 +518,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 151
                 },
@@ -427,7 +529,9 @@
                     "token": "active",
                     "value": "active",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -436,7 +540,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 158
                 },
@@ -445,7 +551,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 159
                 },
@@ -454,7 +562,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -463,7 +573,11 @@
                     "token": "\"Yes\"",
                     "value": "Yes",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 161
                 },
@@ -472,7 +586,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 166
                 },
@@ -481,7 +597,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 167
                 },
@@ -490,7 +608,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 172
                 },
@@ -499,7 +619,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 173
                 },
@@ -508,7 +630,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 174
                 },
@@ -517,7 +641,9 @@
                     "token": "city",
                     "value": "city",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 175
                 },
@@ -526,7 +652,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 179
                 },
@@ -535,7 +663,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 180
                 },
@@ -544,7 +674,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 181
                 },
@@ -553,7 +685,9 @@
                     "token": "\"New york\"",
                     "value": "New york",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@57"
+                    },
                     "flags": 2,
                     "position": 182
                 },
@@ -562,7 +696,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 192
                 },
@@ -571,13 +709,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@69"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 63,
-            "idx": 63
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseUpdate7.out
+++ b/tests/data/parser/parseUpdate7.out
@@ -7,13 +7,19 @@
         "last": 204,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 63,
+            "idx": 63,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,11 @@
                     "token": "customer_table",
                     "value": "customer_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 7
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -49,7 +65,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -58,7 +76,9 @@
                     "token": "\n\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +87,9 @@
                     "token": "INNER JOIN",
                     "value": "INNER JOIN",
                     "keyword": "INNER JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 27
                 },
@@ -76,7 +98,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -85,7 +109,9 @@
                     "token": "employee_table",
                     "value": "employee_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -103,7 +131,9 @@
                     "token": "e",
                     "value": "e",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -112,7 +142,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -121,7 +153,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 67
                 },
@@ -130,7 +164,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -139,7 +175,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -148,7 +186,11 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -157,7 +199,9 @@
                     "token": "city_id",
                     "value": "city_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -175,7 +221,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 80
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -193,7 +243,9 @@
                     "token": "e",
                     "value": "e",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -202,7 +254,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 83
                 },
@@ -211,7 +265,9 @@
                     "token": "city_id",
                     "value": "city_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -220,7 +276,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -229,7 +287,9 @@
                     "token": "LEFT JOIN",
                     "value": "LEFT JOIN",
                     "keyword": "LEFT JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 94
                 },
@@ -238,7 +298,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -247,7 +309,9 @@
                     "token": "anyother_table",
                     "value": "anyother_table",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 124
                 },
@@ -265,7 +331,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -274,7 +342,9 @@
                     "token": "\n      ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -283,7 +353,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 133
                 },
@@ -292,7 +364,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -301,7 +375,9 @@
                     "token": "a",
                     "value": "a",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 136
                 },
@@ -310,7 +386,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 137
                 },
@@ -319,7 +397,9 @@
                     "token": "someID",
                     "value": "someID",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 138
                 },
@@ -328,7 +408,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 144
                 },
@@ -337,7 +419,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 145
                 },
@@ -346,7 +430,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 146
                 },
@@ -355,7 +441,9 @@
                     "token": "e",
                     "value": "e",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 147
                 },
@@ -364,7 +452,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 148
                 },
@@ -373,7 +463,9 @@
                     "token": "someID",
                     "value": "someID",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -382,7 +474,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 155
                 },
@@ -391,7 +485,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 11,
                     "position": 157
                 },
@@ -400,7 +496,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 160
                 },
@@ -409,7 +507,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 161
                 },
@@ -418,7 +518,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 162
                 },
@@ -427,7 +529,9 @@
                     "token": "active",
                     "value": "active",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 163
                 },
@@ -436,7 +540,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 169
                 },
@@ -445,7 +551,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 170
                 },
@@ -454,7 +562,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 171
                 },
@@ -463,7 +573,11 @@
                     "token": "\"Yes\"",
                     "value": "Yes",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 172
                 },
@@ -472,7 +586,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 177
                 },
@@ -481,7 +597,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 178
                 },
@@ -490,7 +608,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 183
                 },
@@ -499,7 +619,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 184
                 },
@@ -508,7 +630,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 16,
                     "position": 185
                 },
@@ -517,7 +641,9 @@
                     "token": "city",
                     "value": "city",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 186
                 },
@@ -526,7 +652,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 190
                 },
@@ -535,7 +663,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 2,
                     "position": 191
                 },
@@ -544,7 +674,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 192
                 },
@@ -553,7 +685,9 @@
                     "token": "\"New york\"",
                     "value": "New york",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@57"
+                    },
                     "flags": 2,
                     "position": 193
                 },
@@ -562,7 +696,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 203
                 },
@@ -571,13 +709,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@69"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 63,
-            "idx": 63
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,

--- a/tests/data/parser/parseUpdateErr.out
+++ b/tests/data/parser/parseUpdateErr.out
@@ -7,13 +7,19 @@
         "last": 87,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 29,
+            "idx": 29,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- extraneous comma",
                     "value": "-- extraneous comma",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 19
                 },
@@ -31,7 +41,11 @@
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 20
                 },
@@ -40,7 +54,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -49,7 +65,11 @@
                     "token": "users",
                     "value": "users",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -58,7 +78,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -67,7 +89,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 11,
                     "position": 37
                 },
@@ -76,7 +100,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -85,7 +111,9 @@
                     "token": "username",
                     "value": "username",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -103,7 +133,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 54
                 },
@@ -112,7 +146,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -121,7 +157,11 @@
                     "token": "\"Dan\"",
                     "value": "Dan",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 56
                 },
@@ -130,7 +170,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 61
                 },
@@ -139,7 +181,9 @@
                     "token": "\n    ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -148,7 +192,9 @@
                     "token": "id",
                     "value": "id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -157,7 +203,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 69
                 },
@@ -166,7 +214,11 @@
                     "token": "155",
                     "value": 155,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -175,7 +227,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 73
                 },
@@ -184,7 +238,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -193,7 +249,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 3,
                     "position": 75
                 },
@@ -202,7 +260,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -211,7 +271,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -220,7 +282,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -229,7 +293,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 2,
                     "position": 83
                 },
@@ -238,7 +304,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -247,7 +315,9 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -256,7 +326,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -265,13 +339,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@37"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 29,
-            "idx": 29
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -339,7 +413,7 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@20"
+                    "@type": "@27"
                 },
                 0
             ]

--- a/tests/data/parser/parseWithStatement.out
+++ b/tests/data/parser/parseWithStatement.out
@@ -7,13 +7,19 @@
         "last": 94,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 38,
+            "idx": 38,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +85,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 23
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -85,7 +107,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +131,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 37
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -139,7 +177,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 39
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -157,7 +199,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -175,7 +221,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -193,7 +243,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -211,7 +267,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 53
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -229,7 +289,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 63
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -247,7 +311,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -265,7 +333,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 72
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -283,7 +355,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 74
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -301,7 +377,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -319,7 +399,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 86
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -337,7 +421,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -346,13 +432,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 38,
-            "idx": 38
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -410,19 +498,9 @@
                                 "@type": "PhpMyAdmin\\SqlParser\\Parser",
                                 "list": {
                                     "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                    "count": 11,
+                                    "idx": 11,
                                     "tokens": [
-                                        {
-                                            "@type": "@19"
-                                        },
-                                        {
-                                            "@type": "@20"
-                                        },
-                                        {
-                                            "@type": "@21"
-                                        },
-                                        {
-                                            "@type": "@22"
-                                        },
                                         {
                                             "@type": "@23"
                                         },
@@ -436,17 +514,27 @@
                                             "@type": "@26"
                                         },
                                         {
-                                            "@type": "@27"
-                                        },
-                                        {
                                             "@type": "@28"
                                         },
                                         {
                                             "@type": "@29"
+                                        },
+                                        {
+                                            "@type": "@30"
+                                        },
+                                        {
+                                            "@type": "@31"
+                                        },
+                                        {
+                                            "@type": "@32"
+                                        },
+                                        {
+                                            "@type": "@33"
+                                        },
+                                        {
+                                            "@type": "@34"
                                         }
-                                    ],
-                                    "count": 11,
-                                    "idx": 11
+                                    ]
                                 },
                                 "statements": [
                                     {
@@ -534,22 +622,9 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Parser",
                         "list": {
                             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                            "count": 8,
+                            "idx": 8,
                             "tokens": [
-                                {
-                                    "@type": "@32"
-                                },
-                                {
-                                    "@type": "@33"
-                                },
-                                {
-                                    "@type": "@34"
-                                },
-                                {
-                                    "@type": "@35"
-                                },
-                                {
-                                    "@type": "@36"
-                                },
                                 {
                                     "@type": "@37"
                                 },
@@ -558,10 +633,23 @@
                                 },
                                 {
                                     "@type": "@39"
+                                },
+                                {
+                                    "@type": "@40"
+                                },
+                                {
+                                    "@type": "@41"
+                                },
+                                {
+                                    "@type": "@42"
+                                },
+                                {
+                                    "@type": "@43"
+                                },
+                                {
+                                    "@type": "@44"
                                 }
-                            ],
-                            "count": 8,
-                            "idx": 8
+                            ]
                         },
                         "statements": [
                             {

--- a/tests/data/parser/parseWithStatement1.out
+++ b/tests/data/parser/parseWithStatement1.out
@@ -7,13 +7,19 @@
         "last": 95,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 38,
+            "idx": 38,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "table",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +85,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +107,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +131,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -121,7 +155,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +177,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -157,7 +199,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -175,7 +221,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -193,7 +243,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -211,7 +267,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 54
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -229,7 +289,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 64
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -247,7 +311,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -265,7 +333,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 73
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -283,7 +355,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 75
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -301,7 +377,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -319,7 +399,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 87
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -337,7 +421,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -346,13 +432,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 38,
-            "idx": 38
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -400,19 +488,9 @@
                                 "@type": "PhpMyAdmin\\SqlParser\\Parser",
                                 "list": {
                                     "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                    "count": 11,
+                                    "idx": 11,
                                     "tokens": [
-                                        {
-                                            "@type": "@19"
-                                        },
-                                        {
-                                            "@type": "@20"
-                                        },
-                                        {
-                                            "@type": "@21"
-                                        },
-                                        {
-                                            "@type": "@22"
-                                        },
                                         {
                                             "@type": "@23"
                                         },
@@ -426,17 +504,27 @@
                                             "@type": "@26"
                                         },
                                         {
-                                            "@type": "@27"
-                                        },
-                                        {
                                             "@type": "@28"
                                         },
                                         {
                                             "@type": "@29"
+                                        },
+                                        {
+                                            "@type": "@30"
+                                        },
+                                        {
+                                            "@type": "@31"
+                                        },
+                                        {
+                                            "@type": "@32"
+                                        },
+                                        {
+                                            "@type": "@33"
+                                        },
+                                        {
+                                            "@type": "@34"
                                         }
-                                    ],
-                                    "count": 11,
-                                    "idx": 11
+                                    ]
                                 },
                                 "statements": [
                                     {
@@ -524,22 +612,9 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Parser",
                         "list": {
                             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                            "count": 8,
+                            "idx": 8,
                             "tokens": [
-                                {
-                                    "@type": "@32"
-                                },
-                                {
-                                    "@type": "@33"
-                                },
-                                {
-                                    "@type": "@34"
-                                },
-                                {
-                                    "@type": "@35"
-                                },
-                                {
-                                    "@type": "@36"
-                                },
                                 {
                                     "@type": "@37"
                                 },
@@ -548,10 +623,23 @@
                                 },
                                 {
                                     "@type": "@39"
+                                },
+                                {
+                                    "@type": "@40"
+                                },
+                                {
+                                    "@type": "@41"
+                                },
+                                {
+                                    "@type": "@42"
+                                },
+                                {
+                                    "@type": "@43"
+                                },
+                                {
+                                    "@type": "@44"
                                 }
-                            ],
-                            "count": 8,
-                            "idx": 8
+                            ]
                         },
                         "statements": [
                             {

--- a/tests/data/parser/parseWithStatement2.out
+++ b/tests/data/parser/parseWithStatement2.out
@@ -7,13 +7,19 @@
         "last": 112,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 46,
+            "idx": 46,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +85,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 23
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -85,7 +107,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +131,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 37
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -139,7 +177,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 39
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -157,7 +199,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -175,7 +221,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 44
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -193,7 +243,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -211,7 +267,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 53
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -229,7 +289,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 55
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -247,7 +311,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -265,7 +333,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 67
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -283,7 +355,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -301,7 +377,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 76
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -319,7 +399,9 @@
                     "token": "DUPLICATE",
                     "value": "DUPLICATE",
                     "keyword": "DUPLICATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 79
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -337,7 +421,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 89
                 },
@@ -346,7 +432,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -355,7 +443,9 @@
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 93
                 },
@@ -364,7 +454,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 99
                 },
@@ -373,7 +465,9 @@
                     "token": "col_name",
                     "value": "col_name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 100
                 },
@@ -382,7 +476,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 108
                 },
@@ -391,7 +487,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 109
                 },
@@ -400,7 +498,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -409,7 +509,9 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -418,13 +520,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 46,
-            "idx": 46
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -482,25 +586,25 @@
                                 "@type": "PhpMyAdmin\\SqlParser\\Parser",
                                 "list": {
                                     "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                    "count": 5,
+                                    "idx": 5,
                                     "tokens": [
                                         {
-                                            "@type": "@19"
-                                        },
-                                        {
-                                            "@type": "@20"
-                                        },
-                                        {
-                                            "@type": "@21"
-                                        },
-                                        {
-                                            "@type": "@22"
-                                        },
-                                        {
                                             "@type": "@23"
+                                        },
+                                        {
+                                            "@type": "@24"
+                                        },
+                                        {
+                                            "@type": "@25"
+                                        },
+                                        {
+                                            "@type": "@26"
+                                        },
+                                        {
+                                            "@type": "@28"
                                         }
-                                    ],
-                                    "count": 5,
-                                    "idx": 5
+                                    ]
                                 },
                                 "statements": [
                                     {
@@ -549,22 +653,9 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Parser",
                         "list": {
                             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                            "count": 8,
+                            "idx": 8,
                             "tokens": [
-                                {
-                                    "@type": "@26"
-                                },
-                                {
-                                    "@type": "@27"
-                                },
-                                {
-                                    "@type": "@28"
-                                },
-                                {
-                                    "@type": "@29"
-                                },
-                                {
-                                    "@type": "@30"
-                                },
                                 {
                                     "@type": "@31"
                                 },
@@ -573,10 +664,23 @@
                                 },
                                 {
                                     "@type": "@33"
+                                },
+                                {
+                                    "@type": "@34"
+                                },
+                                {
+                                    "@type": "@35"
+                                },
+                                {
+                                    "@type": "@36"
+                                },
+                                {
+                                    "@type": "@37"
+                                },
+                                {
+                                    "@type": "@38"
                                 }
-                            ],
-                            "count": 8,
-                            "idx": 8
+                            ]
                         },
                         "statements": [
                             {

--- a/tests/data/parser/parseWithStatement3.out
+++ b/tests/data/parser/parseWithStatement3.out
@@ -7,13 +7,19 @@
         "last": 310,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 115,
+            "idx": 115,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "categories",
                     "value": "categories",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -40,7 +54,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 15
                 },
@@ -49,7 +67,9 @@
                     "token": "identifier",
                     "value": "identifier",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 16
                 },
@@ -58,7 +78,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 26
                 },
@@ -67,7 +89,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -76,7 +100,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 28
                 },
@@ -85,7 +111,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -103,7 +133,9 @@
                     "token": "parent_id",
                     "value": "parent_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -112,7 +144,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -130,7 +166,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -148,7 +188,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 48
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -166,7 +210,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 50
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -184,7 +232,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -193,7 +243,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 58
                 },
@@ -202,7 +254,9 @@
                     "token": "identifier",
                     "value": "identifier",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -211,7 +265,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 69
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -229,7 +287,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -238,7 +298,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 72
                 },
@@ -247,7 +309,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -256,7 +320,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 77
                 },
@@ -265,7 +331,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -274,7 +342,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -283,7 +353,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 80
                 },
@@ -292,7 +364,9 @@
                     "token": "parent_id",
                     "value": "parent_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -301,7 +375,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -310,7 +386,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 91
                 },
@@ -319,7 +397,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 95
                 },
@@ -328,7 +408,9 @@
                     "token": "category",
                     "value": "category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 96
                 },
@@ -337,7 +419,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 104
                 },
@@ -346,7 +430,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 105
                 },
@@ -355,7 +441,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -364,7 +452,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 107
                 },
@@ -373,7 +463,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 112
                 },
@@ -382,7 +474,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 113
                 },
@@ -391,7 +485,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 114
                 },
@@ -400,7 +496,9 @@
                     "token": "identifier",
                     "value": "identifier",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 115
                 },
@@ -409,7 +507,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 125
                 },
@@ -418,7 +518,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 126
                 },
@@ -427,7 +529,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 127
                 },
@@ -436,7 +540,11 @@
                     "token": "'a'",
                     "value": "a",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 1,
                     "position": 128
                 },
@@ -445,7 +553,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 131
                 },
@@ -454,7 +564,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 132
                 },
@@ -463,7 +575,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 141
                 },
@@ -472,7 +586,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 142
                 },
@@ -481,7 +597,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 148
                 },
@@ -490,7 +608,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -499,7 +619,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 150
                 },
@@ -508,7 +630,9 @@
                     "token": "identifier",
                     "value": "identifier",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 151
                 },
@@ -517,7 +641,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 161
                 },
@@ -526,7 +652,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 162
                 },
@@ -535,7 +663,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 163
                 },
@@ -544,7 +674,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 164
                 },
@@ -553,7 +685,9 @@
                     "token": "name",
                     "value": "name",
                     "keyword": "NAME",
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 165
                 },
@@ -562,7 +696,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 169
                 },
@@ -571,7 +707,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 170
                 },
@@ -580,7 +718,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 171
                 },
@@ -589,7 +729,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 172
                 },
@@ -598,7 +740,9 @@
                     "token": "parent_id",
                     "value": "parent_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 173
                 },
@@ -607,7 +751,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 182
                 },
@@ -616,7 +762,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 183
                 },
@@ -625,7 +773,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 187
                 },
@@ -634,7 +784,9 @@
                     "token": "categories",
                     "value": "categories",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 188
                 },
@@ -643,7 +795,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 198
                 },
@@ -652,7 +806,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 199
                 },
@@ -661,7 +817,9 @@
                     "token": "category",
                     "value": "category",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 200
                 },
@@ -670,7 +828,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 208
                 },
@@ -679,7 +839,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 209
                 },
@@ -688,7 +850,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 210
                 },
@@ -697,7 +861,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 211
                 },
@@ -706,7 +872,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 216
                 },
@@ -715,7 +883,9 @@
                     "token": "c",
                     "value": "c",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 217
                 },
@@ -724,7 +894,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 218
                 },
@@ -733,7 +905,9 @@
                     "token": "identifier",
                     "value": "identifier",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 219
                 },
@@ -742,7 +916,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 229
                 },
@@ -751,7 +927,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 2,
                     "position": 230
                 },
@@ -760,7 +938,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 231
                 },
@@ -769,7 +949,9 @@
                     "token": "categories",
                     "value": "categories",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 232
                 },
@@ -778,7 +960,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 242
                 },
@@ -787,7 +971,9 @@
                     "token": "parent_id",
                     "value": "parent_id",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 243
                 },
@@ -796,7 +982,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 252
                 },
@@ -805,7 +993,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 253
                 },
@@ -814,7 +1004,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 254
                 },
@@ -823,7 +1015,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 255
                 },
@@ -832,7 +1026,9 @@
                     "token": "foo",
                     "value": "foo",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 256
                 },
@@ -841,7 +1037,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 259
                 },
@@ -850,7 +1048,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 260
                 },
@@ -859,7 +1059,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 262
                 },
@@ -868,7 +1070,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 263
                 },
@@ -877,7 +1081,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 264
                 },
@@ -886,7 +1092,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 265
                 },
@@ -895,7 +1103,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 271
                 },
@@ -904,7 +1114,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 272
                 },
@@ -913,7 +1125,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 273
                 },
@@ -922,7 +1136,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 274
                 },
@@ -931,7 +1147,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 278
                 },
@@ -940,7 +1158,9 @@
                     "token": "test",
                     "value": "test",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 279
                 },
@@ -949,7 +1169,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 283
                 },
@@ -958,7 +1180,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 284
                 },
@@ -967,7 +1191,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 285
                 },
@@ -976,7 +1202,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 286
                 },
@@ -985,7 +1213,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 292
                 },
@@ -994,7 +1224,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 16,
                     "position": 293
                 },
@@ -1003,7 +1235,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 294
                 },
@@ -1012,7 +1246,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 295
                 },
@@ -1021,7 +1257,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 299
                 },
@@ -1030,7 +1268,9 @@
                     "token": "categories",
                     "value": "categories",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 300
                 },
@@ -1039,13 +1279,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 115,
-            "idx": 115
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -1083,19 +1325,9 @@
                             "@type": "PhpMyAdmin\\SqlParser\\Parser",
                             "list": {
                                 "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                "count": 72,
+                                "idx": 72,
                                 "tokens": [
-                                    {
-                                        "@type": "@18"
-                                    },
-                                    {
-                                        "@type": "@19"
-                                    },
-                                    {
-                                        "@type": "@20"
-                                    },
-                                    {
-                                        "@type": "@21"
-                                    },
                                     {
                                         "@type": "@22"
                                     },
@@ -1191,9 +1423,6 @@
                                     },
                                     {
                                         "@type": "@53"
-                                    },
-                                    {
-                                        "@type": "@54"
                                     },
                                     {
                                         "@type": "@55"
@@ -1299,10 +1528,23 @@
                                     },
                                     {
                                         "@type": "@89"
+                                    },
+                                    {
+                                        "@type": "@90"
+                                    },
+                                    {
+                                        "@type": "@91"
+                                    },
+                                    {
+                                        "@type": "@92"
+                                    },
+                                    {
+                                        "@type": "@93"
+                                    },
+                                    {
+                                        "@type": "@94"
                                     }
-                                ],
-                                "count": 72,
-                                "idx": 72
+                                ]
                             },
                             "statements": [
                                 {
@@ -1488,22 +1730,9 @@
                             "@type": "PhpMyAdmin\\SqlParser\\Parser",
                             "list": {
                                 "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                "count": 9,
+                                "idx": 9,
                                 "tokens": [
-                                    {
-                                        "@type": "@98"
-                                    },
-                                    {
-                                        "@type": "@99"
-                                    },
-                                    {
-                                        "@type": "@100"
-                                    },
-                                    {
-                                        "@type": "@101"
-                                    },
-                                    {
-                                        "@type": "@102"
-                                    },
                                     {
                                         "@type": "@103"
                                     },
@@ -1515,10 +1744,23 @@
                                     },
                                     {
                                         "@type": "@106"
+                                    },
+                                    {
+                                        "@type": "@107"
+                                    },
+                                    {
+                                        "@type": "@108"
+                                    },
+                                    {
+                                        "@type": "@109"
+                                    },
+                                    {
+                                        "@type": "@110"
+                                    },
+                                    {
+                                        "@type": "@111"
                                     }
-                                ],
-                                "count": 9,
-                                "idx": 9
+                                ]
                             },
                             "statements": [
                                 {
@@ -1578,22 +1820,9 @@
                     "@type": "PhpMyAdmin\\SqlParser\\Parser",
                     "list": {
                         "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                        "count": 8,
+                        "idx": 8,
                         "tokens": [
-                            {
-                                "@type": "@109"
-                            },
-                            {
-                                "@type": "@110"
-                            },
-                            {
-                                "@type": "@111"
-                            },
-                            {
-                                "@type": "@112"
-                            },
-                            {
-                                "@type": "@113"
-                            },
                             {
                                 "@type": "@114"
                             },
@@ -1602,10 +1831,23 @@
                             },
                             {
                                 "@type": "@116"
+                            },
+                            {
+                                "@type": "@117"
+                            },
+                            {
+                                "@type": "@118"
+                            },
+                            {
+                                "@type": "@119"
+                            },
+                            {
+                                "@type": "@120"
+                            },
+                            {
+                                "@type": "@121"
                             }
-                        ],
-                        "count": 8,
-                        "idx": 8
+                        ]
                     },
                     "statements": [
                         {

--- a/tests/data/parser/parseWithStatement4.out
+++ b/tests/data/parser/parseWithStatement4.out
@@ -7,13 +7,19 @@
         "last": 80,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 34,
+            "idx": 35,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "table",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +85,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,7 +107,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 27
                 },
@@ -94,7 +118,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +129,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -121,7 +153,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 36
                 },
@@ -130,7 +166,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -139,7 +177,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -157,7 +199,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 43
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -175,7 +221,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 46
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -193,7 +243,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 48
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 54
                 },
@@ -211,7 +265,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -229,7 +289,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 57
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -247,7 +311,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 67
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 73
                 },
@@ -265,7 +333,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@29"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 75
                 },
@@ -283,7 +355,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@18"
+                    },
                     "flags": 16,
                     "position": 76
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -301,7 +377,9 @@
                     "token": "NO",
                     "value": "NO",
                     "keyword": "NO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 78
                 },
@@ -310,13 +388,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 34,
-            "idx": 35
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -364,19 +444,9 @@
                                 "@type": "PhpMyAdmin\\SqlParser\\Parser",
                                 "list": {
                                     "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                    "count": 11,
+                                    "idx": 11,
                                     "tokens": [
-                                        {
-                                            "@type": "@21"
-                                        },
-                                        {
-                                            "@type": "@22"
-                                        },
-                                        {
-                                            "@type": "@23"
-                                        },
-                                        {
-                                            "@type": "@24"
-                                        },
                                         {
                                             "@type": "@25"
                                         },
@@ -390,17 +460,27 @@
                                             "@type": "@28"
                                         },
                                         {
-                                            "@type": "@29"
-                                        },
-                                        {
                                             "@type": "@30"
                                         },
                                         {
                                             "@type": "@31"
+                                        },
+                                        {
+                                            "@type": "@32"
+                                        },
+                                        {
+                                            "@type": "@33"
+                                        },
+                                        {
+                                            "@type": "@34"
+                                        },
+                                        {
+                                            "@type": "@35"
+                                        },
+                                        {
+                                            "@type": "@36"
                                         }
-                                    ],
-                                    "count": 11,
-                                    "idx": 11
+                                    ]
                                 },
                                 "statements": [
                                     {
@@ -523,21 +603,21 @@
             [
                 "An expression was expected.",
                 {
-                    "@type": "@34"
+                    "@type": "@39"
                 },
                 0
             ],
             [
                 "Unexpected end of the WITH CTE.",
                 {
-                    "@type": "@34"
+                    "@type": "@39"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@34"
+                    "@type": "@39"
                 },
                 0
             ]

--- a/tests/data/parser/parseWithStatement5.out
+++ b/tests/data/parser/parseWithStatement5.out
@@ -7,13 +7,19 @@
         "last": 95,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 39,
+            "idx": 39,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "view",
                     "value": "view",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "view_name",
                     "value": "view_name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -67,7 +87,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -76,7 +98,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 24
                 },
@@ -85,7 +109,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 25
                 },
@@ -94,7 +120,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -103,7 +131,9 @@
                     "token": "aa",
                     "value": "aa",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -112,7 +142,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -130,7 +166,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -148,7 +188,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -166,7 +210,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -184,7 +232,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -193,7 +243,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -202,7 +254,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -220,7 +278,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 54
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -238,7 +300,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 64
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -256,7 +322,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -274,7 +344,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 73
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -292,7 +366,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 75
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 81
                 },
@@ -310,7 +388,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 82
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -328,7 +410,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 87
                 },
@@ -337,7 +421,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 91
                 },
@@ -346,7 +432,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 92
                 },
@@ -355,13 +443,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 39,
-            "idx": 39
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -409,19 +499,9 @@
                                 "@type": "PhpMyAdmin\\SqlParser\\Parser",
                                 "list": {
                                     "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                    "count": 11,
+                                    "idx": 11,
                                     "tokens": [
-                                        {
-                                            "@type": "@20"
-                                        },
-                                        {
-                                            "@type": "@21"
-                                        },
-                                        {
-                                            "@type": "@22"
-                                        },
-                                        {
-                                            "@type": "@23"
-                                        },
                                         {
                                             "@type": "@24"
                                         },
@@ -435,17 +515,27 @@
                                             "@type": "@27"
                                         },
                                         {
-                                            "@type": "@28"
-                                        },
-                                        {
                                             "@type": "@29"
                                         },
                                         {
                                             "@type": "@30"
+                                        },
+                                        {
+                                            "@type": "@31"
+                                        },
+                                        {
+                                            "@type": "@32"
+                                        },
+                                        {
+                                            "@type": "@33"
+                                        },
+                                        {
+                                            "@type": "@34"
+                                        },
+                                        {
+                                            "@type": "@35"
                                         }
-                                    ],
-                                    "count": 11,
-                                    "idx": 11
+                                    ]
                                 },
                                 "statements": [
                                     {
@@ -533,22 +623,9 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Parser",
                         "list": {
                             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                            "count": 8,
+                            "idx": 8,
                             "tokens": [
-                                {
-                                    "@type": "@33"
-                                },
-                                {
-                                    "@type": "@34"
-                                },
-                                {
-                                    "@type": "@35"
-                                },
-                                {
-                                    "@type": "@36"
-                                },
-                                {
-                                    "@type": "@37"
-                                },
                                 {
                                     "@type": "@38"
                                 },
@@ -557,10 +634,23 @@
                                 },
                                 {
                                     "@type": "@40"
+                                },
+                                {
+                                    "@type": "@41"
+                                },
+                                {
+                                    "@type": "@42"
+                                },
+                                {
+                                    "@type": "@43"
+                                },
+                                {
+                                    "@type": "@44"
+                                },
+                                {
+                                    "@type": "@45"
                                 }
-                            ],
-                            "count": 8,
-                            "idx": 8
+                            ]
                         },
                         "statements": [
                             {
@@ -633,7 +723,7 @@
                 "parameters": null,
                 "body": [
                     {
-                        "@type": "@39"
+                        "@type": "@44"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseWithStatement6.out
+++ b/tests/data/parser/parseWithStatement6.out
@@ -7,13 +7,19 @@
         "last": 92,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 37,
+            "idx": 37,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "view",
                     "value": "view",
                     "keyword": "VIEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,11 @@
                     "token": "view_name",
                     "value": "view_name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -58,7 +76,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 21
                 },
@@ -67,7 +87,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 22
                 },
@@ -76,7 +98,9 @@
                     "token": "  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 26
                 },
@@ -85,7 +109,9 @@
                     "token": "aa",
                     "value": "aa",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -94,7 +120,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 30
                 },
@@ -103,7 +133,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -112,7 +144,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 35
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 36
                 },
@@ -130,7 +166,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 37
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -148,7 +188,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -166,7 +210,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -202,7 +256,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 51
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -220,7 +278,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 61
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -238,7 +300,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -256,7 +322,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@15"
+                    },
                     "flags": 16,
                     "position": 70
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -274,7 +344,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 72
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -292,7 +366,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -310,7 +388,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 84
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -328,7 +410,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@9"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -337,13 +421,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 37,
-            "idx": 37
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -383,15 +469,6 @@
                 "parameters": null,
                 "body": [
                     {
-                        "@type": "@9"
-                    },
-                    {
-                        "@type": "@10"
-                    },
-                    {
-                        "@type": "@11"
-                    },
-                    {
                         "@type": "@12"
                     },
                     {
@@ -399,9 +476,6 @@
                     },
                     {
                         "@type": "@14"
-                    },
-                    {
-                        "@type": "@15"
                     },
                     {
                         "@type": "@16"
@@ -432,9 +506,6 @@
                     },
                     {
                         "@type": "@25"
-                    },
-                    {
-                        "@type": "@26"
                     },
                     {
                         "@type": "@27"
@@ -468,6 +539,21 @@
                     },
                     {
                         "@type": "@37"
+                    },
+                    {
+                        "@type": "@38"
+                    },
+                    {
+                        "@type": "@39"
+                    },
+                    {
+                        "@type": "@40"
+                    },
+                    {
+                        "@type": "@41"
+                    },
+                    {
+                        "@type": "@42"
                     }
                 ],
                 "options": {

--- a/tests/data/parser/parseWithStatement7.out
+++ b/tests/data/parser/parseWithStatement7.out
@@ -7,13 +7,19 @@
         "last": 111,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 47,
+            "idx": 47,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -67,7 +89,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -85,7 +111,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 16
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -103,7 +133,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -121,7 +155,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -139,7 +177,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -157,7 +201,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 30
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -175,7 +223,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -193,7 +245,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -211,7 +267,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 49
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -229,7 +289,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 51
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -247,7 +311,9 @@
                     "token": "*",
                     "value": "*",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 58
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -265,7 +333,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 60
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 64
                 },
@@ -283,7 +355,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -301,7 +377,9 @@
                     "token": "INNER JOIN",
                     "value": "INNER JOIN",
                     "keyword": "INNER JOIN",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 69
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -319,7 +399,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -328,7 +410,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -337,7 +421,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 87
                 },
@@ -346,7 +432,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -355,7 +443,9 @@
                     "token": "table2",
                     "value": "table2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -364,7 +454,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 96
                 },
@@ -373,7 +465,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 97
                 },
@@ -382,7 +476,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 2,
                     "position": 101
                 },
@@ -391,7 +487,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 102
                 },
@@ -400,7 +498,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 105
                 },
@@ -409,7 +509,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 106
                 },
@@ -418,7 +520,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -427,13 +533,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@53"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 47,
-            "idx": 47
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -467,19 +573,9 @@
                             "@type": "PhpMyAdmin\\SqlParser\\Parser",
                             "list": {
                                 "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                "count": 11,
+                                "idx": 11,
                                 "tokens": [
-                                    {
-                                        "@type": "@13"
-                                    },
-                                    {
-                                        "@type": "@14"
-                                    },
-                                    {
-                                        "@type": "@15"
-                                    },
-                                    {
-                                        "@type": "@16"
-                                    },
                                     {
                                         "@type": "@17"
                                     },
@@ -493,17 +589,27 @@
                                         "@type": "@20"
                                     },
                                     {
-                                        "@type": "@21"
-                                    },
-                                    {
                                         "@type": "@22"
                                     },
                                     {
                                         "@type": "@23"
+                                    },
+                                    {
+                                        "@type": "@24"
+                                    },
+                                    {
+                                        "@type": "@25"
+                                    },
+                                    {
+                                        "@type": "@26"
+                                    },
+                                    {
+                                        "@type": "@27"
+                                    },
+                                    {
+                                        "@type": "@28"
                                     }
-                                ],
-                                "count": 11,
-                                "idx": 11
+                                ]
                             },
                             "statements": [
                                 {
@@ -591,22 +697,9 @@
                     "@type": "PhpMyAdmin\\SqlParser\\Parser",
                     "list": {
                         "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                        "count": 23,
+                        "idx": 23,
                         "tokens": [
-                            {
-                                "@type": "@26"
-                            },
-                            {
-                                "@type": "@27"
-                            },
-                            {
-                                "@type": "@28"
-                            },
-                            {
-                                "@type": "@29"
-                            },
-                            {
-                                "@type": "@30"
-                            },
                             {
                                 "@type": "@31"
                             },
@@ -660,10 +753,23 @@
                             },
                             {
                                 "@type": "@48"
+                            },
+                            {
+                                "@type": "@49"
+                            },
+                            {
+                                "@type": "@50"
+                            },
+                            {
+                                "@type": "@51"
+                            },
+                            {
+                                "@type": "@52"
+                            },
+                            {
+                                "@type": "@54"
                             }
-                        ],
-                        "count": 23,
-                        "idx": 23
+                        ]
                     },
                     "statements": [
                         {

--- a/tests/data/parser/parseWithStatementErr.out
+++ b/tests/data/parser/parseWithStatementErr.out
@@ -7,13 +7,19 @@
         "last": 93,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 37,
+            "idx": 38,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +85,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 23
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -85,7 +107,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +131,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -112,7 +142,11 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 36
                 },
@@ -121,7 +155,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -130,7 +166,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 38
                 },
@@ -139,7 +177,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -148,7 +188,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 41
                 },
@@ -157,7 +199,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -166,7 +210,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 43
                 },
@@ -175,7 +221,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -184,7 +232,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -193,7 +245,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -202,7 +256,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 52
                 },
@@ -211,7 +267,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 61
                 },
@@ -220,7 +278,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 62
                 },
@@ -229,7 +289,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -238,7 +300,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@26"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -247,7 +311,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -256,7 +322,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@17"
+                    },
                     "flags": 16,
                     "position": 71
                 },
@@ -265,7 +333,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -274,7 +344,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 73
                 },
@@ -283,7 +355,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -292,7 +366,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 80
                 },
@@ -301,7 +377,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 84
                 },
@@ -310,7 +388,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 85
                 },
@@ -319,7 +399,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -328,7 +410,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 90
                 },
@@ -337,13 +421,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 37,
-            "idx": 38
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -417,35 +503,35 @@
             [
                 "Unexpected token.",
                 {
-                    "@type": "@12"
+                    "@type": "@15"
                 },
                 0
             ],
             [
                 "Unexpected end of the WITH CTE.",
                 {
-                    "@type": "@12"
+                    "@type": "@15"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@12"
+                    "@type": "@15"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@12"
+                    "@type": "@15"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@15"
+                    "@type": "@19"
                 },
                 0
             ]

--- a/tests/data/parser/parseWithStatementErr1.out
+++ b/tests/data/parser/parseWithStatementErr1.out
@@ -7,13 +7,19 @@
         "last": 92,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 36,
+            "idx": 36,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "table",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +85,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +107,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +131,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -121,7 +155,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +177,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 40
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -157,7 +199,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 42
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -175,7 +221,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -193,7 +245,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 51
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -211,7 +267,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 61
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -229,7 +289,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 69
                 },
@@ -247,7 +311,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 70
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -265,7 +333,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 72
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 78
                 },
@@ -283,7 +355,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 79
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 83
                 },
@@ -301,7 +377,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 84
                 },
@@ -310,7 +388,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 88
                 },
@@ -319,7 +399,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 89
                 },
@@ -328,13 +410,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 36,
-            "idx": 36
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -540,21 +624,21 @@
             [
                 "AS keyword was expected.",
                 {
-                    "@type": "@16"
+                    "@type": "@20"
                 },
                 0
             ],
             [
                 "Unexpected end of the WITH CTE.",
                 {
-                    "@type": "@16"
+                    "@type": "@20"
                 },
                 0
             ],
             [
                 "This type of clause was previously parsed.",
                 {
-                    "@type": "@30"
+                    "@type": "@35"
                 },
                 0
             ]

--- a/tests/data/parser/parseWithStatementErr2.out
+++ b/tests/data/parser/parseWithStatementErr2.out
@@ -7,13 +7,19 @@
         "last": 50,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 24,
+            "idx": 24,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -67,7 +89,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -85,7 +111,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 16
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -103,7 +133,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -121,7 +155,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -139,7 +177,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -157,7 +201,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 30
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -175,7 +223,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -193,7 +245,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -211,7 +267,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 49
                 },
@@ -220,13 +278,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 24,
-            "idx": 24
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -260,19 +320,9 @@
                             "@type": "PhpMyAdmin\\SqlParser\\Parser",
                             "list": {
                                 "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                "count": 11,
+                                "idx": 11,
                                 "tokens": [
-                                    {
-                                        "@type": "@13"
-                                    },
-                                    {
-                                        "@type": "@14"
-                                    },
-                                    {
-                                        "@type": "@15"
-                                    },
-                                    {
-                                        "@type": "@16"
-                                    },
                                     {
                                         "@type": "@17"
                                     },
@@ -286,17 +336,27 @@
                                         "@type": "@20"
                                     },
                                     {
-                                        "@type": "@21"
-                                    },
-                                    {
                                         "@type": "@22"
                                     },
                                     {
                                         "@type": "@23"
+                                    },
+                                    {
+                                        "@type": "@24"
+                                    },
+                                    {
+                                        "@type": "@25"
+                                    },
+                                    {
+                                        "@type": "@26"
+                                    },
+                                    {
+                                        "@type": "@27"
+                                    },
+                                    {
+                                        "@type": "@28"
                                     }
-                                ],
-                                "count": 11,
-                                "idx": 11
+                                ]
                             },
                             "statements": [
                                 {
@@ -399,14 +459,14 @@
             [
                 "An expression was expected.",
                 {
-                    "@type": "@25"
+                    "@type": "@30"
                 },
                 0
             ],
             [
                 "Unexpected end of the WITH CTE.",
                 {
-                    "@type": "@25"
+                    "@type": "@30"
                 },
                 0
             ]

--- a/tests/data/parser/parseWithStatementErr3.out
+++ b/tests/data/parser/parseWithStatementErr3.out
@@ -7,13 +7,19 @@
         "last": 75,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 31,
+            "idx": 31,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "table",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +85,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +107,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +131,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -121,7 +155,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +177,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -157,7 +199,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -175,7 +221,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -193,7 +243,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -211,7 +267,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 54
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -229,7 +289,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 64
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -247,7 +311,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -265,7 +333,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 73
                 },
@@ -274,7 +344,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 74
                 },
@@ -283,13 +355,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 31,
-            "idx": 31
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -337,19 +411,9 @@
                                 "@type": "PhpMyAdmin\\SqlParser\\Parser",
                                 "list": {
                                     "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                    "count": 11,
+                                    "idx": 11,
                                     "tokens": [
-                                        {
-                                            "@type": "@19"
-                                        },
-                                        {
-                                            "@type": "@20"
-                                        },
-                                        {
-                                            "@type": "@21"
-                                        },
-                                        {
-                                            "@type": "@22"
-                                        },
                                         {
                                             "@type": "@23"
                                         },
@@ -363,17 +427,27 @@
                                             "@type": "@26"
                                         },
                                         {
-                                            "@type": "@27"
-                                        },
-                                        {
                                             "@type": "@28"
                                         },
                                         {
                                             "@type": "@29"
+                                        },
+                                        {
+                                            "@type": "@30"
+                                        },
+                                        {
+                                            "@type": "@31"
+                                        },
+                                        {
+                                            "@type": "@32"
+                                        },
+                                        {
+                                            "@type": "@33"
+                                        },
+                                        {
+                                            "@type": "@34"
                                         }
-                                    ],
-                                    "count": 11,
-                                    "idx": 11
+                                    ]
                                 },
                                 "statements": [
                                     {
@@ -496,14 +570,14 @@
             [
                 "The name of the CTE was expected.",
                 {
-                    "@type": "@32"
+                    "@type": "@37"
                 },
                 0
             ],
             [
                 "Unexpected end of the WITH CTE.",
                 {
-                    "@type": "@32"
+                    "@type": "@37"
                 },
                 0
             ]

--- a/tests/data/parser/parseWithStatementErr4.out
+++ b/tests/data/parser/parseWithStatementErr4.out
@@ -7,13 +7,19 @@
         "last": 77,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 32,
+            "idx": 33,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "table",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +85,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +107,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 32
                 },
@@ -103,7 +131,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 33
                 },
@@ -112,7 +144,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 34
                 },
@@ -121,7 +155,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 38
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -139,7 +177,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 42
                 },
@@ -157,7 +199,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 43
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -175,7 +221,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 45
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 51
                 },
@@ -193,7 +243,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 52
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 53
                 },
@@ -211,7 +267,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 54
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -229,7 +289,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 64
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -247,7 +311,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@27"
+                    },
                     "flags": 0,
                     "position": 71
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 72
                 },
@@ -265,7 +333,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 73
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -283,7 +355,9 @@
                     "token": "NO",
                     "value": "NO",
                     "keyword": "NO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 75
                 },
@@ -292,13 +366,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 32,
-            "idx": 33
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -346,19 +422,9 @@
                                 "@type": "PhpMyAdmin\\SqlParser\\Parser",
                                 "list": {
                                     "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                    "count": 11,
+                                    "idx": 11,
                                     "tokens": [
-                                        {
-                                            "@type": "@19"
-                                        },
-                                        {
-                                            "@type": "@20"
-                                        },
-                                        {
-                                            "@type": "@21"
-                                        },
-                                        {
-                                            "@type": "@22"
-                                        },
                                         {
                                             "@type": "@23"
                                         },
@@ -372,17 +438,27 @@
                                             "@type": "@26"
                                         },
                                         {
-                                            "@type": "@27"
-                                        },
-                                        {
                                             "@type": "@28"
                                         },
                                         {
                                             "@type": "@29"
+                                        },
+                                        {
+                                            "@type": "@30"
+                                        },
+                                        {
+                                            "@type": "@31"
+                                        },
+                                        {
+                                            "@type": "@32"
+                                        },
+                                        {
+                                            "@type": "@33"
+                                        },
+                                        {
+                                            "@type": "@34"
                                         }
-                                    ],
-                                    "count": 11,
-                                    "idx": 11
+                                    ]
                                 },
                                 "statements": [
                                     {
@@ -505,21 +581,21 @@
             [
                 "An expression was expected.",
                 {
-                    "@type": "@32"
+                    "@type": "@37"
                 },
                 0
             ],
             [
                 "Unexpected end of the WITH CTE.",
                 {
-                    "@type": "@32"
+                    "@type": "@37"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@32"
+                    "@type": "@37"
                 },
                 0
             ]

--- a/tests/data/parser/parseWithStatementErr5.out
+++ b/tests/data/parser/parseWithStatementErr5.out
@@ -7,13 +7,19 @@
         "last": 73,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 30,
+            "idx": 31,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "table",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 12
                 },
@@ -49,7 +63,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 13
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 23
                 },
@@ -67,7 +85,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 24
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -85,7 +107,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 29
                 },
@@ -94,7 +120,11 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -103,7 +133,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 34
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 35
                 },
@@ -121,7 +155,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 36
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -139,7 +177,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 39
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 40
                 },
@@ -157,7 +199,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 41
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -175,7 +221,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 49
                 },
@@ -193,7 +245,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 50
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 59
                 },
@@ -211,7 +267,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 60
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -229,7 +289,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 67
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -247,7 +311,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 16,
                     "position": 69
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 70
                 },
@@ -265,7 +333,9 @@
                     "token": "NO",
                     "value": "NO",
                     "keyword": "NO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 71
                 },
@@ -274,13 +344,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 30,
-            "idx": 31
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -349,28 +421,28 @@
             [
                 "The name of the CTE was expected.",
                 {
-                    "@type": "@10"
+                    "@type": "@12"
                 },
                 0
             ],
             [
                 "Unexpected end of the WITH CTE.",
                 {
-                    "@type": "@10"
+                    "@type": "@12"
                 },
                 0
             ],
             [
                 "Unexpected beginning of statement.",
                 {
-                    "@type": "@11"
+                    "@type": "@14"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@14"
+                    "@type": "@18"
                 },
                 0
             ]

--- a/tests/data/parser/parseWithStatementErr6.out
+++ b/tests/data/parser/parseWithStatementErr6.out
@@ -7,13 +7,19 @@
         "last": 186,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 70,
+            "idx": 71,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 35,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 6
                 },
@@ -31,7 +41,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 7
                 },
@@ -40,7 +52,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 11
                 },
@@ -49,7 +63,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 12
                 },
@@ -58,7 +74,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -67,7 +85,9 @@
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 23
                 },
@@ -76,7 +96,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -85,7 +107,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -94,7 +120,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 31
                 },
@@ -103,7 +131,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 32
                 },
@@ -112,7 +144,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -121,7 +155,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 37
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 38
                 },
@@ -139,7 +177,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 39
                 },
@@ -148,7 +188,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 41
                 },
@@ -157,7 +199,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 42
                 },
@@ -166,7 +210,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -175,7 +221,9 @@
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 44
                 },
@@ -184,7 +232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -193,7 +243,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 51
                 },
@@ -202,7 +254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -211,7 +265,9 @@
                     "token": "table_name",
                     "value": "table_name",
                     "keyword": "TABLE_NAME",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 56
                 },
@@ -220,7 +276,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -229,7 +287,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 67
                 },
@@ -238,7 +298,9 @@
                     "token": "column1",
                     "value": "column1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 68
                 },
@@ -247,7 +309,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 75
                 },
@@ -256,7 +320,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 76
                 },
@@ -265,7 +331,9 @@
                     "token": "column2",
                     "value": "column2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -274,7 +342,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 84
                 },
@@ -283,7 +353,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 85
                 },
@@ -292,7 +364,9 @@
                     "token": "column3",
                     "value": "column3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 86
                 },
@@ -301,7 +375,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 93
                 },
@@ -310,7 +386,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 94
                 },
@@ -319,7 +397,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 35,
                     "position": 95
                 },
@@ -328,7 +408,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 101
                 },
@@ -337,7 +419,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 102
                 },
@@ -346,7 +430,9 @@
                     "token": "value1",
                     "value": "value1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 103
                 },
@@ -355,7 +441,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 109
                 },
@@ -364,7 +452,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 110
                 },
@@ -373,7 +463,9 @@
                     "token": "value2",
                     "value": "value2",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 111
                 },
@@ -382,7 +474,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 117
                 },
@@ -391,7 +485,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 118
                 },
@@ -400,7 +496,9 @@
                     "token": "value3",
                     "value": "value3",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 119
                 },
@@ -409,7 +507,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 125
                 },
@@ -418,7 +518,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -427,7 +529,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 16,
                     "position": 127
                 },
@@ -436,7 +540,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 128
                 },
@@ -445,7 +551,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 129
                 },
@@ -454,7 +562,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 135
                 },
@@ -463,7 +573,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 136
                 },
@@ -472,7 +584,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 140
                 },
@@ -481,7 +595,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 141
                 },
@@ -490,7 +606,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 145
                 },
@@ -499,7 +617,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 146
                 },
@@ -508,7 +628,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 149
                 },
@@ -517,7 +639,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 150
                 },
@@ -526,7 +650,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 152
                 },
@@ -535,7 +661,9 @@
                     "token": "DUPLICATE",
                     "value": "DUPLICATE",
                     "keyword": "DUPLICATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 1,
                     "position": 153
                 },
@@ -544,7 +672,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 162
                 },
@@ -553,7 +683,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 19,
                     "position": 163
                 },
@@ -562,7 +694,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 166
                 },
@@ -571,7 +705,9 @@
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 167
                 },
@@ -580,7 +716,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 173
                 },
@@ -589,7 +727,9 @@
                     "token": "col_name",
                     "value": "col_name",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@13"
+                    },
                     "flags": 0,
                     "position": 174
                 },
@@ -598,7 +738,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 182
                 },
@@ -607,7 +749,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@16"
+                    },
                     "flags": 2,
                     "position": 183
                 },
@@ -616,7 +760,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 184
                 },
@@ -625,7 +771,11 @@
                     "token": "3",
                     "value": 3,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 185
                 },
@@ -634,13 +784,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 70,
-            "idx": 71
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -821,35 +973,35 @@
             [
                 "Subquery of the CTE was expected.",
                 {
-                    "@type": "@18"
+                    "@type": "@22"
                 },
                 0
             ],
             [
                 "Unexpected end of the WITH CTE.",
                 {
-                    "@type": "@18"
+                    "@type": "@22"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@18"
+                    "@type": "@22"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@48"
+                    "@type": "@52"
                 },
                 0
             ],
             [
                 "Unrecognized statement type.",
                 {
-                    "@type": "@58"
+                    "@type": "@62"
                 },
                 0
             ]

--- a/tests/data/parser/parseWithStatementErr7.out
+++ b/tests/data/parser/parseWithStatementErr7.out
@@ -7,13 +7,19 @@
         "last": 69,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 34,
+            "idx": 34,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -67,7 +89,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -85,7 +111,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 16
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -103,7 +133,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -121,7 +155,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -139,7 +177,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -157,7 +201,9 @@
                     "token": "UNN",
                     "value": "UNN",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 30
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 33
                 },
@@ -175,7 +223,9 @@
                     "token": "ALL",
                     "value": "ALL",
                     "keyword": "ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 34
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 37
                 },
@@ -193,7 +245,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 38
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 44
                 },
@@ -211,7 +267,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 45
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -229,7 +289,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 47
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -247,7 +311,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 49
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 55
                 },
@@ -265,7 +333,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 56
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 60
                 },
@@ -283,7 +355,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 61
                 },
@@ -292,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -301,7 +377,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -310,13 +388,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 34,
-            "idx": 34
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -414,21 +494,21 @@
             [
                 "Unrecognized keyword.",
                 {
-                    "@type": "@20"
+                    "@type": "@25"
                 },
                 0
             ],
             [
                 "This type of clause was previously parsed.",
                 {
-                    "@type": "@22"
+                    "@type": "@27"
                 },
                 0
             ],
             [
                 "Unexpected end of the WITH CTE.",
                 {
-                    "@type": "@26"
+                    "@type": "@31"
                 },
                 0
             ]

--- a/tests/data/parser/parseWithStatementErr8.out
+++ b/tests/data/parser/parseWithStatementErr8.out
@@ -7,13 +7,19 @@
         "last": 69,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 32,
+            "idx": 32,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "WITH",
                     "value": "WITH",
                     "keyword": "WITH",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 3,
                     "position": 0
                 },
@@ -22,7 +28,11 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 4
                 },
@@ -31,7 +41,11 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 5
                 },
@@ -40,7 +54,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 8
                 },
@@ -49,7 +65,11 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 16,
                     "position": 9
                 },
@@ -58,7 +78,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 10
                 },
@@ -67,7 +89,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 14
                 },
@@ -76,7 +100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 15
                 },
@@ -85,7 +111,9 @@
                     "token": "AS",
                     "value": "AS",
                     "keyword": "AS",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 16
                 },
@@ -94,7 +122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 18
                 },
@@ -103,7 +133,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 19
                 },
@@ -112,7 +144,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 20
                 },
@@ -121,7 +155,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 21
                 },
@@ -130,7 +166,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 27
                 },
@@ -139,7 +177,11 @@
                     "token": "1",
                     "value": 1,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 28
                 },
@@ -148,7 +190,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 29
                 },
@@ -157,7 +201,9 @@
                     "token": "UNION ALL",
                     "value": "UNION ALL",
                     "keyword": "UNION ALL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 7,
                     "position": 30
                 },
@@ -166,7 +212,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 39
                 },
@@ -175,7 +223,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 40
                 },
@@ -184,7 +234,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 46
                 },
@@ -193,7 +245,9 @@
                     "token": "2",
                     "value": 2,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@21"
+                    },
                     "flags": 0,
                     "position": 47
                 },
@@ -202,7 +256,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 48
                 },
@@ -211,7 +267,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@10"
+                    },
                     "flags": 16,
                     "position": 49
                 },
@@ -220,7 +278,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 50
                 },
@@ -229,7 +289,9 @@
                     "token": "SELECT",
                     "value": "SELECT",
                     "keyword": "SELECT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@3"
+                    },
                     "flags": 3,
                     "position": 51
                 },
@@ -238,7 +300,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 57
                 },
@@ -247,7 +311,9 @@
                     "token": "col1",
                     "value": "col1",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 58
                 },
@@ -256,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 62
                 },
@@ -265,7 +333,9 @@
                     "token": "FR",
                     "value": "FR",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 63
                 },
@@ -274,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@5"
+                    },
                     "flags": 0,
                     "position": 65
                 },
@@ -283,7 +355,9 @@
                     "token": "cte",
                     "value": "cte",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@7"
+                    },
                     "flags": 0,
                     "position": 66
                 },
@@ -292,13 +366,15 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 32,
-            "idx": 32
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -332,19 +408,9 @@
                             "@type": "PhpMyAdmin\\SqlParser\\Parser",
                             "list": {
                                 "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+                                "count": 11,
+                                "idx": 11,
                                 "tokens": [
-                                    {
-                                        "@type": "@13"
-                                    },
-                                    {
-                                        "@type": "@14"
-                                    },
-                                    {
-                                        "@type": "@15"
-                                    },
-                                    {
-                                        "@type": "@16"
-                                    },
                                     {
                                         "@type": "@17"
                                     },
@@ -358,17 +424,27 @@
                                         "@type": "@20"
                                     },
                                     {
-                                        "@type": "@21"
-                                    },
-                                    {
                                         "@type": "@22"
                                     },
                                     {
                                         "@type": "@23"
+                                    },
+                                    {
+                                        "@type": "@24"
+                                    },
+                                    {
+                                        "@type": "@25"
+                                    },
+                                    {
+                                        "@type": "@26"
+                                    },
+                                    {
+                                        "@type": "@27"
+                                    },
+                                    {
+                                        "@type": "@28"
                                     }
-                                ],
-                                "count": 11,
-                                "idx": 11
+                                ]
                             },
                             "statements": [
                                 {
@@ -506,28 +582,28 @@
             [
                 "An alias was previously found.",
                 {
-                    "@type": "@32"
+                    "@type": "@37"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@32"
+                    "@type": "@37"
                 },
                 0
             ],
             [
                 "An alias was previously found.",
                 {
-                    "@type": "@32"
+                    "@type": "@37"
                 },
                 0
             ],
             [
                 "Unexpected token.",
                 {
-                    "@type": "@32"
+                    "@type": "@37"
                 },
                 0
             ]

--- a/tests/data/parser/parsephpMyAdminExport1.out
+++ b/tests/data/parser/parsephpMyAdminExport1.out
@@ -14,13 +14,19 @@
         "last": 2635,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "count": 505,
+            "idx": 505,
             "tokens": [
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": "-- phpMyAdmin SQL Dump",
                     "value": "-- phpMyAdmin SQL Dump",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Comment",
+                        "value": 4
+                    },
                     "flags": 4,
                     "position": 0
                 },
@@ -29,7 +35,11 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Whitespace",
+                        "value": 3
+                    },
                     "flags": 0,
                     "position": 22
                 },
@@ -38,7 +48,9 @@
                     "token": "-- version 5.0.0-dev",
                     "value": "-- version 5.0.0-dev",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 23
                 },
@@ -47,7 +59,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 43
                 },
@@ -56,7 +70,9 @@
                     "token": "-- https://www.phpmyadmin.net/",
                     "value": "-- https://www.phpmyadmin.net/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 44
                 },
@@ -65,7 +81,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 74
                 },
@@ -74,7 +92,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 75
                 },
@@ -83,7 +103,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 77
                 },
@@ -92,7 +114,9 @@
                     "token": "-- Hôte : xxxx.xxxxx.eu-west-1.rds.amazonaws.com",
                     "value": "-- Hôte : xxxx.xxxxx.eu-west-1.rds.amazonaws.com",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 78
                 },
@@ -101,7 +125,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 126
                 },
@@ -110,7 +136,9 @@
                     "token": "-- Généré le :  mer. 05 sep. 2018 à 00:03",
                     "value": "-- Généré le :  mer. 05 sep. 2018 à 00:03",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 127
                 },
@@ -119,7 +147,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 168
                 },
@@ -128,7 +158,9 @@
                     "token": "-- Version du serveur :  10.0.24-MariaDB",
                     "value": "-- Version du serveur :  10.0.24-MariaDB",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 169
                 },
@@ -137,7 +169,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 209
                 },
@@ -146,7 +180,9 @@
                     "token": "-- Version de PHP :  7.2.8-1+ubuntu18.04.1+deb.sury.org+1",
                     "value": "-- Version de PHP :  7.2.8-1+ubuntu18.04.1+deb.sury.org+1",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 210
                 },
@@ -155,7 +191,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 267
                 },
@@ -164,7 +202,11 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Keyword",
+                        "value": 1
+                    },
                     "flags": 11,
                     "position": 269
                 },
@@ -173,7 +215,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 272
                 },
@@ -182,7 +226,11 @@
                     "token": "SQL_MODE",
                     "value": "SQL_MODE",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "None",
+                        "value": 0
+                    },
                     "flags": 0,
                     "position": 273
                 },
@@ -191,7 +239,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 281
                 },
@@ -200,7 +250,11 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Operator",
+                        "value": 2
+                    },
                     "flags": 2,
                     "position": 282
                 },
@@ -209,7 +263,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 283
                 },
@@ -218,7 +274,11 @@
                     "token": "\"NO_AUTO_VALUE_ON_ZERO\"",
                     "value": "NO_AUTO_VALUE_ON_ZERO",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "String",
+                        "value": 7
+                    },
                     "flags": 2,
                     "position": 284
                 },
@@ -227,7 +287,11 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Delimiter",
+                        "value": 9
+                    },
                     "flags": 0,
                     "position": 307
                 },
@@ -236,7 +300,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 308
                 },
@@ -245,7 +311,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 11,
                     "position": 309
                 },
@@ -254,7 +322,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 312
                 },
@@ -263,7 +333,9 @@
                     "token": "AUTOCOMMIT",
                     "value": "AUTOCOMMIT",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 313
                 },
@@ -272,7 +344,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 323
                 },
@@ -281,7 +355,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 324
                 },
@@ -290,7 +366,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 325
                 },
@@ -299,7 +377,11 @@
                     "token": "0",
                     "value": 0,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Number",
+                        "value": 6
+                    },
                     "flags": 0,
                     "position": 326
                 },
@@ -308,7 +390,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 327
                 },
@@ -317,7 +401,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 328
                 },
@@ -326,7 +412,9 @@
                     "token": "START TRANSACTION",
                     "value": "START TRANSACTION",
                     "keyword": "START TRANSACTION",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 7,
                     "position": 329
                 },
@@ -335,7 +423,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 346
                 },
@@ -344,7 +434,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 347
                 },
@@ -353,7 +445,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 11,
                     "position": 348
                 },
@@ -362,7 +456,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 351
                 },
@@ -371,7 +467,9 @@
                     "token": "time_zone",
                     "value": "time_zone",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 352
                 },
@@ -380,7 +478,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 361
                 },
@@ -389,7 +489,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 362
                 },
@@ -398,7 +500,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 363
                 },
@@ -407,7 +511,9 @@
                     "token": "\"+00:00\"",
                     "value": "+00:00",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 2,
                     "position": 364
                 },
@@ -416,7 +522,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 372
                 },
@@ -425,7 +533,9 @@
                     "token": "\n\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 373
                 },
@@ -434,7 +544,9 @@
                     "token": "/*!40101",
                     "value": "/*!40101",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 10,
                     "position": 376
                 },
@@ -443,7 +555,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 384
                 },
@@ -452,7 +566,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 11,
                     "position": 385
                 },
@@ -461,7 +577,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 388
                 },
@@ -470,7 +588,11 @@
                     "token": "@OLD_CHARACTER_SET_CLIENT",
                     "value": "OLD_CHARACTER_SET_CLIENT",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "PhpMyAdmin\\SqlParser\\TokenType",
+                        "name": "Symbol",
+                        "value": 8
+                    },
                     "flags": 1,
                     "position": 389
                 },
@@ -479,7 +601,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 414
                 },
@@ -488,7 +612,9 @@
                     "token": "@@CHARACTER_SET_CLIENT",
                     "value": "CHARACTER_SET_CLIENT",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 9,
                     "position": 415
                 },
@@ -497,7 +623,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 437
                 },
@@ -506,7 +634,9 @@
                     "token": "*/",
                     "value": "*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 2,
                     "position": 438
                 },
@@ -515,7 +645,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 440
                 },
@@ -524,7 +656,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 441
                 },
@@ -533,7 +667,9 @@
                     "token": "/*!40101",
                     "value": "/*!40101",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 10,
                     "position": 442
                 },
@@ -542,7 +678,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 450
                 },
@@ -551,7 +689,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 11,
                     "position": 451
                 },
@@ -560,7 +700,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 454
                 },
@@ -569,7 +711,9 @@
                     "token": "@OLD_CHARACTER_SET_RESULTS",
                     "value": "OLD_CHARACTER_SET_RESULTS",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 1,
                     "position": 455
                 },
@@ -578,7 +722,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 481
                 },
@@ -587,7 +733,9 @@
                     "token": "@@CHARACTER_SET_RESULTS",
                     "value": "CHARACTER_SET_RESULTS",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 9,
                     "position": 482
                 },
@@ -596,7 +744,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 505
                 },
@@ -605,7 +755,9 @@
                     "token": "*/",
                     "value": "*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 2,
                     "position": 506
                 },
@@ -614,7 +766,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 508
                 },
@@ -623,7 +777,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 509
                 },
@@ -632,7 +788,9 @@
                     "token": "/*!40101",
                     "value": "/*!40101",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 10,
                     "position": 510
                 },
@@ -641,7 +799,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 518
                 },
@@ -650,7 +810,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 11,
                     "position": 519
                 },
@@ -659,7 +821,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 522
                 },
@@ -668,7 +832,9 @@
                     "token": "@OLD_COLLATION_CONNECTION",
                     "value": "OLD_COLLATION_CONNECTION",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 1,
                     "position": 523
                 },
@@ -677,7 +843,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 548
                 },
@@ -686,7 +854,9 @@
                     "token": "@@COLLATION_CONNECTION",
                     "value": "COLLATION_CONNECTION",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 9,
                     "position": 549
                 },
@@ -695,7 +865,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 571
                 },
@@ -704,7 +876,9 @@
                     "token": "*/",
                     "value": "*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 2,
                     "position": 572
                 },
@@ -713,7 +887,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 574
                 },
@@ -722,7 +898,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 575
                 },
@@ -731,7 +909,9 @@
                     "token": "/*!40101",
                     "value": "/*!40101",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 10,
                     "position": 576
                 },
@@ -740,7 +920,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 584
                 },
@@ -749,7 +931,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 11,
                     "position": 585
                 },
@@ -758,7 +942,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 588
                 },
@@ -767,7 +953,9 @@
                     "token": "NAMES",
                     "value": "NAMES",
                     "keyword": "NAMES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 589
                 },
@@ -776,7 +964,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 594
                 },
@@ -785,7 +975,9 @@
                     "token": "utf8mb4",
                     "value": "utf8mb4",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 595
                 },
@@ -794,7 +986,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 602
                 },
@@ -803,7 +997,9 @@
                     "token": "*/",
                     "value": "*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 2,
                     "position": 603
                 },
@@ -812,7 +1008,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 605
                 },
@@ -821,7 +1019,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 606
                 },
@@ -830,7 +1030,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 608
                 },
@@ -839,7 +1041,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 610
                 },
@@ -848,7 +1052,9 @@
                     "token": "-- Base de données :  `xxxxxdbnamexxxxx`",
                     "value": "-- Base de données :  `xxxxxdbnamexxxxx`",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 611
                 },
@@ -857,7 +1063,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 651
                 },
@@ -866,7 +1074,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 652
                 },
@@ -875,7 +1085,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 654
                 },
@@ -884,7 +1096,9 @@
                     "token": "-- --------------------------------------------------------",
                     "value": "-- --------------------------------------------------------",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 656
                 },
@@ -893,7 +1107,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 715
                 },
@@ -902,7 +1118,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 717
                 },
@@ -911,7 +1129,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 719
                 },
@@ -920,7 +1140,9 @@
                     "token": "-- Structure de la table `monitoring__times`",
                     "value": "-- Structure de la table `monitoring__times`",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 720
                 },
@@ -929,7 +1151,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 764
                 },
@@ -938,7 +1162,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 765
                 },
@@ -947,7 +1173,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 767
                 },
@@ -956,7 +1184,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 769
                 },
@@ -965,7 +1195,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 775
                 },
@@ -974,7 +1206,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 776
                 },
@@ -983,7 +1217,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 781
                 },
@@ -992,7 +1228,9 @@
                     "token": "`monitoring__times`",
                     "value": "monitoring__times",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 782
                 },
@@ -1001,7 +1239,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 801
                 },
@@ -1010,7 +1250,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 802
                 },
@@ -1019,7 +1261,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 803
                 },
@@ -1028,7 +1272,9 @@
                     "token": "`idServer`",
                     "value": "idServer",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 806
                 },
@@ -1037,7 +1283,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 816
                 },
@@ -1046,7 +1294,9 @@
                     "token": "int",
                     "value": "INT",
                     "keyword": "INT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 11,
                     "position": 817
                 },
@@ -1055,7 +1305,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 820
                 },
@@ -1064,7 +1316,9 @@
                     "token": "11",
                     "value": 11,
                     "keyword": null,
-                    "type": 6,
+                    "type": {
+                        "@type": "@42"
+                    },
                     "flags": 0,
                     "position": 821
                 },
@@ -1073,7 +1327,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 823
                 },
@@ -1082,7 +1338,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 824
                 },
@@ -1091,7 +1349,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 825
                 },
@@ -1100,7 +1360,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 833
                 },
@@ -1109,7 +1371,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 7,
                     "position": 834
                 },
@@ -1118,7 +1382,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 842
                 },
@@ -1127,7 +1393,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 843
                 },
@@ -1136,7 +1404,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 850
                 },
@@ -1145,7 +1415,9 @@
                     "token": "'Id of server'",
                     "value": "Id of server",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 1,
                     "position": 851
                 },
@@ -1154,7 +1426,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 865
                 },
@@ -1163,7 +1437,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 866
                 },
@@ -1172,7 +1448,9 @@
                     "token": "`time`",
                     "value": "time",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 869
                 },
@@ -1181,7 +1459,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 875
                 },
@@ -1190,7 +1470,9 @@
                     "token": "timestamp",
                     "value": "timestamp",
                     "keyword": "TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 41,
                     "position": 876
                 },
@@ -1199,7 +1481,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 885
                 },
@@ -1208,7 +1492,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 7,
                     "position": 886
                 },
@@ -1217,7 +1503,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 894
                 },
@@ -1226,7 +1514,9 @@
                     "token": "DEFAULT",
                     "value": "DEFAULT",
                     "keyword": "DEFAULT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 35,
                     "position": 895
                 },
@@ -1235,7 +1525,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 902
                 },
@@ -1244,7 +1536,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 35,
                     "position": 903
                 },
@@ -1253,7 +1547,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 920
                 },
@@ -1262,7 +1558,9 @@
                     "token": "ON UPDATE",
                     "value": "ON UPDATE",
                     "keyword": "ON UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 7,
                     "position": 921
                 },
@@ -1271,7 +1569,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 930
                 },
@@ -1280,7 +1580,9 @@
                     "token": "CURRENT_TIMESTAMP",
                     "value": "CURRENT_TIMESTAMP",
                     "keyword": "CURRENT_TIMESTAMP",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 35,
                     "position": 931
                 },
@@ -1289,7 +1591,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 948
                 },
@@ -1298,7 +1602,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 949
                 },
@@ -1307,7 +1613,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 956
                 },
@@ -1316,7 +1624,9 @@
                     "token": "'Time UTC'",
                     "value": "Time UTC",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 1,
                     "position": 957
                 },
@@ -1325,7 +1635,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 967
                 },
@@ -1334,7 +1646,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 968
                 },
@@ -1343,7 +1657,9 @@
                     "token": "`totalTime`",
                     "value": "totalTime",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 971
                 },
@@ -1352,7 +1668,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 982
                 },
@@ -1361,7 +1679,9 @@
                     "token": "float",
                     "value": "FLOAT",
                     "keyword": "FLOAT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 11,
                     "position": 983
                 },
@@ -1370,7 +1690,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 988
                 },
@@ -1379,7 +1701,9 @@
                     "token": "UNSIGNED",
                     "value": "UNSIGNED",
                     "keyword": "UNSIGNED",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 989
                 },
@@ -1388,7 +1712,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 997
                 },
@@ -1397,7 +1723,9 @@
                     "token": "NOT NULL",
                     "value": "NOT NULL",
                     "keyword": "NOT NULL",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 7,
                     "position": 998
                 },
@@ -1406,7 +1734,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1006
                 },
@@ -1415,7 +1745,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 1007
                 },
@@ -1424,7 +1756,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1014
                 },
@@ -1433,7 +1767,9 @@
                     "token": "'Total time in ms'",
                     "value": "Total time in ms",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 1,
                     "position": 1015
                 },
@@ -1442,7 +1778,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1033
                 },
@@ -1451,7 +1789,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1034
                 },
@@ -1460,7 +1800,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1035
                 },
@@ -1469,7 +1811,9 @@
                     "token": "ENGINE",
                     "value": "ENGINE",
                     "keyword": "ENGINE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 1036
                 },
@@ -1478,7 +1822,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 1042
                 },
@@ -1487,7 +1833,9 @@
                     "token": "InnoDB",
                     "value": "InnoDB",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1043
                 },
@@ -1496,7 +1844,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1049
                 },
@@ -1505,7 +1855,9 @@
                     "token": "DEFAULT CHARSET",
                     "value": "DEFAULT CHARSET",
                     "keyword": "DEFAULT CHARSET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 7,
                     "position": 1050
                 },
@@ -1514,7 +1866,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 1065
                 },
@@ -1523,7 +1877,9 @@
                     "token": "utf8",
                     "value": "utf8",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1066
                 },
@@ -1532,7 +1888,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1070
                 },
@@ -1541,7 +1899,9 @@
                     "token": "COLLATE",
                     "value": "COLLATE",
                     "keyword": "COLLATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1071
                 },
@@ -1550,7 +1910,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 1078
                 },
@@ -1559,7 +1921,9 @@
                     "token": "utf8_unicode_ci",
                     "value": "utf8_unicode_ci",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1079
                 },
@@ -1568,7 +1932,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 1094
                 },
@@ -1577,7 +1943,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1095
                 },
@@ -1586,7 +1954,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 1097
                 },
@@ -1595,7 +1965,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1099
                 },
@@ -1604,7 +1976,9 @@
                     "token": "-- Déclencheurs `monitoring__times`",
                     "value": "-- Déclencheurs `monitoring__times`",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 1100
                 },
@@ -1613,7 +1987,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1135
                 },
@@ -1622,7 +1998,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 1136
                 },
@@ -1631,7 +2009,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1138
                 },
@@ -1640,7 +2020,9 @@
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1139
                 },
@@ -1649,7 +2031,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1148
                 },
@@ -1658,7 +2042,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 1149
                 },
@@ -1667,7 +2053,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1151
                 },
@@ -1676,7 +2064,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1152
                 },
@@ -1685,7 +2075,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1158
                 },
@@ -1694,7 +2086,9 @@
                     "token": "TRIGGER",
                     "value": "TRIGGER",
                     "keyword": "TRIGGER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1159
                 },
@@ -1703,7 +2097,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1166
                 },
@@ -1712,7 +2108,9 @@
                     "token": "`copyTimes`",
                     "value": "copyTimes",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1167
                 },
@@ -1721,7 +2119,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1178
                 },
@@ -1730,7 +2130,9 @@
                     "token": "AFTER",
                     "value": "AFTER",
                     "keyword": "AFTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 1179
                 },
@@ -1739,7 +2141,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1184
                 },
@@ -1748,7 +2152,9 @@
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 35,
                     "position": 1185
                 },
@@ -1757,7 +2163,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1191
                 },
@@ -1766,7 +2174,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1192
                 },
@@ -1775,7 +2185,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1194
                 },
@@ -1784,7 +2196,9 @@
                     "token": "`monitoring__times`",
                     "value": "monitoring__times",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1195
                 },
@@ -1793,7 +2207,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1214
                 },
@@ -1802,7 +2218,9 @@
                     "token": "FOR EACH ROW",
                     "value": "FOR EACH ROW",
                     "keyword": "FOR EACH ROW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 7,
                     "position": 1215
                 },
@@ -1811,7 +2229,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1227
                 },
@@ -1820,7 +2240,9 @@
                     "token": "INSERT",
                     "value": "INSERT",
                     "keyword": "INSERT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 35,
                     "position": 1228
                 },
@@ -1829,7 +2251,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1234
                 },
@@ -1838,7 +2262,9 @@
                     "token": "INTO",
                     "value": "INTO",
                     "keyword": "INTO",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1235
                 },
@@ -1847,7 +2273,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1239
                 },
@@ -1856,7 +2284,9 @@
                     "token": "monitoring__times_mirror",
                     "value": "monitoring__times_mirror",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1240
                 },
@@ -1865,7 +2295,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1264
                 },
@@ -1874,7 +2306,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1265
                 },
@@ -1883,7 +2317,9 @@
                     "token": "`idServer`",
                     "value": "idServer",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1266
                 },
@@ -1892,7 +2328,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1276
                 },
@@ -1901,7 +2339,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1277
                 },
@@ -1910,7 +2350,9 @@
                     "token": "`time`",
                     "value": "time",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1278
                 },
@@ -1919,7 +2361,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1284
                 },
@@ -1928,7 +2372,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1285
                 },
@@ -1937,7 +2383,9 @@
                     "token": "`totalTime`",
                     "value": "totalTime",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1286
                 },
@@ -1946,7 +2394,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1297
                 },
@@ -1955,7 +2405,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1298
                 },
@@ -1964,7 +2416,9 @@
                     "token": "VALUES",
                     "value": "VALUES",
                     "keyword": "VALUES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 35,
                     "position": 1299
                 },
@@ -1973,7 +2427,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1305
                 },
@@ -1982,7 +2438,9 @@
                     "token": "new",
                     "value": "new",
                     "keyword": "NEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 1306
                 },
@@ -1991,7 +2449,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1309
                 },
@@ -2000,7 +2460,9 @@
                     "token": "idServer",
                     "value": "idServer",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1310
                 },
@@ -2009,7 +2471,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1318
                 },
@@ -2018,7 +2482,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1319
                 },
@@ -2027,7 +2493,9 @@
                     "token": "new",
                     "value": "new",
                     "keyword": "NEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 1320
                 },
@@ -2036,7 +2504,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1323
                 },
@@ -2045,7 +2515,9 @@
                     "token": "time",
                     "value": "time",
                     "keyword": "TIME",
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1324
                 },
@@ -2054,7 +2526,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1328
                 },
@@ -2063,7 +2537,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1329
                 },
@@ -2072,7 +2548,9 @@
                     "token": "new",
                     "value": "new",
                     "keyword": "NEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 1330
                 },
@@ -2081,7 +2559,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1333
                 },
@@ -2090,7 +2570,9 @@
                     "token": "totalTime",
                     "value": "totalTime",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1334
                 },
@@ -2099,7 +2581,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1343
                 },
@@ -2108,7 +2592,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1344
                 },
@@ -2117,7 +2603,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 1345
                 },
@@ -2126,7 +2614,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1347
                 },
@@ -2135,7 +2625,9 @@
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1348
                 },
@@ -2144,7 +2636,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1357
                 },
@@ -2153,7 +2647,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 1358
                 },
@@ -2162,7 +2658,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1359
                 },
@@ -2171,7 +2669,9 @@
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1360
                 },
@@ -2180,7 +2680,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1369
                 },
@@ -2189,7 +2691,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 1370
                 },
@@ -2198,7 +2702,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1372
                 },
@@ -2207,7 +2713,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1373
                 },
@@ -2216,7 +2724,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1379
                 },
@@ -2225,7 +2735,9 @@
                     "token": "TRIGGER",
                     "value": "TRIGGER",
                     "keyword": "TRIGGER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1380
                 },
@@ -2234,7 +2746,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1387
                 },
@@ -2243,7 +2757,9 @@
                     "token": "`deleteTimes`",
                     "value": "deleteTimes",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1388
                 },
@@ -2252,7 +2768,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1401
                 },
@@ -2261,7 +2779,9 @@
                     "token": "AFTER",
                     "value": "AFTER",
                     "keyword": "AFTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 1402
                 },
@@ -2270,7 +2790,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1407
                 },
@@ -2279,7 +2801,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1408
                 },
@@ -2288,7 +2812,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1414
                 },
@@ -2297,7 +2823,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1415
                 },
@@ -2306,7 +2834,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1417
                 },
@@ -2315,7 +2845,9 @@
                     "token": "`monitoring__times`",
                     "value": "monitoring__times",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1418
                 },
@@ -2324,7 +2856,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1437
                 },
@@ -2333,7 +2867,9 @@
                     "token": "FOR EACH ROW",
                     "value": "FOR EACH ROW",
                     "keyword": "FOR EACH ROW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 7,
                     "position": 1438
                 },
@@ -2342,7 +2878,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1450
                 },
@@ -2351,7 +2889,9 @@
                     "token": "DELETE",
                     "value": "DELETE",
                     "keyword": "DELETE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1451
                 },
@@ -2360,7 +2900,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1457
                 },
@@ -2369,7 +2911,9 @@
                     "token": "FROM",
                     "value": "FROM",
                     "keyword": "FROM",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1458
                 },
@@ -2378,7 +2922,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1462
                 },
@@ -2387,7 +2933,9 @@
                     "token": "monitoring__times_mirror",
                     "value": "monitoring__times_mirror",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1463
                 },
@@ -2396,7 +2944,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1487
                 },
@@ -2405,7 +2955,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1488
                 },
@@ -2414,7 +2966,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1493
                 },
@@ -2423,7 +2977,9 @@
                     "token": "`idServer`",
                     "value": "idServer",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1494
                 },
@@ -2432,7 +2988,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 1504
                 },
@@ -2441,7 +2999,9 @@
                     "token": "old",
                     "value": "old",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1505
                 },
@@ -2450,7 +3010,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1508
                 },
@@ -2459,7 +3021,9 @@
                     "token": "idServer",
                     "value": "idServer",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1509
                 },
@@ -2468,7 +3032,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1517
                 },
@@ -2477,7 +3043,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1518
                 },
@@ -2486,7 +3054,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1521
                 },
@@ -2495,7 +3065,9 @@
                     "token": "`time`",
                     "value": "time",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1522
                 },
@@ -2504,7 +3076,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 1528
                 },
@@ -2513,7 +3087,9 @@
                     "token": "old",
                     "value": "old",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1529
                 },
@@ -2522,7 +3098,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1532
                 },
@@ -2531,7 +3109,9 @@
                     "token": "time",
                     "value": "time",
                     "keyword": "TIME",
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1533
                 },
@@ -2540,7 +3120,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1537
                 },
@@ -2549,7 +3131,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1538
                 },
@@ -2558,7 +3142,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1541
                 },
@@ -2567,7 +3153,9 @@
                     "token": "`totalTime`",
                     "value": "totalTime",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1542
                 },
@@ -2576,7 +3164,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 1553
                 },
@@ -2585,7 +3175,9 @@
                     "token": "old",
                     "value": "old",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1554
                 },
@@ -2594,7 +3186,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1557
                 },
@@ -2603,7 +3197,9 @@
                     "token": "totalTime",
                     "value": "totalTime",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1558
                 },
@@ -2612,7 +3208,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1567
                 },
@@ -2621,7 +3219,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 1568
                 },
@@ -2630,7 +3230,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1570
                 },
@@ -2639,7 +3241,9 @@
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1571
                 },
@@ -2648,7 +3252,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1580
                 },
@@ -2657,7 +3263,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 1581
                 },
@@ -2666,7 +3274,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1582
                 },
@@ -2675,7 +3285,9 @@
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1583
                 },
@@ -2684,7 +3296,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1592
                 },
@@ -2693,7 +3307,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 1593
                 },
@@ -2702,7 +3318,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1595
                 },
@@ -2711,7 +3329,9 @@
                     "token": "CREATE",
                     "value": "CREATE",
                     "keyword": "CREATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1596
                 },
@@ -2720,7 +3340,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1602
                 },
@@ -2729,7 +3351,9 @@
                     "token": "TRIGGER",
                     "value": "TRIGGER",
                     "keyword": "TRIGGER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1603
                 },
@@ -2738,7 +3362,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1610
                 },
@@ -2747,7 +3373,9 @@
                     "token": "`updateTimes`",
                     "value": "updateTimes",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1611
                 },
@@ -2756,7 +3384,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1624
                 },
@@ -2765,7 +3395,9 @@
                     "token": "AFTER",
                     "value": "AFTER",
                     "keyword": "AFTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 1625
                 },
@@ -2774,7 +3406,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1630
                 },
@@ -2783,7 +3417,9 @@
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1631
                 },
@@ -2792,7 +3428,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1637
                 },
@@ -2801,7 +3439,9 @@
                     "token": "ON",
                     "value": "ON",
                     "keyword": "ON",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1638
                 },
@@ -2810,7 +3450,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1640
                 },
@@ -2819,7 +3461,9 @@
                     "token": "`monitoring__times`",
                     "value": "monitoring__times",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1641
                 },
@@ -2828,7 +3472,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1660
                 },
@@ -2837,7 +3483,9 @@
                     "token": "FOR EACH ROW",
                     "value": "FOR EACH ROW",
                     "keyword": "FOR EACH ROW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 7,
                     "position": 1661
                 },
@@ -2846,7 +3494,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1673
                 },
@@ -2855,7 +3505,9 @@
                     "token": "UPDATE",
                     "value": "UPDATE",
                     "keyword": "UPDATE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1674
                 },
@@ -2864,7 +3516,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1680
                 },
@@ -2873,7 +3527,9 @@
                     "token": "monitoring__times_mirror",
                     "value": "monitoring__times_mirror",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1681
                 },
@@ -2882,7 +3538,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1705
                 },
@@ -2891,7 +3549,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 11,
                     "position": 1706
                 },
@@ -2900,7 +3560,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1709
                 },
@@ -2909,7 +3571,9 @@
                     "token": "`idServer`",
                     "value": "idServer",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1710
                 },
@@ -2918,7 +3582,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 1720
                 },
@@ -2927,7 +3593,9 @@
                     "token": "new",
                     "value": "new",
                     "keyword": "NEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 1721
                 },
@@ -2936,7 +3604,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1724
                 },
@@ -2945,7 +3615,9 @@
                     "token": "idServer",
                     "value": "idServer",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1725
                 },
@@ -2954,7 +3626,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1733
                 },
@@ -2963,7 +3637,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1734
                 },
@@ -2972,7 +3648,9 @@
                     "token": "`time`",
                     "value": "time",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1735
                 },
@@ -2981,7 +3659,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 1741
                 },
@@ -2990,7 +3670,9 @@
                     "token": "new",
                     "value": "new",
                     "keyword": "NEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 1742
                 },
@@ -2999,7 +3681,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1745
                 },
@@ -3008,7 +3692,9 @@
                     "token": "time",
                     "value": "time",
                     "keyword": "TIME",
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1746
                 },
@@ -3017,7 +3703,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1750
                 },
@@ -3026,7 +3714,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1751
                 },
@@ -3035,7 +3725,9 @@
                     "token": "`totalTime`",
                     "value": "totalTime",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1752
                 },
@@ -3044,7 +3736,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 1763
                 },
@@ -3053,7 +3747,9 @@
                     "token": "new",
                     "value": "new",
                     "keyword": "NEW",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 1764
                 },
@@ -3062,7 +3758,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1767
                 },
@@ -3071,7 +3769,9 @@
                     "token": "totalTime",
                     "value": "totalTime",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1768
                 },
@@ -3080,7 +3780,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1777
                 },
@@ -3089,7 +3791,9 @@
                     "token": "WHERE",
                     "value": "WHERE",
                     "keyword": "WHERE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1778
                 },
@@ -3098,7 +3802,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1783
                 },
@@ -3107,7 +3813,9 @@
                     "token": "`idServer`",
                     "value": "idServer",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1784
                 },
@@ -3116,7 +3824,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 1794
                 },
@@ -3125,7 +3835,9 @@
                     "token": "old",
                     "value": "old",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1795
                 },
@@ -3134,7 +3846,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1798
                 },
@@ -3143,7 +3857,9 @@
                     "token": "idServer",
                     "value": "idServer",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1799
                 },
@@ -3152,7 +3868,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1807
                 },
@@ -3161,7 +3879,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1808
                 },
@@ -3170,7 +3890,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1811
                 },
@@ -3179,7 +3901,9 @@
                     "token": "`time`",
                     "value": "time",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1812
                 },
@@ -3188,7 +3912,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 1818
                 },
@@ -3197,7 +3923,9 @@
                     "token": "old",
                     "value": "old",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1819
                 },
@@ -3206,7 +3934,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1822
                 },
@@ -3215,7 +3945,9 @@
                     "token": "time",
                     "value": "time",
                     "keyword": "TIME",
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1823
                 },
@@ -3224,7 +3956,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1827
                 },
@@ -3233,7 +3967,9 @@
                     "token": "AND",
                     "value": "AND",
                     "keyword": "AND",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1828
                 },
@@ -3242,7 +3978,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1831
                 },
@@ -3251,7 +3989,9 @@
                     "token": "`totalTime`",
                     "value": "totalTime",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1832
                 },
@@ -3260,7 +4000,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 1843
                 },
@@ -3269,7 +4011,9 @@
                     "token": "old",
                     "value": "old",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1844
                 },
@@ -3278,7 +4022,9 @@
                     "token": ".",
                     "value": ".",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 1847
                 },
@@ -3287,7 +4033,9 @@
                     "token": "totalTime",
                     "value": "totalTime",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1848
                 },
@@ -3296,7 +4044,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1857
                 },
@@ -3305,7 +4055,9 @@
                     "token": "$$",
                     "value": "$$",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 1858
                 },
@@ -3314,7 +4066,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1860
                 },
@@ -3323,7 +4077,9 @@
                     "token": "DELIMITER",
                     "value": "DELIMITER",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 1861
                 },
@@ -3332,7 +4088,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1870
                 },
@@ -3341,7 +4099,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 1871
                 },
@@ -3350,7 +4110,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1872
                 },
@@ -3359,7 +4121,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 1874
                 },
@@ -3368,7 +4132,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1876
                 },
@@ -3377,7 +4143,9 @@
                     "token": "-- Index pour les tables déchargées",
                     "value": "-- Index pour les tables déchargées",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 1877
                 },
@@ -3386,7 +4154,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1912
                 },
@@ -3395,7 +4165,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 1913
                 },
@@ -3404,7 +4176,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1915
                 },
@@ -3413,7 +4187,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 1917
                 },
@@ -3422,7 +4198,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1919
                 },
@@ -3431,7 +4209,9 @@
                     "token": "-- Index pour la table `monitoring__times`",
                     "value": "-- Index pour la table `monitoring__times`",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 1920
                 },
@@ -3440,7 +4220,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1962
                 },
@@ -3449,7 +4231,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 1963
                 },
@@ -3458,7 +4242,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1965
                 },
@@ -3467,7 +4253,9 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1966
                 },
@@ -3476,7 +4264,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1971
                 },
@@ -3485,7 +4275,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 1972
                 },
@@ -3494,7 +4286,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1977
                 },
@@ -3503,7 +4297,9 @@
                     "token": "`monitoring__times`",
                     "value": "monitoring__times",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 1978
                 },
@@ -3512,7 +4308,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 1997
                 },
@@ -3521,7 +4319,9 @@
                     "token": "ADD",
                     "value": "ADD",
                     "keyword": "ADD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 2000
                 },
@@ -3530,7 +4330,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2003
                 },
@@ -3539,7 +4341,9 @@
                     "token": "UNIQUE KEY",
                     "value": "UNIQUE KEY",
                     "keyword": "UNIQUE KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 23,
                     "position": 2004
                 },
@@ -3548,7 +4352,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2014
                 },
@@ -3557,7 +4363,9 @@
                     "token": "`idServer`",
                     "value": "idServer",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 2015
                 },
@@ -3566,7 +4374,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2025
                 },
@@ -3575,7 +4385,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 2026
                 },
@@ -3584,7 +4396,9 @@
                     "token": "`idServer`",
                     "value": "idServer",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 2027
                 },
@@ -3593,7 +4407,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 2037
                 },
@@ -3602,7 +4418,9 @@
                     "token": "`time`",
                     "value": "time",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 2038
                 },
@@ -3611,7 +4429,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 2044
                 },
@@ -3620,7 +4440,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2045
                 },
@@ -3629,7 +4451,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 2046
                 },
@@ -3638,7 +4462,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2051
                 },
@@ -3647,7 +4473,9 @@
                     "token": "BTREE",
                     "value": "BTREE",
                     "keyword": "BTREE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 2052
                 },
@@ -3656,7 +4484,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2057
                 },
@@ -3665,7 +4495,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 2058
                 },
@@ -3674,7 +4506,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2065
                 },
@@ -3683,7 +4517,9 @@
                     "token": "'Unique idServer/time'",
                     "value": "Unique idServer/time",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 1,
                     "position": 2066
                 },
@@ -3692,7 +4528,9 @@
                     "token": ",",
                     "value": ",",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 2088
                 },
@@ -3701,7 +4539,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2089
                 },
@@ -3710,7 +4550,9 @@
                     "token": "ADD",
                     "value": "ADD",
                     "keyword": "ADD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 2092
                 },
@@ -3719,7 +4561,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2095
                 },
@@ -3728,7 +4572,9 @@
                     "token": "KEY",
                     "value": "KEY",
                     "keyword": "KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 19,
                     "position": 2096
                 },
@@ -3737,7 +4583,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2099
                 },
@@ -3746,7 +4594,9 @@
                     "token": "`INDEX_totalTime`",
                     "value": "INDEX_totalTime",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 2100
                 },
@@ -3755,7 +4605,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2117
                 },
@@ -3764,7 +4616,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 2118
                 },
@@ -3773,7 +4627,9 @@
                     "token": "`totalTime`",
                     "value": "totalTime",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 2119
                 },
@@ -3782,7 +4638,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 2130
                 },
@@ -3791,7 +4649,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2131
                 },
@@ -3800,7 +4660,9 @@
                     "token": "USING",
                     "value": "USING",
                     "keyword": "USING",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 2132
                 },
@@ -3809,7 +4671,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2137
                 },
@@ -3818,7 +4682,9 @@
                     "token": "BTREE",
                     "value": "BTREE",
                     "keyword": "BTREE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 2138
                 },
@@ -3827,7 +4693,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2143
                 },
@@ -3836,7 +4704,9 @@
                     "token": "COMMENT",
                     "value": "COMMENT",
                     "keyword": "COMMENT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 2144
                 },
@@ -3845,7 +4715,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2151
                 },
@@ -3854,7 +4726,9 @@
                     "token": "'Index for totalTime column'",
                     "value": "Index for totalTime column",
                     "keyword": null,
-                    "type": 7,
+                    "type": {
+                        "@type": "@31"
+                    },
                     "flags": 1,
                     "position": 2152
                 },
@@ -3863,7 +4737,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 2180
                 },
@@ -3872,7 +4748,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2181
                 },
@@ -3881,7 +4759,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 2183
                 },
@@ -3890,7 +4770,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2185
                 },
@@ -3899,7 +4781,9 @@
                     "token": "-- Contraintes pour les tables déchargées",
                     "value": "-- Contraintes pour les tables déchargées",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 2186
                 },
@@ -3908,7 +4792,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2227
                 },
@@ -3917,7 +4803,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 2228
                 },
@@ -3926,7 +4814,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2230
                 },
@@ -3935,7 +4825,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 2232
                 },
@@ -3944,7 +4836,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2234
                 },
@@ -3953,7 +4847,9 @@
                     "token": "-- Contraintes pour la table `monitoring__times`",
                     "value": "-- Contraintes pour la table `monitoring__times`",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 2235
                 },
@@ -3962,7 +4858,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2283
                 },
@@ -3971,7 +4869,9 @@
                     "token": "--\n",
                     "value": "--\n",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 4,
                     "position": 2284
                 },
@@ -3980,7 +4880,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2286
                 },
@@ -3989,7 +4891,9 @@
                     "token": "ALTER",
                     "value": "ALTER",
                     "keyword": "ALTER",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 2287
                 },
@@ -3998,7 +4902,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2292
                 },
@@ -4007,7 +4913,9 @@
                     "token": "TABLE",
                     "value": "TABLE",
                     "keyword": "TABLE",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 2293
                 },
@@ -4016,7 +4924,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2298
                 },
@@ -4025,7 +4935,9 @@
                     "token": "`monitoring__times`",
                     "value": "monitoring__times",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 2299
                 },
@@ -4034,7 +4946,9 @@
                     "token": "\n  ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2318
                 },
@@ -4043,7 +4957,9 @@
                     "token": "ADD",
                     "value": "ADD",
                     "keyword": "ADD",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 2321
                 },
@@ -4052,7 +4968,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2324
                 },
@@ -4061,7 +4979,9 @@
                     "token": "CONSTRAINT",
                     "value": "CONSTRAINT",
                     "keyword": "CONSTRAINT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 2325
                 },
@@ -4070,7 +4990,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2335
                 },
@@ -4079,7 +5001,9 @@
                     "token": "`monitoring__times__idServer`",
                     "value": "monitoring__times__idServer",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 2336
                 },
@@ -4088,7 +5012,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2365
                 },
@@ -4097,7 +5023,9 @@
                     "token": "FOREIGN KEY",
                     "value": "FOREIGN KEY",
                     "keyword": "FOREIGN KEY",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 23,
                     "position": 2366
                 },
@@ -4106,7 +5034,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2377
                 },
@@ -4115,7 +5045,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 2378
                 },
@@ -4124,7 +5056,9 @@
                     "token": "`idServer`",
                     "value": "idServer",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 2379
                 },
@@ -4133,7 +5067,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 2389
                 },
@@ -4142,7 +5078,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2390
                 },
@@ -4151,7 +5089,9 @@
                     "token": "REFERENCES",
                     "value": "REFERENCES",
                     "keyword": "REFERENCES",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 3,
                     "position": 2391
                 },
@@ -4160,7 +5100,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2401
                 },
@@ -4169,7 +5111,9 @@
                     "token": "`monitoring__servers`",
                     "value": "monitoring__servers",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 2402
                 },
@@ -4178,7 +5122,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2423
                 },
@@ -4187,7 +5133,9 @@
                     "token": "(",
                     "value": "(",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 2424
                 },
@@ -4196,7 +5144,9 @@
                     "token": "`id`",
                     "value": "id",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 2,
                     "position": 2425
                 },
@@ -4205,7 +5155,9 @@
                     "token": ")",
                     "value": ")",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 16,
                     "position": 2429
                 },
@@ -4214,7 +5166,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 2430
                 },
@@ -4223,7 +5177,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2431
                 },
@@ -4232,7 +5188,9 @@
                     "token": "COMMIT",
                     "value": "COMMIT",
                     "keyword": "COMMIT",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 1,
                     "position": 2432
                 },
@@ -4241,7 +5199,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 2438
                 },
@@ -4250,7 +5210,9 @@
                     "token": "\n\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2439
                 },
@@ -4259,7 +5221,9 @@
                     "token": "/*!40101",
                     "value": "/*!40101",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 10,
                     "position": 2441
                 },
@@ -4268,7 +5232,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2449
                 },
@@ -4277,7 +5243,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 11,
                     "position": 2450
                 },
@@ -4286,7 +5254,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2453
                 },
@@ -4295,7 +5265,9 @@
                     "token": "CHARACTER_SET_CLIENT",
                     "value": "CHARACTER_SET_CLIENT",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 2454
                 },
@@ -4304,7 +5276,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 2474
                 },
@@ -4313,7 +5287,9 @@
                     "token": "@OLD_CHARACTER_SET_CLIENT",
                     "value": "OLD_CHARACTER_SET_CLIENT",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 1,
                     "position": 2475
                 },
@@ -4322,7 +5298,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2500
                 },
@@ -4331,7 +5309,9 @@
                     "token": "*/",
                     "value": "*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 2,
                     "position": 2501
                 },
@@ -4340,7 +5320,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 2503
                 },
@@ -4349,7 +5331,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2504
                 },
@@ -4358,7 +5342,9 @@
                     "token": "/*!40101",
                     "value": "/*!40101",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 10,
                     "position": 2505
                 },
@@ -4367,7 +5353,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2513
                 },
@@ -4376,7 +5364,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 11,
                     "position": 2514
                 },
@@ -4385,7 +5375,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2517
                 },
@@ -4394,7 +5386,9 @@
                     "token": "CHARACTER_SET_RESULTS",
                     "value": "CHARACTER_SET_RESULTS",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 2518
                 },
@@ -4403,7 +5397,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 2539
                 },
@@ -4412,7 +5408,9 @@
                     "token": "@OLD_CHARACTER_SET_RESULTS",
                     "value": "OLD_CHARACTER_SET_RESULTS",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 1,
                     "position": 2540
                 },
@@ -4421,7 +5419,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2566
                 },
@@ -4430,7 +5430,9 @@
                     "token": "*/",
                     "value": "*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 2,
                     "position": 2567
                 },
@@ -4439,7 +5441,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 2569
                 },
@@ -4448,7 +5452,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2570
                 },
@@ -4457,7 +5463,9 @@
                     "token": "/*!40101",
                     "value": "/*!40101",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 10,
                     "position": 2571
                 },
@@ -4466,7 +5474,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2579
                 },
@@ -4475,7 +5485,9 @@
                     "token": "SET",
                     "value": "SET",
                     "keyword": "SET",
-                    "type": 1,
+                    "type": {
+                        "@type": "@22"
+                    },
                     "flags": 11,
                     "position": 2580
                 },
@@ -4484,7 +5496,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2583
                 },
@@ -4493,7 +5507,9 @@
                     "token": "COLLATION_CONNECTION",
                     "value": "COLLATION_CONNECTION",
                     "keyword": null,
-                    "type": 0,
+                    "type": {
+                        "@type": "@25"
+                    },
                     "flags": 0,
                     "position": 2584
                 },
@@ -4502,7 +5518,9 @@
                     "token": "=",
                     "value": "=",
                     "keyword": null,
-                    "type": 2,
+                    "type": {
+                        "@type": "@28"
+                    },
                     "flags": 2,
                     "position": 2604
                 },
@@ -4511,7 +5529,9 @@
                     "token": "@OLD_COLLATION_CONNECTION",
                     "value": "OLD_COLLATION_CONNECTION",
                     "keyword": null,
-                    "type": 8,
+                    "type": {
+                        "@type": "@62"
+                    },
                     "flags": 1,
                     "position": 2605
                 },
@@ -4520,7 +5540,9 @@
                     "token": " ",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2630
                 },
@@ -4529,7 +5551,9 @@
                     "token": "*/",
                     "value": "*/",
                     "keyword": null,
-                    "type": 4,
+                    "type": {
+                        "@type": "@4"
+                    },
                     "flags": 2,
                     "position": 2631
                 },
@@ -4538,7 +5562,9 @@
                     "token": ";",
                     "value": ";",
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": 2633
                 },
@@ -4547,7 +5573,9 @@
                     "token": "\n",
                     "value": " ",
                     "keyword": null,
-                    "type": 3,
+                    "type": {
+                        "@type": "@6"
+                    },
                     "flags": 0,
                     "position": 2634
                 },
@@ -4556,13 +5584,13 @@
                     "token": null,
                     "value": null,
                     "keyword": null,
-                    "type": 9,
+                    "type": {
+                        "@type": "@33"
+                    },
                     "flags": 0,
                     "position": null
                 }
-            ],
-            "count": 505,
-            "idx": 505
+            ]
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -4922,33 +5950,6 @@
                         "parameters": null,
                         "body": [
                             {
-                                "@type": "@203"
-                            },
-                            {
-                                "@type": "@204"
-                            },
-                            {
-                                "@type": "@205"
-                            },
-                            {
-                                "@type": "@206"
-                            },
-                            {
-                                "@type": "@207"
-                            },
-                            {
-                                "@type": "@208"
-                            },
-                            {
-                                "@type": "@209"
-                            },
-                            {
-                                "@type": "@210"
-                            },
-                            {
-                                "@type": "@211"
-                            },
-                            {
                                 "@type": "@212"
                             },
                             {
@@ -5019,6 +6020,33 @@
                             },
                             {
                                 "@type": "@235"
+                            },
+                            {
+                                "@type": "@236"
+                            },
+                            {
+                                "@type": "@237"
+                            },
+                            {
+                                "@type": "@238"
+                            },
+                            {
+                                "@type": "@239"
+                            },
+                            {
+                                "@type": "@240"
+                            },
+                            {
+                                "@type": "@241"
+                            },
+                            {
+                                "@type": "@242"
+                            },
+                            {
+                                "@type": "@243"
+                            },
+                            {
+                                "@type": "@244"
                             }
                         ],
                         "options": {
@@ -5071,33 +6099,6 @@
                         "return": null,
                         "parameters": null,
                         "body": [
-                            {
-                                "@type": "@262"
-                            },
-                            {
-                                "@type": "@263"
-                            },
-                            {
-                                "@type": "@264"
-                            },
-                            {
-                                "@type": "@265"
-                            },
-                            {
-                                "@type": "@266"
-                            },
-                            {
-                                "@type": "@267"
-                            },
-                            {
-                                "@type": "@268"
-                            },
-                            {
-                                "@type": "@269"
-                            },
-                            {
-                                "@type": "@270"
-                            },
                             {
                                 "@type": "@271"
                             },
@@ -5160,6 +6161,33 @@
                             },
                             {
                                 "@type": "@291"
+                            },
+                            {
+                                "@type": "@292"
+                            },
+                            {
+                                "@type": "@293"
+                            },
+                            {
+                                "@type": "@294"
+                            },
+                            {
+                                "@type": "@295"
+                            },
+                            {
+                                "@type": "@296"
+                            },
+                            {
+                                "@type": "@297"
+                            },
+                            {
+                                "@type": "@298"
+                            },
+                            {
+                                "@type": "@299"
+                            },
+                            {
+                                "@type": "@300"
                             }
                         ],
                         "options": {
@@ -5212,33 +6240,6 @@
                         "return": null,
                         "parameters": null,
                         "body": [
-                            {
-                                "@type": "@318"
-                            },
-                            {
-                                "@type": "@319"
-                            },
-                            {
-                                "@type": "@320"
-                            },
-                            {
-                                "@type": "@321"
-                            },
-                            {
-                                "@type": "@322"
-                            },
-                            {
-                                "@type": "@323"
-                            },
-                            {
-                                "@type": "@324"
-                            },
-                            {
-                                "@type": "@325"
-                            },
-                            {
-                                "@type": "@326"
-                            },
                             {
                                 "@type": "@327"
                             },
@@ -5361,6 +6362,33 @@
                             },
                             {
                                 "@type": "@367"
+                            },
+                            {
+                                "@type": "@368"
+                            },
+                            {
+                                "@type": "@369"
+                            },
+                            {
+                                "@type": "@370"
+                            },
+                            {
+                                "@type": "@371"
+                            },
+                            {
+                                "@type": "@372"
+                            },
+                            {
+                                "@type": "@373"
+                            },
+                            {
+                                "@type": "@374"
+                            },
+                            {
+                                "@type": "@375"
+                            },
+                            {
+                                "@type": "@376"
                             }
                         ],
                         "options": {
@@ -5397,33 +6425,6 @@
                                 "partitions": null,
                                 "unknown": [
                                     {
-                                        "@type": "@394"
-                                    },
-                                    {
-                                        "@type": "@395"
-                                    },
-                                    {
-                                        "@type": "@396"
-                                    },
-                                    {
-                                        "@type": "@397"
-                                    },
-                                    {
-                                        "@type": "@398"
-                                    },
-                                    {
-                                        "@type": "@399"
-                                    },
-                                    {
-                                        "@type": "@400"
-                                    },
-                                    {
-                                        "@type": "@401"
-                                    },
-                                    {
-                                        "@type": "@402"
-                                    },
-                                    {
                                         "@type": "@403"
                                     },
                                     {
@@ -5446,6 +6447,33 @@
                                     },
                                     {
                                         "@type": "@410"
+                                    },
+                                    {
+                                        "@type": "@411"
+                                    },
+                                    {
+                                        "@type": "@412"
+                                    },
+                                    {
+                                        "@type": "@413"
+                                    },
+                                    {
+                                        "@type": "@414"
+                                    },
+                                    {
+                                        "@type": "@415"
+                                    },
+                                    {
+                                        "@type": "@416"
+                                    },
+                                    {
+                                        "@type": "@417"
+                                    },
+                                    {
+                                        "@type": "@418"
+                                    },
+                                    {
+                                        "@type": "@419"
                                     }
                                 ]
                             },
@@ -5471,37 +6499,37 @@
                                 "partitions": null,
                                 "unknown": [
                                     {
-                                        "@type": "@419"
-                                    },
-                                    {
-                                        "@type": "@420"
-                                    },
-                                    {
-                                        "@type": "@421"
-                                    },
-                                    {
-                                        "@type": "@422"
-                                    },
-                                    {
-                                        "@type": "@423"
-                                    },
-                                    {
-                                        "@type": "@424"
-                                    },
-                                    {
-                                        "@type": "@425"
-                                    },
-                                    {
-                                        "@type": "@426"
-                                    },
-                                    {
-                                        "@type": "@427"
-                                    },
-                                    {
                                         "@type": "@428"
                                     },
                                     {
                                         "@type": "@429"
+                                    },
+                                    {
+                                        "@type": "@430"
+                                    },
+                                    {
+                                        "@type": "@431"
+                                    },
+                                    {
+                                        "@type": "@432"
+                                    },
+                                    {
+                                        "@type": "@433"
+                                    },
+                                    {
+                                        "@type": "@434"
+                                    },
+                                    {
+                                        "@type": "@435"
+                                    },
+                                    {
+                                        "@type": "@436"
+                                    },
+                                    {
+                                        "@type": "@437"
+                                    },
+                                    {
+                                        "@type": "@438"
                                     }
                                 ]
                             }
@@ -5550,33 +6578,6 @@
                                 "partitions": null,
                                 "unknown": [
                                     {
-                                        "@type": "@456"
-                                    },
-                                    {
-                                        "@type": "@457"
-                                    },
-                                    {
-                                        "@type": "@458"
-                                    },
-                                    {
-                                        "@type": "@459"
-                                    },
-                                    {
-                                        "@type": "@460"
-                                    },
-                                    {
-                                        "@type": "@461"
-                                    },
-                                    {
-                                        "@type": "@462"
-                                    },
-                                    {
-                                        "@type": "@463"
-                                    },
-                                    {
-                                        "@type": "@464"
-                                    },
-                                    {
                                         "@type": "@465"
                                     },
                                     {
@@ -5587,6 +6588,33 @@
                                     },
                                     {
                                         "@type": "@468"
+                                    },
+                                    {
+                                        "@type": "@469"
+                                    },
+                                    {
+                                        "@type": "@470"
+                                    },
+                                    {
+                                        "@type": "@471"
+                                    },
+                                    {
+                                        "@type": "@472"
+                                    },
+                                    {
+                                        "@type": "@473"
+                                    },
+                                    {
+                                        "@type": "@474"
+                                    },
+                                    {
+                                        "@type": "@475"
+                                    },
+                                    {
+                                        "@type": "@476"
+                                    },
+                                    {
+                                        "@type": "@477"
                                     }
                                 ]
                             }


### PR DESCRIPTION
Used to replace the `Token::TYPE_*` constants.

The `TokenType::cases()` method replaces the `Token::TYPE_ALL` constant.

Adds the `Token::FLAG_NONE` constant with the same value as `Token::TYPE_NONE`.

- Depends on https://github.com/zumba/json-serializer/pull/55