### PR TITLE
Add basic details for Condition

### DIFF
--- a/src/Components/Condition.php
+++ b/src/Components/Condition.php
@@ -27,6 +27,10 @@ final class Condition implements Component
      */
     public string $expr;
 
+    public string $leftOperand = '';
+    public string $operator = '';
+    public string $rightOperand = '';
+
     /** @param string $expr the condition or the operator */
     public function __construct(string|null $expr = null)
     {

--- a/tests/data/bugs/gh202.out
+++ b/tests/data/bugs/gh202.out
@@ -321,7 +321,10 @@
                             "id"
                         ],
                         "isOperator": false,
-                        "expr": "t.id=1"
+                        "expr": "t.id=1",
+                        "leftOperand": "t.id",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": null,

--- a/tests/data/bugs/gh492.out
+++ b/tests/data/bugs/gh492.out
@@ -274,7 +274,10 @@
                             "orderid"
                         ],
                         "isOperator": false,
-                        "expr": "orderid = ?"
+                        "expr": "orderid = ?",
+                        "leftOperand": "orderid",
+                        "operator": "=",
+                        "rightOperand": "?"
                     }
                 ],
                 "order": null,

--- a/tests/data/bugs/gh496.out
+++ b/tests/data/bugs/gh496.out
@@ -479,7 +479,10 @@
                                     "i"
                                 ],
                                 "isOperator": false,
-                                "expr": "io.id = i.id"
+                                "expr": "io.id = i.id",
+                                "leftOperand": "io.id",
+                                "operator": "=",
+                                "rightOperand": "i.id"
                             }
                         ],
                         "using": null

--- a/tests/data/bugs/gh498.out
+++ b/tests/data/bugs/gh498.out
@@ -452,7 +452,10 @@
                                     "uno"
                                 ],
                                 "isOperator": false,
-                                "expr": "dos.id = uno.id"
+                                "expr": "dos.id = uno.id",
+                                "leftOperand": "dos.id",
+                                "operator": "=",
+                                "rightOperand": "uno.id"
                             }
                         ],
                         "using": null

--- a/tests/data/bugs/gh511.out
+++ b/tests/data/bugs/gh511.out
@@ -794,7 +794,10 @@
                             "id_users_type"
                         ],
                         "isOperator": false,
-                        "expr": "id_users_type = 19"
+                        "expr": "id_users_type = 19",
+                        "leftOperand": "id_users_type",
+                        "operator": "=",
+                        "rightOperand": "19"
                     }
                 ],
                 "order": null,

--- a/tests/data/bugs/pma11836.out
+++ b/tests/data/bugs/pma11836.out
@@ -568,13 +568,19 @@
                             "nombre"
                         ],
                         "isOperator": false,
-                        "expr": "id = IF(id = 1, id, nombre)"
+                        "expr": "id = IF(id = 1, id, nombre)",
+                        "leftOperand": "id",
+                        "operator": "=",
+                        "rightOperand": "IF(id = 1, id, nombre)"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "AND"
+                        "expr": "AND",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -583,7 +589,10 @@
                             "alumnos"
                         ],
                         "isOperator": false,
-                        "expr": "id not in (SELECT id FROM alumnos)"
+                        "expr": "id not in (SELECT id FROM alumnos)",
+                        "leftOperand": "id not in (SELECT id FROM alumnos)",
+                        "operator": "",
+                        "rightOperand": ""
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseCreateOrReplaceView1.out
+++ b/tests/data/parser/parseCreateOrReplaceView1.out
@@ -682,7 +682,10 @@
                                 "1990-01-19"
                             ],
                             "isOperator": false,
-                            "expr": "(mytable.birth > '1990-01-19')"
+                            "expr": "(mytable.birth > '1990-01-19')",
+                            "leftOperand": "(mytable.birth",
+                            "operator": ">",
+                            "rightOperand": "'1990-01-19')"
                         }
                     ],
                     "group": [

--- a/tests/data/parser/parseCreateView3.out
+++ b/tests/data/parser/parseCreateView3.out
@@ -473,7 +473,10 @@
                                 "one space"
                             ],
                             "isOperator": false,
-                            "expr": "`one space` > 3.0"
+                            "expr": "`one space` > 3.0",
+                            "leftOperand": "`one space`",
+                            "operator": ">",
+                            "rightOperand": "3.0"
                         }
                     ],
                     "group": null,

--- a/tests/data/parser/parseCreateViewWithUnion.out
+++ b/tests/data/parser/parseCreateViewWithUnion.out
@@ -606,7 +606,10 @@
                                 "M"
                             ],
                             "isOperator": false,
-                            "expr": "`employees`.`gender` = 'M'"
+                            "expr": "`employees`.`gender` = 'M'",
+                            "leftOperand": "`employees`.`gender`",
+                            "operator": "=",
+                            "rightOperand": "'M'"
                         }
                     ],
                     "group": null,

--- a/tests/data/parser/parseDelete.out
+++ b/tests/data/parser/parseDelete.out
@@ -486,13 +486,19 @@
                             "id"
                         ],
                         "isOperator": false,
-                        "expr": "`id`<3"
+                        "expr": "`id`<3",
+                        "leftOperand": "`id`",
+                        "operator": "<",
+                        "rightOperand": "3"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "AND"
+                        "expr": "AND",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -501,13 +507,19 @@
                             "Dan"
                         ],
                         "isOperator": false,
-                        "expr": "(username=\"Dan\""
+                        "expr": "(username=\"Dan\"",
+                        "leftOperand": "(username",
+                        "operator": "=",
+                        "rightOperand": "\"Dan\""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "OR"
+                        "expr": "OR",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -516,7 +528,10 @@
                             "Paul"
                         ],
                         "isOperator": false,
-                        "expr": "username=\"Paul\")"
+                        "expr": "username=\"Paul\")",
+                        "leftOperand": "username",
+                        "operator": "=",
+                        "rightOperand": "\"Paul\")"
                     }
                 ],
                 "order": [

--- a/tests/data/parser/parseDelete10.out
+++ b/tests/data/parser/parseDelete10.out
@@ -443,7 +443,10 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": false,
-                        "expr": "1=1"
+                        "expr": "1=1",
+                        "leftOperand": "1",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseDelete11.out
+++ b/tests/data/parser/parseDelete11.out
@@ -467,7 +467,10 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": false,
-                        "expr": "1=1"
+                        "expr": "1=1",
+                        "leftOperand": "1",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseDelete12.out
+++ b/tests/data/parser/parseDelete12.out
@@ -291,7 +291,10 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": false,
-                        "expr": "1=1"
+                        "expr": "1=1",
+                        "leftOperand": "1",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseDelete13.out
+++ b/tests/data/parser/parseDelete13.out
@@ -261,7 +261,10 @@
                             "salary"
                         ],
                         "isOperator": false,
-                        "expr": "x.salary = 20"
+                        "expr": "x.salary = 20",
+                        "leftOperand": "x.salary",
+                        "operator": "=",
+                        "rightOperand": "20"
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseDelete3.out
+++ b/tests/data/parser/parseDelete3.out
@@ -214,7 +214,10 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": false,
-                        "expr": "1=1"
+                        "expr": "1=1",
+                        "leftOperand": "1",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseDelete4.out
+++ b/tests/data/parser/parseDelete4.out
@@ -258,7 +258,10 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": false,
-                        "expr": "1=1"
+                        "expr": "1=1",
+                        "leftOperand": "1",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": [

