### PR TITLE
Add `bin/sql-parser` executable file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [5.9.x] - YYYY-MM-DD
 
+- Add `bin/sql-parser` executable file (#517)
+
 ## [5.8.2] - 2023-09-19
 
 - Fix a regression with the ALTER operation (#511)

--- a/bin/sql-parser
+++ b/bin/sql-parser
@@ -1,0 +1,31 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$files = [
+    __DIR__ . "/../vendor/autoload.php",
+    __DIR__ . "/../../vendor/autoload.php",
+    __DIR__ . "/../../../autoload.php",
+    "vendor/autoload.php"
+];
+
+$found = false;
+foreach ($files as $file) {
+    if (file_exists($file)) {
+        require_once $file;
+        $found = true;
+        break;
+    }
+}
+
+if (! $found) {
+    die(
+        "You need to set up the project dependencies using the following commands:" . PHP_EOL .
+        "curl -sS https://getcomposer.org/installer | php" . PHP_EOL .
+        "php composer.phar install" . PHP_EOL
+    );
+}
+
+$cli = new PhpMyAdmin\SqlParser\Utils\CLI();
+exit($cli->run());

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
     "bin": [
         "bin/highlight-query",
         "bin/lint-query",
+        "bin/sql-parser",
         "bin/tokenize-query"
     ],
     "autoload": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -292,7 +292,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'expr' on mixed\\.$#"
-			count: 4
+			count: 2
 			path: src/Components/OptionsArray.php
 
 		-
@@ -307,12 +307,12 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 1 on mixed\\.$#"
-			count: 6
+			count: 2
 			path: src/Components/OptionsArray.php
 
 		-
 			message: "#^Cannot access offset 2 on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Components/OptionsArray.php
 
 		-
@@ -847,7 +847,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'c' on mixed\\.$#"
-			count: 2
+			count: 1
 			path: src/Utils/CLI.php
 
 		-
@@ -862,7 +862,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'q' on mixed\\.$#"
-			count: 12
+			count: 9
 			path: src/Utils/CLI.php
 
 		-

--- a/src/Utils/CLI.php
+++ b/src/Utils/CLI.php
@@ -24,6 +24,30 @@ use const STDIN;
  */
 class CLI
 {
+    public function run(): int
+    {
+        $params = $this->getopt('', ['lint', 'highlight', 'tokenize']);
+        if ($params !== false) {
+            if (isset($params['lint'])) {
+                return $this->runLint(false);
+            }
+
+            if (isset($params['highlight'])) {
+                return $this->runHighlight(false);
+            }
+
+            if (isset($params['tokenize'])) {
+                return $this->runTokenize(false);
+            }
+        }
+
+        $this->usageLint(false);
+        $this->usageHighlight(false);
+        $this->usageTokenize(false);
+
+        return 1;
+    }
+
     /**
      * @param string[]|false[] $params
      * @param string[]         $longopts
@@ -45,10 +69,12 @@ class CLI
     /**
      * @return void
      */
-    public function usageHighlight()
+    public function usageHighlight(bool $isStandalone = true)
     {
-        echo "Usage: highlight-query --query SQL [--format html|cli|text] [--ansi]\n";
-        echo "       cat file.sql | highlight-query\n";
+        $command = $isStandalone ? 'highlight-query' : 'sql-parser --highlight';
+
+        echo 'Usage: ' . $command . ' --query SQL [--format html|cli|text] [--ansi]' . "\n";
+        echo '       cat file.sql | ' . $command . "\n";
     }
 
     /**
@@ -95,7 +121,7 @@ class CLI
     /**
      * @return int
      */
-    public function runHighlight()
+    public function runHighlight(bool $isStandalone = true)
     {
         $params = $this->parseHighlight();
         if ($params === false) {
@@ -103,7 +129,7 @@ class CLI
         }
 
         if (isset($params['h'])) {
-            $this->usageHighlight();
+            $this->usageHighlight($isStandalone);
 
             return 0;
         }
@@ -131,7 +157,7 @@ class CLI
         }
 
         echo "ERROR: Missing parameters!\n";
-        $this->usageHighlight();
+        $this->usageHighlight($isStandalone);
 
         return 1;
     }
@@ -139,10 +165,12 @@ class CLI
     /**
      * @return void
      */
-    public function usageLint()
+    public function usageLint(bool $isStandalone = true)
     {
-        echo "Usage: lint-query --query SQL [--ansi]\n";
-        echo "       cat file.sql | lint-query\n";
+        $command = $isStandalone ? 'lint-query' : 'sql-parser --lint';
+
+        echo 'Usage: ' . $command . ' --query SQL [--ansi]' . "\n";
+        echo '       cat file.sql | ' . $command . "\n";
     }
 
     /**
@@ -165,7 +193,7 @@ class CLI
     /**
      * @return int
      */
-    public function runLint()
+    public function runLint(bool $isStandalone = true)
     {
         $params = $this->parseLint();
         if ($params === false) {
@@ -173,7 +201,7 @@ class CLI
         }
 
         if (isset($params['h'])) {
-            $this->usageLint();
+            $this->usageLint($isStandalone);
 
             return 0;
         }
@@ -210,7 +238,7 @@ class CLI
         }
 
         echo "ERROR: Missing parameters!\n";
-        $this->usageLint();
+        $this->usageLint($isStandalone);
 
         return 1;
     }
@@ -218,10 +246,12 @@ class CLI
     /**
      * @return void
      */
-    public function usageTokenize()
+    public function usageTokenize(bool $isStandalone = true)
     {
-        echo "Usage: tokenize-query --query SQL [--ansi]\n";
-        echo "       cat file.sql | tokenize-query\n";
+        $command = $isStandalone ? 'tokenize-query' : 'sql-parser --tokenize';
+
+        echo 'Usage: ' . $command . ' --query SQL [--ansi]' . "\n";
+        echo '       cat file.sql | ' . $command . "\n";
     }
 
     /**
@@ -243,7 +273,7 @@ class CLI
     /**
      * @return int
      */
-    public function runTokenize()
+    public function runTokenize(bool $isStandalone = true)
     {
         $params = $this->parseTokenize();
         if ($params === false) {
@@ -251,7 +281,7 @@ class CLI
         }
 
         if (isset($params['h'])) {
-            $this->usageTokenize();
+            $this->usageTokenize($isStandalone);
 
             return 0;
         }
@@ -287,7 +317,7 @@ class CLI
         }
 
         echo "ERROR: Missing parameters!\n";
-        $this->usageTokenize();
+        $this->usageTokenize($isStandalone);
 
         return 1;
     }


### PR DESCRIPTION
- Related to #517

This new executable file acts only as an alias to the other executable files.

This will allow the other files to be removed in 6.0.0.