### PR TITLE
Fix PHP notice in Utils\Error::get()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -466,11 +466,6 @@ parameters:
 			path: src/Context.php
 
 		-
-			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Exceptions\\\\ParserException\\:\\:\\$token \\(PhpMyAdmin\\\\SqlParser\\\\Token\\) does not accept PhpMyAdmin\\\\SqlParser\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Exceptions/ParserException.php
-
-		-
 			message: "#^Cannot access property \\$type on PhpMyAdmin\\\\SqlParser\\\\Token\\|null\\.$#"
 			count: 2
 			path: src/Lexer.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -656,11 +656,6 @@
   <file src="src/Contexts/ContextMySql80300.php">
     <PropertyTypeCoercion occurrences="1"/>
   </file>
-  <file src="src/Exceptions/ParserException.php">
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>$token</code>
-    </PossiblyNullPropertyAssignmentValue>
-  </file>
   <file src="src/Lexer.php">
     <LoopInvalidation occurrences="3">
       <code>$this-&gt;last</code>

--- a/src/Exceptions/ParserException.php
+++ b/src/Exceptions/ParserException.php
@@ -15,14 +15,14 @@ class ParserException extends Exception
     /**
      * The token that produced this error.
      *
-     * @var Token
+     * @var Token|null
      */
     public $token;
 
     /**
-     * @param string $msg   the message of this exception
-     * @param Token  $token the token that produced this exception
-     * @param int    $code  the code of this error
+     * @param string     $msg   the message of this exception
+     * @param Token|null $token the token that produced this exception
+     * @param int        $code  the code of this error
      */
     public function __construct($msg = '', ?Token $token = null, $code = 0)
     {

--- a/src/Tools/TestGenerator.php
+++ b/src/Tools/TestGenerator.php
@@ -46,7 +46,7 @@ class TestGenerator
      * @param string $query the query to be analyzed
      * @param string $type  test's type (may be `lexer` or `parser`)
      *
-     * @return array<string, string|Lexer|Parser|array<string, array<int, array<int, int|string|Token>>>|null>
+     * @return array<string, string|Lexer|Parser|array<string, array<int, array<int, int|string|Token|null>>>|null>
      */
     public static function generate($query, $type = 'parser')
     {
@@ -72,8 +72,6 @@ class TestGenerator
 
         /**
          * Parser's errors.
-         *
-         * @var array<int, array<int, int|string|Token>>
          */
         $parserErrors = [];
 

--- a/src/Utils/Error.php
+++ b/src/Utils/Error.php
@@ -50,8 +50,8 @@ class Error
                     $ret[] = [
                         $err->getMessage(),
                         $err->getCode(),
-                        $err->token->token,
-                        $err->token->position,
+                        $err->token !== null ? $err->token->token : '',
+                        $err->token !== null ? $err->token->position : null,
                     ];
                 }
             }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,7 +57,7 @@ abstract class TestCase extends BaseTestCase
      * @psalm-return (
      *     $obj is Lexer
      *     ? list<array{string, string, int, int}>
-     *     : list<array{string, Token, int}>
+     *     : list<array{string, Token|null, int}>
      * )
      */
     public function getErrorsAsArray($obj): array

--- a/tests/Utils/ErrorTest.php
+++ b/tests/Utils/ErrorTest.php
@@ -34,6 +34,16 @@ class ErrorTest extends TestCase
         );
     }
 
+    public function testGetWithNullToken(): void
+    {
+        $lexer = new Lexer('LOCK TABLES table1 AS `t1` LOCAL');
+        $parser = new Parser($lexer->list);
+        $this->assertEquals(
+            [['Unexpected keyword.', 0, 'LOCAL', 27], ['Unexpected end of LOCK expression.', 0, null, null]],
+            Error::get([$lexer, $parser])
+        );
+    }
+
     public function testFormat(): void
     {
         $this->assertEquals(


### PR DESCRIPTION
```
PHP Notice: Trying to get property 'token' of non-object in src/Utils/Error.php on line 54
PHP Notice: Trying to get property 'position' of non-object in src/Utils/Error.php on line 55
```