--- a/tests/data/parser/parseDelete5.out
+++ b/tests/data/parser/parseDelete5.out
@@ -324,7 +324,10 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": false,
-                        "expr": "1=1"
+                        "expr": "1=1",
+                        "leftOperand": "1",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": [

--- a/tests/data/parser/parseDeleteErr11.out
+++ b/tests/data/parser/parseDeleteErr11.out
@@ -260,7 +260,10 @@
                             "a"
                         ],
                         "isOperator": false,
-                        "expr": "a = 1"
+                        "expr": "a = 1",
+                        "leftOperand": "a",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseDeleteErr4.out
+++ b/tests/data/parser/parseDeleteErr4.out
@@ -512,7 +512,10 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": false,
-                        "expr": "1=1"
+                        "expr": "1=1",
+                        "leftOperand": "1",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseDeleteErr5.out
+++ b/tests/data/parser/parseDeleteErr5.out
@@ -346,7 +346,10 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": false,
-                        "expr": "1=1"
+                        "expr": "1=1",
+                        "leftOperand": "1",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": [

--- a/tests/data/parser/parseDeleteErr6.out
+++ b/tests/data/parser/parseDeleteErr6.out
@@ -523,7 +523,10 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": false,
-                        "expr": "1=1"
+                        "expr": "1=1",
+                        "leftOperand": "1",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseDeleteErr7.out
+++ b/tests/data/parser/parseDeleteErr7.out
@@ -326,7 +326,10 @@
                             "a"
                         ],
                         "isOperator": false,
-                        "expr": "a = 1"
+                        "expr": "a = 1",
+                        "leftOperand": "a",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": [

--- a/tests/data/parser/parseDeleteJoin.out
+++ b/tests/data/parser/parseDeleteJoin.out
@@ -545,13 +545,19 @@
                             "t2"
                         ],
                         "isOperator": false,
-                        "expr": "t1.id=t2.id"
+                        "expr": "t1.id=t2.id",
+                        "leftOperand": "t1.id",
+                        "operator": "=",
+                        "rightOperand": "t2.id"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "AND"
+                        "expr": "AND",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -561,7 +567,10 @@
                             "t3"
                         ],
                         "isOperator": false,
-                        "expr": "t2.id=t3.id"
+                        "expr": "t2.id=t3.id",
+                        "leftOperand": "t2.id",
+                        "operator": "=",
+                        "rightOperand": "t3.id"
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseExplain3.out
+++ b/tests/data/parser/parseExplain3.out
@@ -945,13 +945,19 @@
                                                 "payment"
                                             ],
                                             "isOperator": false,
-                                            "expr": "staff.staff_id = payment.staff_id"
+                                            "expr": "staff.staff_id = payment.staff_id",
+                                            "leftOperand": "staff.staff_id",
+                                            "operator": "=",
+                                            "rightOperand": "payment.staff_id"
                                         },
                                         {
                                             "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                             "identifiers": [],
                                             "isOperator": true,
-                                            "expr": "AND"
+                                            "expr": "AND",
+                                            "leftOperand": "",
+                                            "operator": "",
+                                            "rightOperand": ""
                                         },
                                         {
                                             "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -960,7 +966,10 @@
                                                 "2005-08%"
                                             ],
                                             "isOperator": false,
-                                            "expr": "payment_date LIKE '2005-08%'"
+                                            "expr": "payment_date LIKE '2005-08%'",
+                                            "leftOperand": "payment_date LIKE '2005-08%'",
+                                            "operator": "",
+                                            "rightOperand": ""
                                         }
                                     ],
                                     "using": null

--- a/tests/data/parser/parseSelect.out
+++ b/tests/data/parser/parseSelect.out
@@ -1015,7 +1015,10 @@
                             "id"
                         ],
                         "isOperator": false,
-                        "expr": "id > 0"
+                        "expr": "id > 0",
+                        "leftOperand": "id",
+                        "operator": ">",
+                        "rightOperand": "0"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelect10.out
+++ b/tests/data/parser/parseSelect10.out
@@ -357,7 +357,10 @@
                             "UPPER"
                         ],
                         "isOperator": false,
-                        "expr": "BINARY(my_column) != BINARY(UPPER(my_column))"
+                        "expr": "BINARY(my_column) != BINARY(UPPER(my_column))",
+                        "leftOperand": "BINARY(my_column)",
+                        "operator": "!=",
+                        "rightOperand": "BINARY(UPPER(my_column))"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelect13.out
+++ b/tests/data/parser/parseSelect13.out
@@ -11970,7 +11970,10 @@
                             "postid"
                         ],
                         "isOperator": false,
-                        "expr": "post.postid IN (0,3254399,3254508,3254743,3254817,3254969,3255328,3255582,3257603,3257873,3258126,3258150,3258254,3258272,3258311,3260767,3260770,3260776,3261180,3261263,3261317,3261318)"
+                        "expr": "post.postid IN (0,3254399,3254508,3254743,3254817,3254969,3255328,3255582,3257603,3257873,3258126,3258150,3258254,3258272,3258311,3260767,3260770,3260776,3261180,3261263,3261317,3261318)",
+                        "leftOperand": "post.postid IN (0,3254399,3254508,3254743,3254817,3254969,3255328,3255582,3257603,3257873,3258126,3258150,3258254,3258272,3258311,3260767,3260770,3260776,3261180,3261263,3261317,3261318)",
+                        "operator": "",
+                        "rightOperand": ""
                     }
                 ],
                 "group": null,
@@ -12018,7 +12021,10 @@
                                     "post"
                                 ],
                                 "isOperator": false,
-                                "expr": "(user.userid = post.userid)"
+                                "expr": "(user.userid = post.userid)",
+                                "leftOperand": "(user.userid",
+                                "operator": "=",
+                                "rightOperand": "post.userid)"
                             }
                         ],
                         "using": null
@@ -12045,7 +12051,10 @@
                                     "user"
                                 ],
                                 "isOperator": false,
-                                "expr": "(userfield.userid = user.userid)"
+                                "expr": "(userfield.userid = user.userid)",
+                                "leftOperand": "(userfield.userid",
+                                "operator": "=",
+                                "rightOperand": "user.userid)"
                             }
                         ],
                         "using": null
@@ -12072,7 +12081,10 @@
                                     "user"
                                 ],
                                 "isOperator": false,
-                                "expr": "(usertextfield.userid = user.userid)"
+                                "expr": "(usertextfield.userid = user.userid)",
+                                "leftOperand": "(usertextfield.userid",
+                                "operator": "=",
+                                "rightOperand": "user.userid)"
                             }
                         ],
                         "using": null
@@ -12099,7 +12111,10 @@
                                     "post"
                                 ],
                                 "isOperator": false,
-                                "expr": "(icon.iconid = post.iconid)"
+                                "expr": "(icon.iconid = post.iconid)",
+                                "leftOperand": "(icon.iconid",
+                                "operator": "=",
+                                "rightOperand": "post.iconid)"
                             }
                         ],
                         "using": null
@@ -12126,7 +12141,10 @@
                                     "user"
                                 ],
                                 "isOperator": false,
-                                "expr": "(avatar.avatarid = user.avatarid)"
+                                "expr": "(avatar.avatarid = user.avatarid)",
+                                "leftOperand": "(avatar.avatarid",
+                                "operator": "=",
+                                "rightOperand": "user.avatarid)"
                             }
                         ],
                         "using": null
@@ -12153,7 +12171,10 @@
                                     "user"
                                 ],
                                 "isOperator": false,
