### PR TITLE
Push Statement::parse() down to SelectStatement

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -596,6 +596,121 @@ parameters:
 			path: src/Statements/RenameStatement.php
 
 		-
+			message: "#^Access to an undefined property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$call\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Access to an undefined property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$fields\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Access to an undefined property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$renames\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Access to an undefined property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$set\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Access to an undefined property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$table\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Access to an undefined property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$tables\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Access to an undefined property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$values\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statement\\:\\:\\$options \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$endOptions \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$expr \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\>\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$from \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\>\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$group \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\GroupKeyword\\>\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$groupOptions \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$having \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\Condition\\>\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$indexHints \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\IndexHint\\>\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$into \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$join \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\JoinKeyword\\>\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$limit \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$order \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\OrderKeyword\\>\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$partition \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$procedure \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$union \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\>\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$where \\(array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\Condition\\>\\|null\\) does not accept array\\<PhpMyAdmin\\\\SqlParser\\\\Component\\>\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\ArrayObj\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\FunctionCall\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\IntoKeyword\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\|PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
+			count: 1
+			path: src/Statements/SelectStatement.php
+
+		-
 			message: "#^Cannot call method build\\(\\) on PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
 			count: 1
 			path: src/Statements/SetStatement.php

--- a/src/Statements/SelectStatement.php
+++ b/src/Statements/SelectStatement.php
@@ -15,7 +15,15 @@ use PhpMyAdmin\SqlParser\Components\JoinKeyword;
 use PhpMyAdmin\SqlParser\Components\Limit;
 use PhpMyAdmin\SqlParser\Components\OptionsArray;
 use PhpMyAdmin\SqlParser\Components\OrderKeyword;
+use PhpMyAdmin\SqlParser\Exceptions\ParserException;
+use PhpMyAdmin\SqlParser\Parser;
+use PhpMyAdmin\SqlParser\Parsers\OptionsArrays;
 use PhpMyAdmin\SqlParser\Statement;
+use PhpMyAdmin\SqlParser\TokensList;
+use PhpMyAdmin\SqlParser\TokenType;
+
+use function array_key_exists;
+use function is_string;
 
 /**
  * `SELECT` statement.
@@ -316,6 +324,206 @@ class SelectStatement extends Statement
      * @see SelectStatement::STATEMENT_END_OPTIONS
      */
     public OptionsArray|null $endOptions = null;
