### PR TITLE
Fix field name for when parsing index hints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -456,7 +456,7 @@ parameters:
 			path: src/Statement.php
 
 		-
-			message: "#^Access to an undefined property PhpMyAdmin\\\\SqlParser\\\\Statement\\:\\:\\$index_hints\\.$#"
+			message: "#^Access to an undefined property PhpMyAdmin\\\\SqlParser\\\\Statement\\:\\:\\$indexHints\\.$#"
 			count: 1
 			path: src/Statement.php
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -192,7 +192,7 @@ class Parser
         ],
         'FORCE' => [
             'class' => Parsers\IndexHints::class,
-            'field' => 'index_hints',
+            'field' => 'indexHints',
         ],
         'FROM' => [
             'class' => Parsers\ExpressionArray::class,
@@ -209,7 +209,7 @@ class Parser
         ],
         'IGNORE' => [
             'class' => Parsers\IndexHints::class,
-            'field' => 'index_hints',
+            'field' => 'indexHints',
         ],
         'INTO' => [
             'class' => Parsers\IntoKeywords::class,
@@ -331,7 +331,7 @@ class Parser
         ],
         'USE' => [
             'class' => Parsers\IndexHints::class,
-            'field' => 'index_hints',
+            'field' => 'indexHints',
         ],
         'VALUE' => [
             'class' => Parsers\Array2d::class,

--- a/tests/data/parser/parseSelectIndexHint1.out
+++ b/tests/data/parser/parseSelectIndexHint1.out
@@ -503,35 +503,7 @@
                         "subquery": null
                     }
                 ],
-                "indexHints": null,
-                "partition": null,
-                "where": [
-                    {
-                        "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
-                        "identifiers": [
-                            "city_id"
-                        ],
-                        "isOperator": false,
-                        "expr": "city_id<0"
-                    }
-                ],
-                "group": null,
-                "groupOptions": null,
-                "having": null,
-                "order": null,
-                "limit": null,
-                "procedure": null,
-                "into": null,
-                "join": null,
-                "union": [],
-                "endOptions": null,
-                "options": {
-                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
-                },
-                "first": 0,
-                "last": 37,
-                "index_hints": [
+                "indexHints": [
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\IndexHint",
                         "type": "FORCE",
@@ -568,7 +540,34 @@
                             }
                         ]
                     }
-                ]
+                ],
+                "partition": null,
+                "where": [
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
+                        "identifiers": [
+                            "city_id"
+                        ],
+                        "isOperator": false,
+                        "expr": "city_id<0"
+                    }
+                ],
+                "group": null,
+                "groupOptions": null,
+                "having": null,
+                "order": null,
+                "limit": null,
+                "procedure": null,
+                "into": null,
+                "join": null,
+                "union": [],
+                "endOptions": null,
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 0,
+                "last": 37
             }
         ],
         "brackets": 0

--- a/tests/data/parser/parseSelectIndexHint2.out
+++ b/tests/data/parser/parseSelectIndexHint2.out
@@ -492,35 +492,7 @@
                         "subquery": null
                     }
                 ],
-                "indexHints": null,
-                "partition": null,
-                "where": [
-                    {
-                        "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
-                        "identifiers": [
-                            "city_id"
-                        ],
-                        "isOperator": false,
-                        "expr": "city_id<0"
-                    }
-                ],
-                "group": null,
-                "groupOptions": null,
-                "having": null,
-                "order": null,
-                "limit": null,
-                "procedure": null,
-                "into": null,
-                "join": null,
-                "union": [],
-                "endOptions": null,
-                "options": {
-                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
-                },
-                "first": 0,
-                "last": 37,
-                "index_hints": [
+                "indexHints": [
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\IndexHint",
                         "type": "USE",
@@ -557,7 +529,34 @@
                             }
                         ]
                     }