-                                "expr": "(customavatar.userid = user.userid)"
+                                "expr": "(customavatar.userid = user.userid)",
+                                "leftOperand": "(customavatar.userid",
+                                "operator": "=",
+                                "rightOperand": "user.userid)"
                             }
                         ],
                         "using": null
@@ -12180,7 +12201,10 @@
                                     "post"
                                 ],
                                 "isOperator": false,
-                                "expr": "(spamlog.postid = post.postid)"
+                                "expr": "(spamlog.postid = post.postid)",
+                                "leftOperand": "(spamlog.postid",
+                                "operator": "=",
+                                "rightOperand": "post.postid)"
                             }
                         ],
                         "using": null
@@ -12208,13 +12232,19 @@
                                     "primaryid"
                                 ],
                                 "isOperator": false,
-                                "expr": "(post.postid = deletionlog.primaryid"
+                                "expr": "(post.postid = deletionlog.primaryid",
+                                "leftOperand": "(post.postid",
+                                "operator": "=",
+                                "rightOperand": "deletionlog.primaryid"
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                 "identifiers": [],
                                 "isOperator": true,
-                                "expr": "AND"
+                                "expr": "AND",
+                                "leftOperand": "",
+                                "operator": "",
+                                "rightOperand": ""
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -12224,7 +12254,10 @@
                                     "post"
                                 ],
                                 "isOperator": false,
-                                "expr": "deletionlog.type = 'post')"
+                                "expr": "deletionlog.type = 'post')",
+                                "leftOperand": "deletionlog.type",
+                                "operator": "=",
+                                "rightOperand": "'post')"
                             }
                         ],
                         "using": null
@@ -12251,7 +12284,10 @@
                                     "post"
                                 ],
                                 "isOperator": false,
-                                "expr": "(editlog.postid = post.postid)"
+                                "expr": "(editlog.postid = post.postid)",
+                                "leftOperand": "(editlog.postid",
+                                "operator": "=",
+                                "rightOperand": "post.postid)"
                             }
                         ],
                         "using": null
@@ -12278,13 +12314,19 @@
                                     "post"
                                 ],
                                 "isOperator": false,
-                                "expr": "(postparsed.postid = post.postid"
+                                "expr": "(postparsed.postid = post.postid",
+                                "leftOperand": "(postparsed.postid",
+                                "operator": "=",
+                                "rightOperand": "post.postid"
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                 "identifiers": [],
                                 "isOperator": true,
-                                "expr": "AND"
+                                "expr": "AND",
+                                "leftOperand": "",
+                                "operator": "",
+                                "rightOperand": ""
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -12293,13 +12335,19 @@
                                     "styleid"
                                 ],
                                 "isOperator": false,
-                                "expr": "postparsed.styleid = 23"
+                                "expr": "postparsed.styleid = 23",
+                                "leftOperand": "postparsed.styleid",
+                                "operator": "=",
+                                "rightOperand": "23"
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                 "identifiers": [],
                                 "isOperator": true,
-                                "expr": "AND"
+                                "expr": "AND",
+                                "leftOperand": "",
+                                "operator": "",
+                                "rightOperand": ""
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -12308,7 +12356,10 @@
                                     "languageid"
                                 ],
                                 "isOperator": false,
-                                "expr": "postparsed.languageid = 5)"
+                                "expr": "postparsed.languageid = 5)",
+                                "leftOperand": "postparsed.languageid",
+                                "operator": "=",
+                                "rightOperand": "5)"
                             }
                         ],
                         "using": null
@@ -12335,13 +12386,19 @@
                                     "user"
                                 ],
                                 "isOperator": false,
-                                "expr": "(sigparsed.userid = user.userid"
+                                "expr": "(sigparsed.userid = user.userid",
+                                "leftOperand": "(sigparsed.userid",
+                                "operator": "=",
+                                "rightOperand": "user.userid"
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                 "identifiers": [],
                                 "isOperator": true,
-                                "expr": "AND"
+                                "expr": "AND",
+                                "leftOperand": "",
+                                "operator": "",
+                                "rightOperand": ""
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -12350,13 +12407,19 @@
                                     "styleid"
                                 ],
                                 "isOperator": false,
-                                "expr": "sigparsed.styleid = 23"
+                                "expr": "sigparsed.styleid = 23",
+                                "leftOperand": "sigparsed.styleid",
+                                "operator": "=",
+                                "rightOperand": "23"
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                 "identifiers": [],
                                 "isOperator": true,
-                                "expr": "AND"
+                                "expr": "AND",
+                                "leftOperand": "",
+                                "operator": "",
+                                "rightOperand": ""
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -12365,7 +12428,10 @@
                                     "languageid"
                                 ],
                                 "isOperator": false,
-                                "expr": "sigparsed.languageid = 5)"
+                                "expr": "sigparsed.languageid = 5)",
+                                "leftOperand": "sigparsed.languageid",
+                                "operator": "=",
+                                "rightOperand": "5)"
                             }
                         ],
                         "using": null
@@ -12392,7 +12458,10 @@
                                     "post"
                                 ],
                                 "isOperator": false,
-                                "expr": "(sigpic.userid = post.userid)"
+                                "expr": "(sigpic.userid = post.userid)",
+                                "leftOperand": "(sigpic.userid",
+                                "operator": "=",
+                                "rightOperand": "post.userid)"
                             }
                         ],
                         "using": null
@@ -12420,7 +12489,10 @@
                                     "postid"
                                 ],
                                 "isOperator": false,
-                                "expr": "post_icon_list.post_id=post.postid"
+                                "expr": "post_icon_list.post_id=post.postid",
+                                "leftOperand": "post_icon_list.post_id",
+                                "operator": "=",
+                                "rightOperand": "post.postid"
                             }
                         ],
                         "using": null
@@ -12448,13 +12520,19 @@
                                     "postid"
                                 ],
                                 "isOperator": false,
-                                "expr": "(approvedlog.itemid=post.postid"
+                                "expr": "(approvedlog.itemid=post.postid",
+                                "leftOperand": "(approvedlog.itemid",
+                                "operator": "=",
+                                "rightOperand": "post.postid"
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                 "identifiers": [],
                                 "isOperator": true,
-                                "expr": "AND"
+                                "expr": "AND",
+                                "leftOperand": "",
+                                "operator": "",
+                                "rightOperand": ""
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -12464,7 +12542,10 @@
                                     "postapprove"
                                 ],
                                 "isOperator": false,
-                                "expr": "approvedlog.action='postapprove')"
+                                "expr": "approvedlog.action='postapprove')",
+                                "leftOperand": "approvedlog.action",
+                                "operator": "=",
+                                "rightOperand": "'postapprove')"
                             }
                         ],
                         "using": null
@@ -12492,13 +12573,19 @@
                                     "postid"
                                 ],
                                 "isOperator": false,
-                                "expr": "(movedlog.itemid=post.postid"
+                                "expr": "(movedlog.itemid=post.postid",
+                                "leftOperand": "(movedlog.itemid",
+                                "operator": "=",
+                                "rightOperand": "post.postid"
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                 "identifiers": [],
                                 "isOperator": true,
-                                "expr": "AND"
+                                "expr": "AND",
+                                "leftOperand": "",
+                                "operator": "",
+                                "rightOperand": ""
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -12508,7 +12595,10 @@
                                     "postmove"
                                 ],
                                 "isOperator": false,
-                                "expr": "movedlog.action='postmove')"
+                                "expr": "movedlog.action='postmove')",
+                                "leftOperand": "movedlog.action",
+                                "operator": "=",
+                                "rightOperand": "'postmove')"
                             }
                         ],
                         "using": null