+
+    /**
+     * Parses the statements defined by the tokens list.
+     *
+     * @param Parser     $parser the instance that requests parsing
+     * @param TokensList $list   the list of tokens to be parsed
+     *
+     * @throws ParserException
+     */
+    public function parse(Parser $parser, TokensList $list): void
+    {
+        /**
+         * Array containing all list of clauses parsed.
+         * This is used to check for duplicates.
+         */
+        $parsedClauses = [];
+
+        // This may be corrected by the parser.
+        $this->first = $list->idx;
+
+        /**
+         * Whether options were parsed or not.
+         * For statements that do not have any options this is set to `true` by
+         * default.
+         */
+        $parsedOptions = static::$statementOptions === [];
+
+        for (; $list->idx < $list->count; ++$list->idx) {
+            /**
+             * Token parsed at this moment.
+             */
+            $token = $list->tokens[$list->idx];
+
+            // End of statement.
+            if ($token->type === TokenType::Delimiter) {
+                break;
+            }
+
+            // Checking if this closing bracket is the pair for a bracket
+            // outside the statement.
+            if (($token->value === ')') && ($parser->brackets > 0)) {
+                --$parser->brackets;
+                continue;
+            }
+
+            // Only keywords are relevant here. Other parts of the query are
+            // processed in the functions below.
+            if ($token->type !== TokenType::Keyword) {
+                if (($token->type !== TokenType::Comment) && ($token->type !== TokenType::Whitespace)) {
+                    $parser->error('Unexpected token.', $token);
+                }
+
+                continue;
+            }
+
+            // Unions are parsed by the parser because they represent more than
+            // one statement.
+            if (
+                ($token->keyword === 'UNION') ||
+                ($token->keyword === 'UNION ALL') ||
+                ($token->keyword === 'UNION DISTINCT') ||
+                ($token->keyword === 'EXCEPT') ||
+                ($token->keyword === 'INTERSECT')
+            ) {
+                break;
+            }
+
+            $lastIdx = $list->idx;
+
+            // ON DUPLICATE KEY UPDATE ...
+            // has to be parsed in parent statement (INSERT or REPLACE)
+            // so look for it and break
+            if ($token->value === 'ON') {
+                ++$list->idx; // Skip ON
+
+                // look for ON DUPLICATE KEY UPDATE
+                $first = $list->getNextOfType(TokenType::Keyword);
+                $second = $list->getNextOfType(TokenType::Keyword);
+                $third = $list->getNextOfType(TokenType::Keyword);
+
+                if (
+                    $first && $second && $third
+                    && $first->value === 'DUPLICATE'
+                    && $second->value === 'KEY'
+                    && $third->value === 'UPDATE'
+                ) {
+                    $list->idx = $lastIdx;
+                    break;
+                }
+            }
+
+            $list->idx = $lastIdx;
+
+            /**
+             * The name of the class that is used for parsing.
+             */
+            $class = null;
+
+            /**
+             * The name of the field where the result of the parsing is stored.
+             */
+            $field = null;
+
+            /**
+             * Parser's options.
+             */
+            $options = [];
+
+            // Looking for duplicated clauses.
+            if (
+                is_string($token->value)
+                && (
+                    isset(Parser::KEYWORD_PARSERS[$token->value])
+                    || (
+                        isset(Parser::STATEMENT_PARSERS[$token->value])
+                        && Parser::STATEMENT_PARSERS[$token->value] !== ''
+                    )
+                )
+            ) {
+                if (array_key_exists($token->value, $parsedClauses)) {
+                    $parser->error('This type of clause was previously parsed.', $token);
+                    break;
+                }
+
+                $parsedClauses[$token->value] = true;
+            }
+
+            // Checking if this is the beginning of a clause.
+            // Fix Issue #221: As `truncate` is not a keyword,
+            // but it might be the beginning of a statement of truncate,
+            // so let the value use the keyword field for truncate type.
+            $tokenValue = $token->keyword === 'TRUNCATE' ? $token->keyword : $token->value;
+            if (is_string($tokenValue) && isset(Parser::KEYWORD_PARSERS[$tokenValue]) && $list->idx < $list->count) {
+                $class = Parser::KEYWORD_PARSERS[$tokenValue]['class'];
+                $field = Parser::KEYWORD_PARSERS[$tokenValue]['field'];
+                if (isset(Parser::KEYWORD_PARSERS[$tokenValue]['options'])) {
+                    $options = Parser::KEYWORD_PARSERS[$tokenValue]['options'];
+                }
+            }
+
+            // Checking if this is the beginning of the statement.
+            if (
+                isset(Parser::STATEMENT_PARSERS[$token->keyword])
+                && Parser::STATEMENT_PARSERS[$token->keyword] !== ''
+            ) {
+                if (static::$clauses !== [] && is_string($token->value) && ! isset(static::$clauses[$token->value])) {
+                    // Some keywords (e.g. `SET`) may be the beginning of a
+                    // statement and a clause.
+                    // If such keyword was found, and it cannot be a clause of
+                    // this statement it means it is a new statement, but no
+                    // delimiter was found between them.
+                    $parser->error(
+                        'A new statement was found, but no delimiter between it and the previous one.',
+                        $token,
+                    );
+                    break;
+                }
+
+                if (! $parsedOptions) {
+                    if (! array_key_exists((string) $token->value, static::$statementOptions)) {
+                        // Skipping keyword because if it is not a option.
+                        ++$list->idx;
+                    }
+
+                    $this->options = OptionsArrays::parse($parser, $list, static::$statementOptions);
+                    $parsedOptions = true;
+                }
+            } elseif ($class === null) {
+                if ($token->value === 'WITH ROLLUP') {
+                    // Handle group options in Select statement
+                    $this->groupOptions = OptionsArrays::parse($parser, $list, self::STATEMENT_GROUP_OPTIONS);
+                } elseif ($token->value === 'FOR UPDATE' || $token->value === 'LOCK IN SHARE MODE') {
+                    // Handle special end options in Select statement
+                    $this->endOptions = OptionsArrays::parse($parser, $list, self::STATEMENT_END_OPTIONS);
+                } else {
+                    // There is no parser for this keyword and isn't the beginning
+                    // of a statement (so no options) either.
+                    $parser->error('Unrecognized keyword.', $token);
+                    continue;
+                }
+            }
+
+            if ($class === null) {
+                continue;
+            }
+
+            // Parsing this keyword.
+            // We can't parse keyword at the end of statement
+            if ($list->idx >= $list->count) {
+                $parser->error('Keyword at end of statement.', $token);
+                continue;
+            }
+
+            ++$list->idx; // Skipping keyword or last option.
+            $this->$field = $class::parse($parser, $list, $options);
+        }
+
+        // This may be corrected by the parser.
+        $this->last = --$list->idx; // Go back to last used token.
+    }
 
     /**
      * Gets the clauses of this statement.


### PR DESCRIPTION
This removes SelectStatement specific code from Statement::parse() method.