### PR TITLE
Fix replace clause of select statement with FOR UPDATE

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -9,6 +9,7 @@ use Stringable;
 
 use function array_flip;
 use function array_keys;
+use function array_push;
 use function count;
 use function in_array;
 use function stripos;
@@ -455,6 +456,28 @@ abstract class Statement implements Stringable
     public function getClauses()
     {
         return static::$CLAUSES;
+    }
+
+    /**
+     * Gets the clause order of this statement as an array
+     * with clause as key and index as value.
+     *
+     * @return array<string, int>
+     */
+    public function getClauseOrder(): array
+    {
+        $clauses = [];
+        foreach (array_keys($this->getClauses()) as $key) {
+            if ($key === '_END_OPTIONS') {
+                if (static::$END_OPTIONS !== []) {
+                    array_push($clauses, ...array_keys(static::$END_OPTIONS));
+                }
+            } else {
+                $clauses[] = $key;
+            }
+        }
+
+        return array_flip($clauses);
     }
 
     /**

--- a/src/Utils/Query.php
+++ b/src/Utils/Query.php
@@ -641,7 +641,7 @@ class Query
         /**
          * The clauses of this type of statement and their index.
          */
-        $clauses = array_flip(array_keys($statement->getClauses()));
+        $clauses = $statement->getClauseOrder();
 
         /**
          * Lexer used for lexing the clause.

--- a/tests/Utils/QueryTest.php
+++ b/tests/Utils/QueryTest.php
@@ -600,6 +600,16 @@ class QueryTest extends TestCase
                 'ORDER BY city'
             )
         );
+
+        $parser = new Parser('SELECT * FROM `t` FOR UPDATE');
+        $this->assertEquals(
+            'SELECT * FROM `t` LIMIT 0, 25 FOR UPDATE',
+            Query::replaceClause(
+                $parser->statements[0],
+                $parser->list,
+                'LIMIT 0, 25'
+            )
+        );
     }
 
     public function testReplaceClauseOnlyKeyword(): void


### PR DESCRIPTION
Fixes phpmyadmin/phpmyadmin#17190

Replaces _END_OPTIONS with the actual names from here:
https://github.com/phpmyadmin/sql-parser/blob/29f982a9559ac9a97b19e58b78a3fa4c41d5e43f/src/Statements/SelectStatement.php#L84-L228