@@ -12536,7 +12626,10 @@
                                     "postid"
                                 ],
                                 "isOperator": false,
-                                "expr": "scheduled_approval.post_id = post.postid"
+                                "expr": "scheduled_approval.post_id = post.postid",
+                                "leftOperand": "scheduled_approval.post_id",
+                                "operator": "=",
+                                "rightOperand": "post.postid"
                             }
                         ],
                         "using": null
@@ -12563,7 +12656,10 @@
                                     "post"
                                 ],
                                 "isOperator": false,
-                                "expr": "additional_user_data.userid=post.userid"
+                                "expr": "additional_user_data.userid=post.userid",
+                                "leftOperand": "additional_user_data.userid",
+                                "operator": "=",
+                                "rightOperand": "post.userid"
                             }
                         ],
                         "using": null
@@ -12591,7 +12687,10 @@
                                     "postid"
                                 ],
                                 "isOperator": false,
-                                "expr": "paid_post_activation.post_id = post.postid"
+                                "expr": "paid_post_activation.post_id = post.postid",
+                                "leftOperand": "paid_post_activation.post_id",
+                                "operator": "=",
+                                "rightOperand": "post.postid"
                             }
                         ],
                         "using": null
@@ -12619,7 +12718,10 @@
                                     "userid"
                                 ],
                                 "isOperator": false,
-                                "expr": "alm_Model_UserData.user_id=user.userid"
+                                "expr": "alm_Model_UserData.user_id=user.userid",
+                                "leftOperand": "alm_Model_UserData.user_id",
+                                "operator": "=",
+                                "rightOperand": "user.userid"
                             }
                         ],
                         "using": null

--- a/tests/data/parser/parseSelect16.out
+++ b/tests/data/parser/parseSelect16.out
@@ -2970,13 +2970,19 @@
                                         "Y"
                                     ],
                                     "isOperator": false,
-                                    "expr": "p.cc = 'Y'"
+                                    "expr": "p.cc = 'Y'",
+                                    "leftOperand": "p.cc",
+                                    "operator": "=",
+                                    "rightOperand": "'Y'"
                                 },
                                 {
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                     "identifiers": [],
                                     "isOperator": true,
-                                    "expr": "AND"
+                                    "expr": "AND",
+                                    "leftOperand": "",
+                                    "operator": "",
+                                    "rightOperand": ""
                                 },
                                 {
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -2985,7 +2991,10 @@
                                         "Found"
                                     ],
                                     "isOperator": false,
-                                    "expr": "dd = 'Found'"
+                                    "expr": "dd = 'Found'",
+                                    "leftOperand": "dd",
+                                    "operator": "=",
+                                    "rightOperand": "'Found'"
                                 }
                             ],
                             [
@@ -2997,13 +3006,19 @@
                                         ""
                                     ],
                                     "isOperator": false,
-                                    "expr": "p.cc = ''"
+                                    "expr": "p.cc = ''",
+                                    "leftOperand": "p.cc",
+                                    "operator": "=",
+                                    "rightOperand": "''"
                                 },
                                 {
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                     "identifiers": [],
                                     "isOperator": true,
-                                    "expr": "AND"
+                                    "expr": "AND",
+                                    "leftOperand": "",
+                                    "operator": "",
+                                    "rightOperand": ""
                                 },
                                 {
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -3012,7 +3027,10 @@
                                         "Found"
                                     ],
                                     "isOperator": false,
-                                    "expr": "dd = 'Found'"
+                                    "expr": "dd = 'Found'",
+                                    "leftOperand": "dd",
+                                    "operator": "=",
+                                    "rightOperand": "'Found'"
                                 }
                             ]
                         ],
@@ -3064,7 +3082,10 @@
                                         "Found"
                                     ],
                                     "isOperator": false,
-                                    "expr": "dd = 'Found'"
+                                    "expr": "dd = 'Found'",
+                                    "leftOperand": "dd",
+                                    "operator": "=",
+                                    "rightOperand": "'Found'"
                                 }
                             ]
                         ],
@@ -3112,7 +3133,10 @@
                                         "2021-01-28"
                                     ],
                                     "isOperator": false,
-                                    "expr": "(SELECT MAX(cd) from LSA act group by act.an having p.acn = act.an) > '2021-01-28'"
+                                    "expr": "(SELECT MAX(cd) from LSA act group by act.an having p.acn = act.an) > '2021-01-28'",
+                                    "leftOperand": "(SELECT MAX(cd) from LSA act group by act.an having p.acn = act.an)",
+                                    "operator": ">",
+                                    "rightOperand": "'2021-01-28'"
                                 }
                             ],
                             [
@@ -3124,7 +3148,10 @@
                                         "2021-01-28"
                                     ],
                                     "isOperator": false,
-                                    "expr": "p.co < '2021-01-28'"
+                                    "expr": "p.co < '2021-01-28'",
+                                    "leftOperand": "p.co",
+                                    "operator": "<",
+                                    "rightOperand": "'2021-01-28'"
                                 }
                             ]
                         ],
@@ -3187,13 +3214,19 @@
                             "a"
                         ],
                         "isOperator": false,
-                        "expr": "p.a =1"
+                        "expr": "p.a =1",
+                        "leftOperand": "p.a",
+                        "operator": "=",
+                        "rightOperand": "1"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "AND"
+                        "expr": "AND",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -3202,13 +3235,19 @@
                             "mr"
                         ],
                         "isOperator": false,
-                        "expr": "p.mr = 1"
+                        "expr": "p.mr = 1",
+                        "leftOperand": "p.mr",
+                        "operator": "=",
+                        "rightOperand": "1"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "AND"
+                        "expr": "AND",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -3218,13 +3257,19 @@
                             "23"
                         ],
                         "isOperator": false,
-                        "expr": "p.sc<> '23'"
+                        "expr": "p.sc<> '23'",
+                        "leftOperand": "p.sc",
+                        "operator": "<>",
+                        "rightOperand": "'23'"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "AND"
+                        "expr": "AND",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -3234,13 +3279,19 @@
                             "TEXT"
                         ],
                         "isOperator": false,
-                        "expr": "qa.qt = 'TEXT'"
+                        "expr": "qa.qt = 'TEXT'",
+                        "leftOperand": "qa.qt",
+                        "operator": "=",
+                        "rightOperand": "'TEXT'"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "AND"
+                        "expr": "AND",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -3250,13 +3301,19 @@
                             "TEXT"
                         ],
                         "isOperator": false,
-                        "expr": "p.tl = \"TEXT\""
+                        "expr": "p.tl = \"TEXT\"",
+                        "leftOperand": "p.tl",
+                        "operator": "=",
+                        "rightOperand": "\"TEXT\""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "AND"
+                        "expr": "AND",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -3265,7 +3322,10 @@
                             "a"
                         ],
                         "isOperator": false,
-                        "expr": "qa.a = 1"
+                        "expr": "qa.a = 1",
+                        "leftOperand": "qa.a",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "group": null,
@@ -3299,7 +3359,10 @@
                                     "ID"
                                 ],
                                 "isOperator": false,
-                                "expr": "qa.pi = p.ID"
+                                "expr": "qa.pi = p.ID",
+                                "leftOperand": "qa.pi",
+                                "operator": "=",
+                                "rightOperand": "p.ID"
                             }
                         ],
                         "using": null
@@ -3327,7 +3390,10 @@
                                     "an"
                                 ],
                                 "isOperator": false,
-                                "expr": "p.acn = act.an"
+                                "expr": "p.acn = act.an",
+                                "leftOperand": "p.acn",
+                                "operator": "=",
+                                "rightOperand": "act.an"
                             }
                         ],
                         "using": null

