### PR TITLE
Add native property types in Lexer

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -386,11 +386,6 @@ parameters:
 			path: src/Lexer.php
 
 		-
-			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Lexer\\:\\:\\$delimiter \\(string\\) does not accept null\\.$#"
-			count: 1
-			path: src/Lexer.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between non\\-empty\\-array\\<non\\-empty\\-string, int\\> and array\\{\\} will always evaluate to false\\.$#"
 			count: 1
 			path: src/Lexer.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -590,7 +590,6 @@
       <code>$token</code>
     </PossiblyNullArgument>
     <PossiblyNullOperand>
-      <code><![CDATA[$this->delimiter]]></code>
       <code><![CDATA[$this->str[$this->last++]]]></code>
       <code><![CDATA[$this->str[$this->last++]]]></code>
       <code><![CDATA[$this->str[$this->last]]]></code>
@@ -616,9 +615,6 @@
       <code><![CDATA[$this->str[++$this->last]]]></code>
       <code><![CDATA[$this->str[++$this->last]]]></code>
     </PossiblyNullOperand>
-    <PossiblyNullPropertyAssignmentValue>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
     <PossiblyNullPropertyFetch>
       <code><![CDATA[$next->type]]></code>
       <code><![CDATA[$next->value]]></code>

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -239,7 +239,7 @@ class Lexer
                 $pos = $this->last + 1;
 
                 // Parsing the delimiter.
-                $this->delimiter = null;
+                $this->delimiter = '';
                 $delimiterLen = 0;
                 while (
                     ++$this->last < $this->len
@@ -250,7 +250,7 @@ class Lexer
                     ++$delimiterLen;
                 }
 
-                if (empty($this->delimiter)) {
+                if ($this->delimiter === '') {
                     $this->error('Expected delimiter.', '', $this->last);
                     $this->delimiter = ';';
                 }

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -66,49 +66,37 @@ class Lexer
 
     /**
      * The string to be parsed.
-     *
-     * @var string|UtfString
      */
-    public $str = '';
+    public string|UtfString $str = '';
 
     /**
      * The length of `$str`.
      *
      * By storing its length, a lot of time is saved, because parsing methods
      * would call `strlen` everytime.
-     *
-     * @var int
      */
-    public $len = 0;
+    public int $len = 0;
 
     /**
      * The index of the last parsed character.
-     *
-     * @var int
      */
-    public $last = 0;
+    public int $last = 0;
 
     /**
      * Tokens extracted from given strings.
-     *
-     * @var TokensList
      */
-    public $list;
+    public TokensList $list;
 
     /**
      * The default delimiter. This is used, by default, in all new instances.
-     *
-     * @var string
      */
-    public static $defaultDelimiter = ';';
+    public static string $defaultDelimiter = ';';
 
     /**
      * Statements delimiter.
      * This may change during lexing.
-     *
-     * @var string
      */
-    public $delimiter;
+    public string $delimiter;
 
     /**
      * The length of the delimiter.
@@ -116,10 +104,8 @@ class Lexer
      * Because `parseDelimiter` can be called a lot, it would perform a lot of
      * calls to `strlen`, which might affect performance when the delimiter is
      * big.
-     *
-     * @var int
      */
-    public $delimiterLen;
+    public int $delimiterLen;
 
     /**
      * @param string|UtfString $str       the query to be lexed


### PR DESCRIPTION
I am still not sure what to do about this `null` delimiter, so at the moment I decided to just add it to the baselines. 