### PR TITLE
Add native param types

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -646,15 +646,6 @@
       <code><![CDATA[self::STATEMENT_PARSERS[$statementName ?? $token->keyword]]]></code>
       <code><![CDATA[self::STATEMENT_PARSERS[$token->keyword]]]></code>
     </MixedArrayOffset>
-    <PossiblyNullArgument>
-      <code>$list</code>
-      <code>$list</code>
-      <code>$list</code>
-      <code><![CDATA[$token->token]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullArrayAccess>
-      <code><![CDATA[$list->tokens[$list->idx]]]></code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullArrayOffset>
       <code><![CDATA[$list->tokens]]></code>
       <code>self::STATEMENT_PARSERS</code>
@@ -664,27 +655,9 @@
       <code><![CDATA[$list->idx]]></code>
       <code>$prevLastIdx</code>
     </PossiblyNullOperand>
-    <PossiblyNullPropertyAssignment>
-      <code>$list</code>
-      <code>$list</code>
-    </PossiblyNullPropertyAssignment>
     <PossiblyNullPropertyAssignmentValue>
       <code>$lastIdx</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyNullPropertyFetch>
-      <code><![CDATA[$list->count]]></code>
-      <code><![CDATA[$list->idx]]></code>
-      <code><![CDATA[$list->tokens]]></code>
-      <code><![CDATA[$token->keyword]]></code>
-      <code><![CDATA[$token->token]]></code>
-      <code><![CDATA[$token->type]]></code>
-      <code><![CDATA[$token->value]]></code>
-    </PossiblyNullPropertyFetch>
-    <PossiblyNullReference>
-      <code>getNextOfType</code>
-      <code>getNextOfType</code>
-      <code>getNextOfType</code>
-    </PossiblyNullReference>
     <UnsupportedPropertyReferenceUsage>
       <code><![CDATA[$list = &$this->list]]></code>
     </UnsupportedPropertyReferenceUsage>
@@ -1533,13 +1506,6 @@
   </file>
   <file src="tests/Utils/QueryTest.php">
     <PossiblyNullArgument>
-      <code><![CDATA[$parser->list]]></code>
-      <code><![CDATA[$parser->list]]></code>
-      <code><![CDATA[$parser->list]]></code>
-      <code><![CDATA[$parser->list]]></code>
-      <code><![CDATA[$parser->list]]></code>
-      <code><![CDATA[$parser->list]]></code>
-      <code><![CDATA[$parser->list]]></code>
       <code><![CDATA[$parser->list]]></code>
       <code><![CDATA[$parser->list]]></code>
       <code><![CDATA[$parser->list]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1026,8 +1026,6 @@
       <code>$idx</code>
     </MixedArgumentTypeCoercion>
     <PossiblyFalseArgument>
-      <code>$params</code>
-      <code>$params</code>
       <code><![CDATA[$params['c']]]></code>
       <code><![CDATA[$params['q']]]></code>
       <code><![CDATA[$params['q']]]></code>

--- a/src/Components/AlterOperation.php
+++ b/src/Components/AlterOperation.php
@@ -264,9 +264,9 @@ final class AlterOperation implements Component
      * @param Token[]                    $unknown    unparsed tokens found at the end of operation
      */
     public function __construct(
-        $options = null,
-        $field = null,
-        $partitions = null,
+        OptionsArray|null $options = null,
+        Expression|string|null $field = null,
+        array|null $partitions = null,
         public array $unknown = []
     ) {
         $this->partitions = $partitions;
@@ -527,7 +527,7 @@ final class AlterOperation implements Component
      *
      * @param string $tokenValue Value of current token
      */
-    private static function checkIfColumnDefinitionKeyword($tokenValue): bool
+    private static function checkIfColumnDefinitionKeyword(string $tokenValue): bool
     {
         $commonOptions = [
             'AUTO_INCREMENT',
@@ -551,7 +551,7 @@ final class AlterOperation implements Component
      *
      * @param Token $token token to check
      */
-    private static function checkIfTokenQuotedSymbol($token): bool
+    private static function checkIfTokenQuotedSymbol(Token $token): bool
     {
         return $token->type === TokenType::Symbol && $token->flags === Token::FLAG_SYMBOL_BACKTICK;
     }

--- a/src/Components/Condition.php
+++ b/src/Components/Condition.php
@@ -80,7 +80,7 @@ final class Condition implements Component
     /**
      * @param string $expr the condition or the operator
      */
-    public function __construct($expr = null)
+    public function __construct(string|null $expr = null)
     {
         $this->expr = trim((string) $expr);
     }

--- a/src/Components/CreateDefinition.php
+++ b/src/Components/CreateDefinition.php
@@ -150,11 +150,11 @@ final class CreateDefinition implements Component
      * @param Reference|null    $references   references
      */
     public function __construct(
-        $name = null,
-        $options = null,
-        $type = null,
-        $isConstraint = false,
-        $references = null
+        string|null $name = null,
+        OptionsArray|null $options = null,
+        DataType|Key|null $type = null,
+        bool $isConstraint = false,
+        Reference|null $references = null
     ) {
         $this->name = $name;
         $this->options = $options;

--- a/src/Components/DataType.php
+++ b/src/Components/DataType.php
@@ -78,9 +78,9 @@ final class DataType implements Component
      * @param OptionsArray   $options    the options of this data type
      */
     public function __construct(
-        $name = null,
+        string|null $name = null,
         array $parameters = [],
-        $options = null
+        OptionsArray|null $options = null
     ) {
         $this->name = $name;
         $this->parameters = $parameters;

--- a/src/Components/Expression.php
+++ b/src/Components/Expression.php
@@ -110,8 +110,12 @@ final class Expression implements Component
      * @param string|null $column   the name of the column
      * @param string|null $alias    the name of the alias
      */
-    public function __construct($database = null, $table = null, $column = null, $alias = null)
-    {
+    public function __construct(
+        string|null $database = null,
+        string|null $table = null,
+        string|null $column = null,
+        string|null $alias = null
+    ) {
         if (($column === null) && ($alias === null)) {
             $this->expr = $database; // case 1
             $this->alias = $table; // case 2

--- a/src/Components/FunctionCall.php
+++ b/src/Components/FunctionCall.php
@@ -34,7 +34,7 @@ final class FunctionCall implements Component
      * @param string|null            $name       the name of the function to be called
      * @param string[]|ArrayObj|null $parameters the parameters of this function
      */
-    public function __construct($name = null, $parameters = null)
+    public function __construct(string|null $name = null, array|ArrayObj|null $parameters = null)
     {
         $this->name = $name;
         if (is_array($parameters)) {

--- a/src/Components/GroupKeyword.php
+++ b/src/Components/GroupKeyword.php
@@ -30,7 +30,7 @@ final class GroupKeyword implements Component
     /**
      * @param Expression $expr the expression that we are sorting by
      */
-    public function __construct($expr = null)
+    public function __construct(Expression|null $expr = null)
     {
         $this->expr = $expr;
     }

--- a/src/Components/IntoKeyword.php
+++ b/src/Components/IntoKeyword.php
@@ -113,12 +113,12 @@ final class IntoKeyword implements Component
      * @param bool|null              $fieldsKeyword options for OPTIONS keyword
      */
     public function __construct(
-        $type = null,
-        $dest = null,
-        $columns = null,
-        $values = null,
-        $fieldsOptions = null,
-        $fieldsKeyword = null
+        string|null $type = null,
+        string|Expression|null $dest = null,
+        array|null $columns = null,
+        array|null $values = null,
+        OptionsArray|null $fieldsOptions = null,
+        bool|null $fieldsKeyword = null
     ) {
         $this->type = $type;
         $this->dest = $dest;
@@ -236,7 +236,7 @@ final class IntoKeyword implements Component
      * @param TokensList $list    A token list
      * @param string     $keyword The keyword
      */
-    public function parseFileOptions(Parser $parser, TokensList $list, $keyword = 'FIELDS'): void
+    public function parseFileOptions(Parser $parser, TokensList $list, string $keyword = 'FIELDS'): void
     {
         ++$list->idx;
 

--- a/src/Components/JoinKeyword.php
+++ b/src/Components/JoinKeyword.php
@@ -78,8 +78,12 @@ final class JoinKeyword implements Component
      * @param Condition[] $on    join conditions
      * @param ArrayObj    $using columns joined
      */
-    public function __construct($type = null, $expr = null, $on = null, $using = null)
-    {
+    public function __construct(
+        string|null $type = null,
+        Expression|null $expr = null,
+        array|null $on = null,
+        ArrayObj|null $using = null
+    ) {
         $this->type = $type;
         $this->expr = $expr;
         $this->on = $on;

--- a/src/Components/Key.php
+++ b/src/Components/Key.php
@@ -105,10 +105,10 @@ final class Key implements Component
      * @phpstan-param array{name?: string, length?: int, order?: string}[] $columns
      */
     public function __construct(
-        $name = null,
+        string|null $name = null,
         array $columns = [],
-        $type = null,
-        $options = null
+        string|null $type = null,
+        OptionsArray|null $options = null
     ) {
         $this->name = $name;
         $this->columns = $columns;

--- a/src/Components/Limit.php
+++ b/src/Components/Limit.php
@@ -33,7 +33,7 @@ final class Limit implements Component
      * @param int|string $rowCount the row count
      * @param int|string $offset   the offset
      */
-    public function __construct($rowCount = 0, $offset = 0)
+    public function __construct(int|string $rowCount = 0, int|string $offset = 0)
     {
         $this->rowCount = $rowCount;
         $this->offset = $offset;

--- a/src/Components/OptionsArray.php
+++ b/src/Components/OptionsArray.php
@@ -291,7 +291,7 @@ final class OptionsArray implements Component
      * @param bool   $getExpr Gets the expression instead of the value.
      *                        The value is the processed form of the expression.
      */
-    public function has($key, $getExpr = false): mixed
+    public function has(string $key, bool $getExpr = false): mixed
     {
         foreach ($this->options as $option) {
             if (is_array($option)) {
@@ -313,7 +313,7 @@ final class OptionsArray implements Component
      *
      * @return bool whether the key was found and deleted or not
      */
-    public function remove($key): bool
+    public function remove(string $key): bool
     {
         foreach ($this->options as $idx => $option) {
             if (is_array($option)) {

--- a/src/Components/OrderKeyword.php
+++ b/src/Components/OrderKeyword.php
@@ -34,7 +34,7 @@ final class OrderKeyword implements Component
      * @param Expression $expr the expression that we are sorting by
      * @param string     $type the sorting type
      */
-    public function __construct($expr = null, $type = 'ASC')
+    public function __construct(Expression|null $expr = null, string $type = 'ASC')
     {
         $this->expr = $expr;
         $this->type = $type;

--- a/src/Components/ParameterDefinition.php
+++ b/src/Components/ParameterDefinition.php
@@ -44,7 +44,7 @@ final class ParameterDefinition implements Component
      * @param string   $inOut parameter's directional type (IN / OUT or None)
      * @param DataType $type  parameter's type
      */
-    public function __construct($name = null, $inOut = null, $type = null)
+    public function __construct(string|null $name = null, string|null $inOut = null, DataType|null $type = null)
     {
         $this->name = $name;
         $this->inOut = $inOut;

--- a/src/Components/Reference.php
+++ b/src/Components/Reference.php
@@ -62,7 +62,7 @@ final class Reference implements Component
      * @param string[]     $columns the columns referenced
      * @param OptionsArray $options the options
      */
-    public function __construct($table = null, array $columns = [], $options = null)
+    public function __construct(Expression|null $table = null, array $columns = [], OptionsArray|null $options = null)
     {
         $this->table = $table;
         $this->columns = $columns;

--- a/src/Components/RenameOperation.php
+++ b/src/Components/RenameOperation.php
@@ -34,7 +34,7 @@ final class RenameOperation implements Component
      * @param Expression $old old expression
      * @param Expression $new new expression containing new name
      */
-    public function __construct($old = null, $new = null)
+    public function __construct(Expression|null $old = null, Expression|null $new = null)
     {
         $this->old = $old;
         $this->new = $new;

--- a/src/Components/SetOperation.php
+++ b/src/Components/SetOperation.php
@@ -37,7 +37,7 @@ final class SetOperation implements Component
      * @param string $column Field's name..
      * @param string $value  new value
      */
-    public function __construct($column = '', $value = '')
+    public function __construct(string $column = '', string $value = '')
     {
         $this->column = $column;
         $this->value = $value;

--- a/src/Context.php
+++ b/src/Context.php
@@ -604,10 +604,8 @@ abstract class Context
 
     /**
      * Sets the SQL mode.
-     *
-     * @param int|string $mode
      */
-    public static function setMode($mode = self::SQL_MODE_NONE): void
+    public static function setMode(int|string $mode = self::SQL_MODE_NONE): void
     {
         if (is_int($mode)) {
             static::$mode = $mode;

--- a/src/Exceptions/LexerException.php
+++ b/src/Exceptions/LexerException.php
@@ -31,7 +31,7 @@ class LexerException extends Exception
      * @param int    $pos  the position of the character
      * @param int    $code the code of this error
      */
-    public function __construct($msg = '', $ch = '', $pos = 0, $code = 0)
+    public function __construct(string $msg = '', string $ch = '', int $pos = 0, int $code = 0)
     {
         parent::__construct($msg, $code);
         $this->ch = $ch;

--- a/src/Exceptions/ParserException.php
+++ b/src/Exceptions/ParserException.php
@@ -24,7 +24,7 @@ class ParserException extends Exception
      * @param Token  $token the token that produced this exception
      * @param int    $code  the code of this error
      */
-    public function __construct($msg = '', Token|null $token = null, $code = 0)
+    public function __construct(string $msg = '', Token|null $token = null, int $code = 0)
     {
         parent::__construct($msg, $code);
         $this->token = $token;

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -127,7 +127,7 @@ class Lexer
      *                                    enabled or not
      * @param string           $delimiter the delimiter to be used
      */
-    public function __construct($str, $strict = false, $delimiter = null)
+    public function __construct(string|UtfString $str, bool $strict = false, string|null $delimiter = null)
     {
         if (Context::$keywords === []) {
             Context::load();
@@ -158,7 +158,7 @@ class Lexer
      *
      * @param string $delimiter the new delimiter
      */
-    public function setDelimiter($delimiter): void
+    public function setDelimiter(string $delimiter): void
     {
         $this->delimiter = $delimiter;
         $this->delimiterLen = strlen($delimiter);
@@ -383,7 +383,7 @@ class Lexer
      *
      * @throws LexerException throws the exception, if strict mode is enabled.
      */
-    public function error($msg, $str = '', $pos = 0, $code = 0): void
+    public function error(string $msg, string $str = '', int $pos = 0, int $code = 0): void
     {
         $error = new LexerException(
             Translator::gettext($msg),
@@ -873,7 +873,7 @@ class Lexer
      *
      * @throws LexerException
      */
-    public function parseString($quote = ''): Token|null
+    public function parseString(string $quote = ''): Token|null
     {
         $token = $this->str[$this->last];
         $flags = Context::isString($token);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -377,7 +377,7 @@ class Parser
      * @param string|UtfString|TokensList|null $list   the list of tokens to be parsed
      * @param bool                             $strict whether strict mode should be enabled or not
      */
-    public function __construct($list = null, $strict = false)
+    public function __construct(string|UtfString|TokensList|null $list = null, bool $strict = false)
     {
         if (Context::$keywords === []) {
             Context::load();
@@ -634,7 +634,7 @@ class Parser
      *
      * @throws ParserException throws the exception, if strict mode is enabled.
      */
-    public function error($msg, Token|null $token = null, $code = 0): void
+    public function error(string $msg, Token|null $token = null, int $code = 0): void
     {
         $error = new ParserException(
             Translator::gettext($msg),

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -465,7 +465,7 @@ abstract class Statement implements Stringable
      *
      * @throws Exceptions\ParserException
      */
-    public function validateClauseOrder($parser, $list): bool
+    public function validateClauseOrder(Parser $parser, TokensList $list): bool
     {
         $clauses = array_flip(array_keys($this->getClauses()));
 

--- a/src/Statements/LoadStatement.php
+++ b/src/Statements/LoadStatement.php
@@ -311,7 +311,7 @@ class LoadStatement extends Statement
      * @param TokensList $list    A token list
      * @param string     $keyword The keyword
      */
-    public function parseFileOptions(Parser $parser, TokensList $list, $keyword = 'FIELDS'): void
+    public function parseFileOptions(Parser $parser, TokensList $list, string $keyword = 'FIELDS'): void
     {
         ++$list->idx;
 
@@ -326,12 +326,7 @@ class LoadStatement extends Statement
         }
     }
 
-    /**
-     * @param Parser     $parser
-     * @param TokensList $list
-     * @param int        $state
-     */
-    public function parseKeywordsAccordingToState($parser, $list, $state): int
+    public function parseKeywordsAccordingToState(Parser $parser, TokensList $list, int $state): int
     {
         $token = $list->tokens[$list->idx];
 

--- a/src/Statements/PurgeStatement.php
+++ b/src/Statements/PurgeStatement.php
@@ -124,7 +124,7 @@ class PurgeStatement extends Statement
      * @param Token    $token            token to be parsed
      * @param string[] $expectedKeywords array of possibly expected keywords at this point
      */
-    private static function parseExpectedKeyword($parser, $token, $expectedKeywords): mixed
+    private static function parseExpectedKeyword(Parser $parser, Token $token, array $expectedKeywords): mixed
     {
         if ($token->type === TokenType::Keyword) {
             if (in_array($token->keyword, $expectedKeywords)) {

--- a/src/TokensList.php
+++ b/src/TokensList.php
@@ -156,7 +156,7 @@ class TokensList implements ArrayAccess
      * @param TokenType $type  the type of the token
      * @param string    $value the value of the token
      */
-    public function getNextOfTypeAndValue(TokenType $type, $value): Token|null
+    public function getNextOfTypeAndValue(TokenType $type, string $value): Token|null
     {
         for (; $this->idx < $this->count; ++$this->idx) {
             if (($this->tokens[$this->idx]->type === $type) && ($this->tokens[$this->idx]->value === $value)) {

--- a/src/Tools/ContextGenerator.php
+++ b/src/Tools/ContextGenerator.php
@@ -221,7 +221,7 @@ PHP;
      * @param int                                        $spaces the number of spaces that starts every line
      * @param int                                        $line   the length of a line
      */
-    public static function printWords($words, $spaces = 8, $line = 140): string
+    public static function printWords(array $words, int $spaces = 8, int $line = 140): string
     {
         $typesCount = count($words);
         $ret = '';
@@ -275,7 +275,7 @@ PHP;
      *   keywords: array<int, array<int, array<int, string>>>
      * } $options
      */
-    public static function generate($options): string
+    public static function generate(array $options): string
     {
         if (isset($options['keywords'])) {
             $options['keywords'] = static::printWords($options['keywords']);
@@ -289,7 +289,7 @@ PHP;
      *
      * @param string $name name to format
      */
-    public static function formatName($name): string
+    public static function formatName(string $name): string
     {
         /* Split name and version */
         $parts = [];
@@ -329,7 +329,7 @@ PHP;
      * @param string $input  the input file
      * @param string $output the output directory
      */
-    public static function build($input, $output): void
+    public static function build(string $input, string $output): void
     {
         /**
          * The directory that contains the input file.
@@ -383,7 +383,7 @@ PHP;
      * @param string $input  the input directory
      * @param string $output the output directory
      */
-    public static function buildAll($input, $output): void
+    public static function buildAll(string $input, string $output): void
     {
         $files = scandir($input);
 

--- a/src/Tools/CustomJsonSerializer.php
+++ b/src/Tools/CustomJsonSerializer.php
@@ -30,6 +30,7 @@ class CustomJsonSerializer extends JsonSerializer
      *
      * @return array<string,mixed>
      */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints
     protected function extractObjectData($value, $ref, $properties): array
     {
         $data = [];

--- a/src/Tools/TestGenerator.php
+++ b/src/Tools/TestGenerator.php
@@ -48,7 +48,7 @@ class TestGenerator
      *
      * @return array<string, string|Lexer|Parser|array<string, array<int, array<int, int|string|Token>>>|null>
      */
-    public static function generate($query, $type = 'parser'): array
+    public static function generate(string $query, string $type = 'parser'): array
     {
         /**
          * Lexer used for tokenizing the query.
@@ -133,8 +133,13 @@ class TestGenerator
      * @param string $debug  the debug file
      * @param bool   $ansi   activate quotes ANSI mode
      */
-    public static function build($type, $input, $output, $debug = null, $ansi = false): void
-    {
+    public static function build(
+        string $type,
+        string $input,
+        string $output,
+        string|null $debug = null,
+        bool $ansi = false
+    ): void {
         // Support query types: `lexer` / `parser`.
         if (! in_array($type, ['lexer', 'parser'])) {
             throw new Exception('Unknown test type (expected `lexer` or `parser`).');
@@ -197,11 +202,10 @@ class TestGenerator
     /**
      * Generates recursively all tests preserving the directory structure.
      *
-     * @param string     $input  the input directory
-     * @param string     $output the output directory
-     * @param mixed|null $debug
+     * @param string $input  the input directory
+     * @param string $output the output directory
      */
-    public static function buildAll($input, $output, $debug = null): void
+    public static function buildAll(string $input, string $output, mixed $debug = null): void
     {
         $files = scandir($input);
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -63,7 +63,7 @@ class Translator
      *
      * @return string translated string (or original, if not found)
      */
-    public static function gettext($msgid): string
+    public static function gettext(string $msgid): string
     {
         if (! class_exists(Loader::class, true)) {
             return $msgid;

--- a/src/UtfString.php
+++ b/src/UtfString.php
@@ -74,7 +74,7 @@ class UtfString implements ArrayAccess, Stringable
     /**
      * @param string $str the string
      */
-    public function __construct($str)
+    public function __construct(string $str)
     {
         $this->str = $str;
         $this->byteLen = mb_strlen($str, '8bit');

--- a/src/Utils/BufferedQuery.php
+++ b/src/Utils/BufferedQuery.php
@@ -84,7 +84,7 @@ class BufferedQuery
      * @param array<string, bool|string> $options the options of this parser
      * @psalm-param array{delimiter?: non-empty-string, parse_delimiter?: bool, add_delimiter?: bool} $options
      */
-    public function __construct($query = '', array $options = [])
+    public function __construct(string $query = '', array $options = [])
     {
         // Merges specified options with defaults.
         $this->options = array_merge(
@@ -107,10 +107,8 @@ class BufferedQuery
      * Sets the delimiter.
      *
      * Used to update the length of it too.
-     *
-     * @param string $delimiter
      */
-    public function setDelimiter($delimiter): void
+    public function setDelimiter(string $delimiter): void
     {
         $this->delimiter = $delimiter;
         $this->delimiterLen = strlen($delimiter);
@@ -121,7 +119,7 @@ class BufferedQuery
      *
      * @param bool $end whether the end of the buffer was reached
      */
-    public function extract($end = false): string|false
+    public function extract(bool $end = false): string|false
     {
         /**
          * The last parsed position.

--- a/src/Utils/CLI.php
+++ b/src/Utils/CLI.php
@@ -32,7 +32,7 @@ class CLI
      * @param string[]|false[] $params
      * @param string[]         $longopts
      */
-    public function mergeLongOpts(&$params, &$longopts): void
+    public function mergeLongOpts(array &$params, array &$longopts): void
     {
         foreach ($longopts as $value) {
             $value = rtrim($value, ':');
@@ -51,12 +51,11 @@ class CLI
     }
 
     /**
-     * @param string   $opt
      * @param string[] $long
      *
      * @return string[]|false[]|false
      */
-    public function getopt($opt, $long): array|false
+    public function getopt(string $opt, array $long): array|false
     {
         return getopt($opt, $long);
     }

--- a/src/Utils/CLI.php
+++ b/src/Utils/CLI.php
@@ -149,6 +149,10 @@ class CLI
             'ansi',
         ];
         $params = $this->getopt('hq:c:a', $longopts);
+        if ($params === false) {
+            return false;
+        }
+
         $this->mergeLongOpts($params, $longopts);
 
         return $params;
@@ -221,6 +225,10 @@ class CLI
             'ansi',
         ];
         $params = $this->getopt('hq:a', $longopts);
+        if ($params === false) {
+            return false;
+        }
+
         $this->mergeLongOpts($params, $longopts);
 
         return $params;

--- a/src/Utils/Error.php
+++ b/src/Utils/Error.php
@@ -29,7 +29,7 @@ class Error
      *               `$err[3]` holds the position of the string.
      *               (i.e. `[$msg, $code, $str, $pos]`)
      */
-    public static function get($objs): array
+    public static function get(array $objs): array
     {
         $ret = [];
 

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -326,7 +326,7 @@ class Formatter
      *
      * @param TokensList $list the list of tokens
      */
-    public function formatList($list): string
+    public function formatList(TokensList $list): string
     {
         /**
          * The query to be returned.
@@ -636,7 +636,7 @@ class Formatter
      *
      * @param Token $token the token to be printed
      */
-    public function toString($token): string
+    public function toString(Token $token): string
     {
         $text = $token->token;
         static $prev;
@@ -697,7 +697,7 @@ class Formatter
      *
      * @return string the formatted string
      */
-    public static function format($query, array $options = []): string
+    public static function format(string $query, array $options = []): string
     {
         $lexer = new Lexer($query);
         $formatter = new self($options);
@@ -712,7 +712,7 @@ class Formatter
      *
      * @param TokensList $list the list of tokens
      */
-    public static function getGroupLength($list): int
+    public static function getGroupLength(TokensList $list): int
     {
         /**
          * The number of opening brackets found.
@@ -758,7 +758,7 @@ class Formatter
      *
      * @psalm-return 1|2|false
      */
-    public static function isClause($token): int|false
+    public static function isClause(Token $token): int|false
     {
         if (
             ($token->type === TokenType::Keyword && isset(Parser::STATEMENT_PARSERS[$token->keyword]))

--- a/src/Utils/Query.php
+++ b/src/Utils/Query.php
@@ -286,7 +286,7 @@ class Query
      * @return array<string, bool|string>
      * @psalm-return QueryFlagsType
      */
-    private static function getFlagsSelect(SelectStatement $statement, $flags): array
+    private static function getFlagsSelect(SelectStatement $statement, array $flags): array
     {
         $flags['querytype'] = 'SELECT';
         $flags['is_select'] = true;
@@ -362,7 +362,7 @@ class Query
      * @return array<string, bool|string>
      * @psalm-return QueryFlagsType
      */
-    public static function getFlags($statement, $all = false): array
+    public static function getFlags(Statement|null $statement, bool $all = false): array
     {
         $flags = ['querytype' => false];
         if ($all) {
@@ -469,7 +469,7 @@ class Query
      *      statement?: Statement|null, parser?: Parser
      * }
      */
-    public static function getAll($query): array
+    public static function getAll(string $query): array
     {
         $parser = new Parser($query);
 
@@ -557,7 +557,7 @@ class Query
      *
      * @return array<int, string>
      */
-    public static function getTables($statement): array
+    public static function getTables(Statement $statement): array
     {
         $expressions = [];
 
@@ -611,8 +611,13 @@ class Query
      *                              should not be included.
      * @param bool       $skipFirst whether to skip the first keyword in clause
      */
-    public static function getClause($statement, $list, $clause, $type = 0, $skipFirst = true): string
-    {
+    public static function getClause(
+        Statement $statement,
+        TokensList $list,
+        string $clause,
+        int|string $type = 0,
+        bool $skipFirst = true
+    ): string {
         /**
          * The index of the current clause.
          *
@@ -738,8 +743,13 @@ class Query
      * @param bool       $onlyType  whether only the type of the clause should
      *                              be replaced or the entire clause
      */
-    public static function replaceClause($statement, $list, $old, $new = null, $onlyType = false): string
-    {
+    public static function replaceClause(
+        Statement $statement,
+        TokensList $list,
+        string $old,
+        string|null $new = null,
+        bool $onlyType = false
+    ): string {
         // TODO: Update the tokens list and the statement.
 
         if ($new === null) {
@@ -766,7 +776,7 @@ class Query
      *                              arrays having two values: [$old, $new].
      *                              Clauses must be sorted.
      */
-    public static function replaceClauses($statement, $list, array $ops): string
+    public static function replaceClauses(Statement $statement, TokensList $list, array $ops): string
     {
         $count = count($ops);
 
@@ -816,7 +826,7 @@ class Query
      *                                 the remaining part of the query and the last delimiter
      * @psalm-return array{string|null, string, string|null}
      */
-    public static function getFirstStatement($query, $delimiter = null): array
+    public static function getFirstStatement(string $query, string|null $delimiter = null): array
     {
         $lexer = new Lexer($query, false, $delimiter);
         $list = $lexer->list;
@@ -882,7 +892,7 @@ class Query
      * @param TokensList $list      the list of tokens
      * @param string     $clause    the clause to be returned
      */
-    public static function getClauseStartOffset($statement, $list, $clause): int
+    public static function getClauseStartOffset(Statement $statement, TokensList $list, string $clause): int
     {
         /**
          * The count of brackets.

--- a/src/Utils/Routine.php
+++ b/src/Utils/Routine.php
@@ -25,7 +25,7 @@ class Routine
      *
      * @return string[]
      */
-    public static function getReturnType($param): array
+    public static function getReturnType(string $param): array
     {
         $lexer = new Lexer($param);
 
@@ -59,7 +59,7 @@ class Routine
      *
      * @return string[]
      */
-    public static function getParameter($param): array
+    public static function getParameter(string $param): array
     {
         $lexer = new Lexer('(' . $param . ')');
 
@@ -99,7 +99,7 @@ class Routine
      *
      * @return array<string, int|array<int, mixed[]|string|null>>
      */
-    public static function getParameters($statement): array
+    public static function getParameters(CreateStatement $statement): array
     {
         $retval = [
             'num' => 0,

--- a/src/Utils/Table.php
+++ b/src/Utils/Table.php
@@ -94,7 +94,7 @@ class Table
      *  expr?: mixed
      * }>
      */
-    public static function getFields($statement): array
+    public static function getFields(CreateStatement $statement): array
     {
         if (empty($statement->fields) || (! is_array($statement->fields)) || (! $statement->options->has('TABLE'))) {
             return [];


### PR DESCRIPTION
It's still not possible to remove `SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint` because of `Token` class. I don't know how to fix it. @MauricioFauth maybe you have some cool idea?