--- a/tests/data/parser/parseSelect3.out
+++ b/tests/data/parser/parseSelect3.out
@@ -478,7 +478,10 @@
                             "id"
                         ],
                         "isOperator": false,
-                        "expr": "right_tbl.id IS NULL"
+                        "expr": "right_tbl.id IS NULL",
+                        "leftOperand": "right_tbl.id IS NULL",
+                        "operator": "",
+                        "rightOperand": ""
                     }
                 ],
                 "group": null,
@@ -511,7 +514,10 @@
                                     "right_tbl"
                                 ],
                                 "isOperator": false,
-                                "expr": "left_tbl.id = right_tbl.id"
+                                "expr": "left_tbl.id = right_tbl.id",
+                                "leftOperand": "left_tbl.id",
+                                "operator": "=",
+                                "rightOperand": "right_tbl.id"
                             }
                         ],
                         "using": null

--- a/tests/data/parser/parseSelect4.out
+++ b/tests/data/parser/parseSelect4.out
@@ -339,7 +339,10 @@
                             "AB"
                         ],
                         "isOperator": false,
-                        "expr": "RIGHT(name, 2) = 'AB'"
+                        "expr": "RIGHT(name, 2) = 'AB'",
+                        "leftOperand": "RIGHT(name, 2)",
+                        "operator": "=",
+                        "rightOperand": "'AB'"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelect5.out
+++ b/tests/data/parser/parseSelect5.out
@@ -625,7 +625,10 @@
                             "AB"
                         ],
                         "isOperator": false,
-                        "expr": "RIGHT(name, 2) = 'AB'"
+                        "expr": "RIGHT(name, 2) = 'AB'",
+                        "leftOperand": "RIGHT(name, 2)",
+                        "operator": "=",
+                        "rightOperand": "'AB'"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelect6.out
+++ b/tests/data/parser/parseSelect6.out
@@ -677,13 +677,19 @@
                                     "t1"
                                 ],
                                 "isOperator": false,
-                                "expr": "(t2.a=t1.a"
+                                "expr": "(t2.a=t1.a",
+                                "leftOperand": "(t2.a",
+                                "operator": "=",
+                                "rightOperand": "t1.a"
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                 "identifiers": [],
                                 "isOperator": true,
-                                "expr": "AND"
+                                "expr": "AND",
+                                "leftOperand": "",
+                                "operator": "",
+                                "rightOperand": ""
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -693,13 +699,19 @@
                                     "t1"
                                 ],
                                 "isOperator": false,
-                                "expr": "t3.b=t1.b"
+                                "expr": "t3.b=t1.b",
+                                "leftOperand": "t3.b",
+                                "operator": "=",
+                                "rightOperand": "t1.b"
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                 "identifiers": [],
                                 "isOperator": true,
-                                "expr": "AND"
+                                "expr": "AND",
+                                "leftOperand": "",
+                                "operator": "",
+                                "rightOperand": ""
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -709,7 +721,10 @@
                                     "t1"
                                 ],
                                 "isOperator": false,
-                                "expr": "t4.c=t1.c)"
+                                "expr": "t4.c=t1.c)",
+                                "leftOperand": "t4.c",
+                                "operator": "=",
+                                "rightOperand": "t1.c)"
                             }
                         ],
                         "using": null

--- a/tests/data/parser/parseSelect7.out
+++ b/tests/data/parser/parseSelect7.out
@@ -688,13 +688,19 @@
                                     "t1"
                                 ],
                                 "isOperator": false,
-                                "expr": "(t2.a=t1.a"
+                                "expr": "(t2.a=t1.a",
+                                "leftOperand": "(t2.a",
+                                "operator": "=",
+                                "rightOperand": "t1.a"
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                 "identifiers": [],
                                 "isOperator": true,
-                                "expr": "AND"
+                                "expr": "AND",
+                                "leftOperand": "",
+                                "operator": "",
+                                "rightOperand": ""
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -704,13 +710,19 @@
                                     "t1"
                                 ],
                                 "isOperator": false,
-                                "expr": "t3.b=t1.b"
+                                "expr": "t3.b=t1.b",
+                                "leftOperand": "t3.b",
+                                "operator": "=",
+                                "rightOperand": "t1.b"
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                 "identifiers": [],
                                 "isOperator": true,
-                                "expr": "AND"
+                                "expr": "AND",
+                                "leftOperand": "",
+                                "operator": "",
+                                "rightOperand": ""
                             },
                             {
                                 "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -720,7 +732,10 @@
                                     "t1"
                                 ],
                                 "isOperator": false,
-                                "expr": "t4.c=t1.c)"
+                                "expr": "t4.c=t1.c)",
+                                "leftOperand": "t4.c",
+                                "operator": "=",
+                                "rightOperand": "t1.c)"
                             }
                         ],
                         "using": null

--- a/tests/data/parser/parseSelect8.out
+++ b/tests/data/parser/parseSelect8.out
@@ -447,7 +447,10 @@
                             "y"
                         ],
                         "isOperator": false,
-                        "expr": "p.x=t.y"
+                        "expr": "p.x=t.y",
+                        "leftOperand": "p.x",
+                        "operator": "=",
+                        "rightOperand": "t.y"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelect9.out
+++ b/tests/data/parser/parseSelect9.out
@@ -887,13 +887,19 @@
                             "2016-03-01"
                         ],
                         "isOperator": false,
-                        "expr": "casein_pipe > '2016-03-01'"
+                        "expr": "casein_pipe > '2016-03-01'",
+                        "leftOperand": "casein_pipe",
+                        "operator": ">",
+                        "rightOperand": "'2016-03-01'"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "AND"
+                        "expr": "AND",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -901,13 +907,19 @@
                             "campaign_id_pipe"
                         ],
                         "isOperator": false,
-                        "expr": "`campaign_id_pipe` = 24569"
+                        "expr": "`campaign_id_pipe` = 24569",
+                        "leftOperand": "`campaign_id_pipe`",
+                        "operator": "=",
+                        "rightOperand": "24569"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "AND"
+                        "expr": "AND",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -915,7 +927,10 @@
                             "weeksonlist_pipe"
                         ],
                         "isOperator": false,
-                        "expr": "`weeksonlist_pipe` = 1"
+                        "expr": "`weeksonlist_pipe` = 1",
+                        "leftOperand": "`weeksonlist_pipe`",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelectCase2.out
+++ b/tests/data/parser/parseSelectCase2.out
@@ -635,7 +635,10 @@
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                     "identifiers": [],
                                     "isOperator": false,
-                                    "expr": "1=1"
+                                    "expr": "1=1",
+                                    "leftOperand": "1",
+                                    "operator": "=",
+                                    "rightOperand": "1"
                                 }
                             ]
                         ],

--- a/tests/data/parser/parseSelectCase3.out
+++ b/tests/data/parser/parseSelectCase3.out
@@ -701,7 +701,10 @@
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                     "identifiers": [],
                                     "isOperator": false,
-                                    "expr": "1=1"
+                                    "expr": "1=1",
+                                    "leftOperand": "1",
+                                    "operator": "=",
+                                    "rightOperand": "1"
                                 }
                             ],
                             [
@@ -709,7 +712,10 @@
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                     "identifiers": [],
                                     "isOperator": false,
-                                    "expr": "2=1"
+                                    "expr": "2=1",
+                                    "leftOperand": "2",
+                                    "operator": "=",
+                                    "rightOperand": "1"
                                 }
                             ]
                         ],