-                ]
+                ],
+                "partition": null,
+                "where": [
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
+                        "identifiers": [
+                            "city_id"
+                        ],
+                        "isOperator": false,
+                        "expr": "city_id<0"
+                    }
+                ],
+                "group": null,
+                "groupOptions": null,
+                "having": null,
+                "order": null,
+                "limit": null,
+                "procedure": null,
+                "into": null,
+                "join": null,
+                "union": [],
+                "endOptions": null,
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 0,
+                "last": 37
             }
         ],
         "brackets": 0

--- a/tests/data/parser/parseSelectIndexHintErr1.out
+++ b/tests/data/parser/parseSelectIndexHintErr1.out
@@ -248,26 +248,7 @@
                         "subquery": null
                     }
                 ],
-                "indexHints": null,
-                "partition": null,
-                "where": null,
-                "group": null,
-                "groupOptions": null,
-                "having": null,
-                "order": null,
-                "limit": null,
-                "procedure": null,
-                "into": null,
-                "join": null,
-                "union": [],
-                "endOptions": null,
-                "options": {
-                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
-                },
-                "first": 0,
-                "last": 14,
-                "index_hints": [
+                "indexHints": [
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\IndexHint",
                         "type": "FORCE",
@@ -286,7 +267,25 @@
                             }
                         ]
                     }
-                ]
+                ],
+                "partition": null,
+                "where": null,
+                "group": null,
+                "groupOptions": null,
+                "having": null,
+                "order": null,
+                "limit": null,
+                "procedure": null,
+                "into": null,
+                "join": null,
+                "union": [],
+                "endOptions": null,
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 0,
+                "last": 14
             }
         ],
         "brackets": 0

--- a/tests/data/parser/parseSelectIndexHintErr2.out
+++ b/tests/data/parser/parseSelectIndexHintErr2.out
@@ -248,7 +248,7 @@
                         "subquery": null
                     }
                 ],
-                "indexHints": null,
+                "indexHints": [],
                 "partition": null,
                 "where": null,
                 "group": null,
@@ -266,8 +266,7 @@
                     "options": []
                 },
                 "first": 0,
-                "last": 14,
-                "index_hints": []
+                "last": 14
             }
         ],
         "brackets": 0

--- a/tests/data/parser/parseSelectIndexHintErr3.out
+++ b/tests/data/parser/parseSelectIndexHintErr3.out
@@ -292,7 +292,7 @@
                         "subquery": null
                     }
                 ],
-                "indexHints": null,
+                "indexHints": [],
                 "partition": null,
                 "where": null,
                 "group": null,
@@ -310,8 +310,7 @@
                     "options": []
                 },
                 "first": 0,
-                "last": 18,
-                "index_hints": []
+                "last": 18
             }
         ],
         "brackets": 0

--- a/tests/data/parser/parseSelectIndexHintErr4.out
+++ b/tests/data/parser/parseSelectIndexHintErr4.out
@@ -292,26 +292,7 @@
                         "subquery": null
                     }
                 ],
-                "indexHints": null,
-                "partition": null,
-                "where": null,
-                "group": null,
-                "groupOptions": null,
-                "having": null,
-                "order": null,
-                "limit": null,
-                "procedure": null,
-                "into": null,
-                "join": null,
-                "union": [],
-                "endOptions": null,
-                "options": {
-                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                    "options": []
-                },
-                "first": 0,
-                "last": 18,
-                "index_hints": [
+                "indexHints": [
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\IndexHint",
                         "type": "FORCE",
@@ -330,7 +311,25 @@
                             }
                         ]
                     }
-                ]
+                ],
+                "partition": null,
+                "where": null,
+                "group": null,
+                "groupOptions": null,
+                "having": null,
+                "order": null,
+                "limit": null,
+                "procedure": null,
+                "into": null,
+                "join": null,
+                "union": [],
+                "endOptions": null,
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 0,
+                "last": 18
             }
         ],
         "brackets": 0


### PR DESCRIPTION
This didn't fail because Statement classes allows dynamic properties.