--- a/tests/data/parser/parseSelectCaseAlias1.out
+++ b/tests/data/parser/parseSelectCaseAlias1.out
@@ -789,7 +789,10 @@
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                     "identifiers": [],
                                     "isOperator": false,
-                                    "expr": "1=1"
+                                    "expr": "1=1",
+                                    "leftOperand": "1",
+                                    "operator": "=",
+                                    "rightOperand": "1"
                                 }
                             ],
                             [
@@ -797,7 +800,10 @@
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                     "identifiers": [],
                                     "isOperator": false,
-                                    "expr": "2=1"
+                                    "expr": "2=1",
+                                    "leftOperand": "2",
+                                    "operator": "=",
+                                    "rightOperand": "1"
                                 }
                             ]
                         ],

--- a/tests/data/parser/parseSelectCaseAlias2.out
+++ b/tests/data/parser/parseSelectCaseAlias2.out
@@ -745,7 +745,10 @@
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                     "identifiers": [],
                                     "isOperator": false,
-                                    "expr": "1=1"
+                                    "expr": "1=1",
+                                    "leftOperand": "1",
+                                    "operator": "=",
+                                    "rightOperand": "1"
                                 }
                             ],
                             [
@@ -753,7 +756,10 @@
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                     "identifiers": [],
                                     "isOperator": false,
-                                    "expr": "2=1"
+                                    "expr": "2=1",
+                                    "leftOperand": "2",
+                                    "operator": "=",
+                                    "rightOperand": "1"
                                 }
                             ]
                         ],

--- a/tests/data/parser/parseSelectCaseAliasErr4.out
+++ b/tests/data/parser/parseSelectCaseAliasErr4.out
@@ -333,7 +333,10 @@
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                     "identifiers": [],
                                     "isOperator": false,
-                                    "expr": "2 IS NULL"
+                                    "expr": "2 IS NULL",
+                                    "leftOperand": "2 IS NULL",
+                                    "operator": "",
+                                    "rightOperand": ""
                                 }
                             ]
                         ],

--- a/tests/data/parser/parseSelectCaseErr3.out
+++ b/tests/data/parser/parseSelectCaseErr3.out
@@ -611,7 +611,10 @@
                                     "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                                     "identifiers": [],
                                     "isOperator": false,
-                                    "expr": "1=1"
+                                    "expr": "1=1",
+                                    "leftOperand": "1",
+                                    "operator": "=",
+                                    "rightOperand": "1"
                                 }
                             ]
                         ],

--- a/tests/data/parser/parseSelectEndOptions1.out
+++ b/tests/data/parser/parseSelectEndOptions1.out
@@ -337,7 +337,10 @@
                             "pid"
                         ],
                         "isOperator": false,
-                        "expr": "pid = 20"
+                        "expr": "pid = 20",
+                        "leftOperand": "pid",
+                        "operator": "=",
+                        "rightOperand": "20"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelectEndOptions2.out
+++ b/tests/data/parser/parseSelectEndOptions2.out
@@ -337,7 +337,10 @@
                             "pid"
                         ],
                         "isOperator": false,
-                        "expr": "pid = 20"
+                        "expr": "pid = 20",
+                        "leftOperand": "pid",
+                        "operator": "=",
+                        "rightOperand": "20"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelectEndOptionsErr.out
+++ b/tests/data/parser/parseSelectEndOptionsErr.out
@@ -359,7 +359,10 @@
                             "pid"
                         ],
                         "isOperator": false,
-                        "expr": "pid = 20"
+                        "expr": "pid = 20",
+                        "leftOperand": "pid",
+                        "operator": "=",
+                        "rightOperand": "20"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelectErr1.out
+++ b/tests/data/parser/parseSelectErr1.out
@@ -961,7 +961,10 @@
                             "id"
                         ],
                         "isOperator": false,
-                        "expr": "id > 0"
+                        "expr": "id > 0",
+                        "leftOperand": "id",
+                        "operator": ">",
+                        "rightOperand": "0"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelectErr2.out
+++ b/tests/data/parser/parseSelectErr2.out
@@ -249,7 +249,10 @@
                             ""
                         ],
                         "isOperator": false,
-                        "expr": "foo = @"
+                        "expr": "foo = @",
+                        "leftOperand": "foo",
+                        "operator": "=",
+                        "rightOperand": "@"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelectIndexHint1.out
+++ b/tests/data/parser/parseSelectIndexHint1.out
@@ -549,7 +549,10 @@
                             "city_id"
                         ],
                         "isOperator": false,
-                        "expr": "city_id<0"
+                        "expr": "city_id<0",
+                        "leftOperand": "city_id",
+                        "operator": "<",
+                        "rightOperand": "0"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelectIndexHint2.out
+++ b/tests/data/parser/parseSelectIndexHint2.out
@@ -538,7 +538,10 @@
                             "city_id"
                         ],
                         "isOperator": false,
-                        "expr": "city_id<0"
+                        "expr": "city_id<0",
+                        "leftOperand": "city_id",
+                        "operator": "<",
+                        "rightOperand": "0"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelectJoinMultiple.out
+++ b/tests/data/parser/parseSelectJoinMultiple.out
@@ -326,7 +326,10 @@
                             "username"
                         ],
                         "isOperator": false,
-                        "expr": "customer= 'username'"
+                        "expr": "customer= 'username'",
+                        "leftOperand": "customer",
+                        "operator": "=",
+                        "rightOperand": "'username'"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelectJoinMultiple2.out
+++ b/tests/data/parser/parseSelectJoinMultiple2.out
@@ -458,7 +458,10 @@
                             "username"
                         ],
                         "isOperator": false,
-                        "expr": "customer= 'username'"
+                        "expr": "customer= 'username'",
+                        "leftOperand": "customer",
+                        "operator": "=",
+                        "rightOperand": "'username'"
                     }
                 ],
                 "group": null,
@@ -508,7 +511,10 @@
                                     "id"
                                 ],
                                 "isOperator": false,
-                                "expr": "orders.item_id = items.id"
+                                "expr": "orders.item_id = items.id",
+                                "leftOperand": "orders.item_id",
+                                "operator": "=",
+                                "rightOperand": "items.id"
                             }
                         ],
                         "using": null

--- a/tests/data/parser/parseSelectJoinStraight.out
+++ b/tests/data/parser/parseSelectJoinStraight.out
@@ -423,7 +423,10 @@
                                     "b"
                                 ],
                                 "isOperator": false,
-                                "expr": "table111.a = table113.b"
+                                "expr": "table111.a = table113.b",
+                                "leftOperand": "table111.a",
+                                "operator": "=",
+                                "rightOperand": "table113.b"
                             }
                         ],
                         "using": null

--- a/tests/data/parser/parseSelectUnion.out
+++ b/tests/data/parser/parseSelectUnion.out
@@ -457,7 +457,10 @@
                             "a"
                         ],
                         "isOperator": false,
-                        "expr": "a=1"
+                        "expr": "a=1",
+                        "leftOperand": "a",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "group": null,
@@ -506,7 +509,10 @@
                                         "a"
                                     ],
                                     "isOperator": false,
-                                    "expr": "a=2"
+                                    "expr": "a=2",
+                                    "leftOperand": "a",
+                                    "operator": "=",
+                                    "rightOperand": "2"
                                 }
                             ],
                             "group": null,

--- a/tests/data/parser/parseSelectWhere.out
+++ b/tests/data/parser/parseSelectWhere.out
@@ -3774,13 +3774,19 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "film_id = 10"
+                        "expr": "film_id = 10",
+                        "leftOperand": "film_id",
+                        "operator": "=",
+                        "rightOperand": "10"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "OR"
+                        "expr": "OR",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -3788,7 +3794,10 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "film_id >= 20"
+                        "expr": "film_id >= 20",
+                        "leftOperand": "film_id",
+                        "operator": ">=",
+                        "rightOperand": "20"
                     }
                 ],
                 "group": null,
@@ -3843,13 +3852,19 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "(film_id < 10)"
+                        "expr": "(film_id < 10)",
+                        "leftOperand": "(film_id",
+                        "operator": "<",
+                        "rightOperand": "10)"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "||"
+                        "expr": "||",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -3857,7 +3872,10 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "(film_id > 20)"
+                        "expr": "(film_id > 20)",
+                        "leftOperand": "(film_id",
+                        "operator": ">",
+                        "rightOperand": "20)"
                     }
                 ],
                 "group": null,
@@ -3912,13 +3930,19 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "`film_id` != 10"
+                        "expr": "`film_id` != 10",
+                        "leftOperand": "`film_id`",
+                        "operator": "!=",
+                        "rightOperand": "10"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "AND"
+                        "expr": "AND",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -3926,7 +3950,10 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "`film_id` <= 20"
+                        "expr": "`film_id` <= 20",
+                        "leftOperand": "`film_id`",
+                        "operator": "<=",
+                        "rightOperand": "20"
                     }
                 ],
                 "group": null,
@@ -3982,13 +4009,19 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "`film`.`film_id` <> 10"
+                        "expr": "`film`.`film_id` <> 10",
+                        "leftOperand": "`film`.`film_id`",
+                        "operator": "<>",
+                        "rightOperand": "10"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "&&"
+                        "expr": "&&",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -3997,7 +4030,10 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "`film`.`film_id` <= 20"
+                        "expr": "`film`.`film_id` <= 20",
+                        "leftOperand": "`film`.`film_id`",
+                        "operator": "<=",
+                        "rightOperand": "20"
                     }
                 ],
                 "group": null,
@@ -4053,13 +4089,19 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "film.film_id < 20"
+                        "expr": "film.film_id < 20",
+                        "leftOperand": "film.film_id",
+                        "operator": "<",
+                        "rightOperand": "20"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "XOR"
+                        "expr": "XOR",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -4069,7 +4111,10 @@
                             "PG-13"
                         ],
                         "isOperator": false,
-                        "expr": "film.rating = 'PG-13'"
+                        "expr": "film.rating = 'PG-13'",
+                        "leftOperand": "film.rating",
+                        "operator": "=",
+                        "rightOperand": "'PG-13'"
                     }
                 ],
                 "group": null,
@@ -4124,7 +4169,10 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "film_id = 10"
+                        "expr": "film_id = 10",
+                        "leftOperand": "film_id",
+                        "operator": "=",
+                        "rightOperand": "10"
                     }
                 ],
                 "group": null,
@@ -4179,7 +4227,10 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "NOT film_id > 10"
+                        "expr": "NOT film_id > 10",
+                        "leftOperand": "NOT film_id",
+                        "operator": ">",
+                        "rightOperand": "10"
                     }
                 ],
                 "group": null,
@@ -4234,7 +4285,10 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "! (film_id > 10)"
+                        "expr": "! (film_id > 10)",
+                        "leftOperand": "! (film_id",
+                        "operator": ">",
+                        "rightOperand": "10)"
                     }
                 ],
                 "group": null,
@@ -4289,7 +4343,10 @@
                             "description"
                         ],
                         "isOperator": false,
-                        "expr": "description IS NULL"
+                        "expr": "description IS NULL",
+                        "leftOperand": "description IS NULL",
+                        "operator": "",
+                        "rightOperand": ""
                     }
                 ],
                 "group": null,
@@ -4344,7 +4401,10 @@
                             "description"
                         ],
                         "isOperator": false,
-                        "expr": "description IS NOT NULL"
+                        "expr": "description IS NOT NULL",
+                        "leftOperand": "description IS NOT NULL",
+                        "operator": "",
+                        "rightOperand": ""
                     }
                 ],
                 "group": null,
@@ -4399,7 +4459,10 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "film_id BETWEEN 10 AND 20"
+                        "expr": "film_id BETWEEN 10 AND 20",
+                        "leftOperand": "film_id BETWEEN 10 AND 20",
+                        "operator": "",
+                        "rightOperand": ""
                     }
                 ],
                 "group": null,
@@ -4454,7 +4517,10 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "film_id NOT BETWEEN 10 AND 20"
+                        "expr": "film_id NOT BETWEEN 10 AND 20",
+                        "leftOperand": "film_id NOT BETWEEN 10 AND 20",
+                        "operator": "",
+                        "rightOperand": ""
                     }
                 ],
                 "group": null,
@@ -4509,7 +4575,10 @@
                             "film_id"
                         ],
                         "isOperator": false,
-                        "expr": "film_id IN (3,5,7)"
+                        "expr": "film_id IN (3,5,7)",
+                        "leftOperand": "film_id IN (3,5,7)",
+                        "operator": "",
+                        "rightOperand": ""
                     }
                 ],
                 "group": null,
@@ -4566,7 +4635,10 @@
                             "pg"
                         ],
                         "isOperator": false,
-                        "expr": "rating = UPPER('pg')"
+                        "expr": "rating = UPPER('pg')",
+                        "leftOperand": "rating",
+                        "operator": "=",
+                        "rightOperand": "UPPER('pg')"
                     }
                 ],
                 "group": null,
@@ -4623,7 +4695,10 @@
                             "PG"
                         ],
                         "isOperator": false,
-                        "expr": "rating SOUNDS LIKE 'PG'"
+                        "expr": "rating SOUNDS LIKE 'PG'",
+                        "leftOperand": "rating SOUNDS LIKE 'PG'",
+                        "operator": "",
+                        "rightOperand": ""
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelectWhereCollate.out
+++ b/tests/data/parser/parseSelectWhereCollate.out
@@ -394,13 +394,19 @@
                             "foo"
                         ],
                         "isOperator": false,
-                        "expr": "first_col = 'foo'"
+                        "expr": "first_col = 'foo'",
+                        "leftOperand": "first_col",
+                        "operator": "=",
+                        "rightOperand": "'foo'"
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": true,
-                        "expr": "AND"
+                        "expr": "AND",
+                        "leftOperand": "",
+                        "operator": "",
+                        "rightOperand": ""
                     },
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
@@ -410,7 +416,10 @@
                             "bar"
                         ],
                         "isOperator": false,
-                        "expr": "second_col COLLATE utf8_bin = 'bar'"
+                        "expr": "second_col COLLATE utf8_bin = 'bar'",
+                        "leftOperand": "second_col COLLATE utf8_bin",
+                        "operator": "=",
+                        "rightOperand": "'bar'"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelectWrongOrder.out
+++ b/tests/data/parser/parseSelectWrongOrder.out
@@ -335,7 +335,10 @@
                             "pid"
                         ],
                         "isOperator": false,
-                        "expr": "pid = 20"
+                        "expr": "pid = 20",
+                        "leftOperand": "pid",
+                        "operator": "=",
+                        "rightOperand": "20"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseSelectWrongOrder2.out
+++ b/tests/data/parser/parseSelectWrongOrder2.out
@@ -433,7 +433,10 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": false,
-                        "expr": "1=1"
+                        "expr": "1=1",
+                        "leftOperand": "1",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "group": null,

--- a/tests/data/parser/parseTransaction.out
+++ b/tests/data/parser/parseTransaction.out
@@ -551,7 +551,10 @@
                                     "type"
                                 ],
                                 "isOperator": false,
-                                "expr": "type=1"
+                                "expr": "type=1",
+                                "leftOperand": "type",
+                                "operator": "=",
+                                "rightOperand": "1"
                             }
                         ],
                         "group": null,
@@ -599,7 +602,10 @@
                                     "type"
                                 ],
                                 "isOperator": false,
-                                "expr": "type=1"
+                                "expr": "type=1",
+                                "leftOperand": "type",
+                                "operator": "=",
+                                "rightOperand": "1"
                             }
                         ],
                         "order": null,

--- a/tests/data/parser/parseTransaction2.out
+++ b/tests/data/parser/parseTransaction2.out
@@ -551,7 +551,10 @@
                                     "type"
                                 ],
                                 "isOperator": false,
-                                "expr": "type=1"
+                                "expr": "type=1",
+                                "leftOperand": "type",
+                                "operator": "=",
+                                "rightOperand": "1"
                             }
                         ],
                         "group": null,
@@ -599,7 +602,10 @@
                                     "type"
                                 ],
                                 "isOperator": false,
-                                "expr": "type=1"
+                                "expr": "type=1",
+                                "leftOperand": "type",
+                                "operator": "=",
+                                "rightOperand": "1"
                             }
                         ],
                         "order": null,

--- a/tests/data/parser/parseUpdate2.out
+++ b/tests/data/parser/parseUpdate2.out
@@ -447,7 +447,10 @@
                             "Paul"
                         ],
                         "isOperator": false,
-                        "expr": "username = \"Paul\""
+                        "expr": "username = \"Paul\"",
+                        "leftOperand": "username",
+                        "operator": "=",
+                        "rightOperand": "\"Paul\""
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseUpdate3.out
+++ b/tests/data/parser/parseUpdate3.out
@@ -268,7 +268,10 @@
                             "baz"
                         ],
                         "isOperator": false,
-                        "expr": "baz = 0"
+                        "expr": "baz = 0",
+                        "leftOperand": "baz",
+                        "operator": "=",
+                        "rightOperand": "0"
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseUpdate4.out
+++ b/tests/data/parser/parseUpdate4.out
@@ -428,7 +428,10 @@
                             "CountryCode"
                         ],
                         "isOperator": false,
-                        "expr": "x.Code=y.CountryCode"
+                        "expr": "x.Code=y.CountryCode",
+                        "leftOperand": "x.Code",
+                        "operator": "=",
+                        "rightOperand": "y.CountryCode"
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseUpdate5.out
+++ b/tests/data/parser/parseUpdate5.out
@@ -541,7 +541,10 @@
                             "id"
                         ],
                         "isOperator": false,
-                        "expr": "u.id = 1"
+                        "expr": "u.id = 1",
+                        "leftOperand": "u.id",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": null,
@@ -570,7 +573,10 @@
                                     "user_id"
                                 ],
                                 "isOperator": false,
-                                "expr": "u.id = ud.user_id"
+                                "expr": "u.id = ud.user_id",
+                                "leftOperand": "u.id",
+                                "operator": "=",
+                                "rightOperand": "ud.user_id"
                             }
                         ],
                         "using": null

--- a/tests/data/parser/parseUpdate6.out
+++ b/tests/data/parser/parseUpdate6.out
@@ -760,7 +760,10 @@
                             "New york"
                         ],
                         "isOperator": false,
-                        "expr": "c.city = \"New york\""
+                        "expr": "c.city = \"New york\"",
+                        "leftOperand": "c.city",
+                        "operator": "=",
+                        "rightOperand": "\"New york\""
                     }
                 ],
                 "order": null,
@@ -788,7 +791,10 @@
                                     "e"
                                 ],
                                 "isOperator": false,
-                                "expr": "c.city_id = e.city_id"
+                                "expr": "c.city_id = e.city_id",
+                                "leftOperand": "c.city_id",
+                                "operator": "=",
+                                "rightOperand": "e.city_id"
                             }
                         ],
                         "using": null
@@ -815,7 +821,10 @@
                                     "e"
                                 ],
                                 "isOperator": false,
-                                "expr": "a.someID = e.someID"
+                                "expr": "a.someID = e.someID",
+                                "leftOperand": "a.someID",
+                                "operator": "=",
+                                "rightOperand": "e.someID"
                             }
                         ],
                         "using": null

--- a/tests/data/parser/parseUpdate7.out
+++ b/tests/data/parser/parseUpdate7.out
@@ -760,7 +760,10 @@
                             "New york"
                         ],
                         "isOperator": false,
-                        "expr": "c.city = \"New york\""
+                        "expr": "c.city = \"New york\"",
+                        "leftOperand": "c.city",
+                        "operator": "=",
+                        "rightOperand": "\"New york\""
                     }
                 ],
                 "order": null,
@@ -788,7 +791,10 @@
                                     "e"
                                 ],
                                 "isOperator": false,
-                                "expr": "c.city_id = e.city_id"
+                                "expr": "c.city_id = e.city_id",
+                                "leftOperand": "c.city_id",
+                                "operator": "=",
+                                "rightOperand": "e.city_id"
                             }
                         ],
                         "using": null
@@ -815,7 +821,10 @@
                                     "e"
                                 ],
                                 "isOperator": false,
-                                "expr": "a.someID = e.someID"
+                                "expr": "a.someID = e.someID",
+                                "leftOperand": "a.someID",
+                                "operator": "=",
+                                "rightOperand": "e.someID"
                             }
                         ],
                         "using": null

--- a/tests/data/parser/parseUpdateErr.out
+++ b/tests/data/parser/parseUpdateErr.out
@@ -391,7 +391,10 @@
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
                         "identifiers": [],
                         "isOperator": false,
-                        "expr": "1 = 1"
+                        "expr": "1 = 1",
+                        "leftOperand": "1",
+                        "operator": "=",
+                        "rightOperand": "1"
                     }
                 ],
                 "order": null,

--- a/tests/data/parser/parseWithStatement3.out
+++ b/tests/data/parser/parseWithStatement3.out
@@ -1607,7 +1607,10 @@
                                                 "a"
                                             ],
                                             "isOperator": false,
-                                            "expr": "c.identifier = 'a'"
+                                            "expr": "c.identifier = 'a'",
+                                            "leftOperand": "c.identifier",
+                                            "operator": "=",
+                                            "rightOperand": "'a'"
                                         }
                                     ],
                                     "group": null,
@@ -1689,7 +1692,10 @@
                                                             "parent_id"
                                                         ],
                                                         "isOperator": false,
-                                                        "expr": "c.identifier = categories.parent_id"
+                                                        "expr": "c.identifier = categories.parent_id",
+                                                        "leftOperand": "c.identifier",
+                                                        "operator": "=",
+                                                        "rightOperand": "categories.parent_id"
                                                     }
                                                 ],
                                                 "group": null,

--- a/tests/data/parser/parseWithStatement7.out
+++ b/tests/data/parser/parseWithStatement7.out
@@ -835,7 +835,10 @@
                                                 "cte"
                                             ],
                                             "isOperator": false,
-                                            "expr": "table2.col1=cte.col1"
+                                            "expr": "table2.col1=cte.col1",
+                                            "leftOperand": "table2.col1",
+                                            "operator": "=",
+                                            "rightOperand": "cte.col1"
                                         }
                                     ],
                                     "using": null


### PR DESCRIPTION
Adds `leftOperand`, `operator` and `rightOperand` properties to the `Condition` component.

It only splits comparison operators for now.

- Related to #357