### PR TITLE
Fix query flags for lower-case functions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -956,6 +956,11 @@ parameters:
 			path: src/Utils/Query.php
 
 		-
+			message: "#^Parameter \\#1 \\$str of function strtoupper expects string, mixed given\\.$#"
+			count: 1
+			path: src/Utils/Query.php
+
+		-
 			message: "#^Cannot access offset 'value' on mixed\\.$#"
 			count: 3
 			path: src/Utils/Routine.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1342,8 +1342,9 @@
     <InvalidNullableReturnType occurrences="1">
       <code>int</code>
     </InvalidNullableReturnType>
-    <MixedArgument occurrences="1">
+    <MixedArgument occurrences="2">
       <code>$expr</code>
+      <code>$expr-&gt;function</code>
     </MixedArgument>
     <MixedArrayOffset occurrences="2">
       <code>$clauses[$token-&gt;keyword]</code>

--- a/src/Utils/Query.php
+++ b/src/Utils/Query.php
@@ -36,6 +36,7 @@ use function array_keys;
 use function count;
 use function in_array;
 use function is_string;
+use function strtoupper;
 use function trim;
 
 /**
@@ -317,9 +318,10 @@ class Query
 
         foreach ($expressions as $expr) {
             if (! empty($expr->function)) {
-                if ($expr->function === 'COUNT') {
+                $function = strtoupper($expr->function);
+                if ($function === 'COUNT') {
                     $flags['is_count'] = true;
-                } elseif (in_array($expr->function, static::$FUNCTIONS)) {
+                } elseif (in_array($function, static::$FUNCTIONS, true)) {
                     $flags['is_func'] = true;
                 }
             }

--- a/tests/Utils/QueryTest.php
+++ b/tests/Utils/QueryTest.php
@@ -182,6 +182,24 @@ class QueryTest extends TestCase
                 ],
             ],
             [
+                'SELECT count(*) FROM tbl',
+                [
+                    'is_count' => true,
+                    'is_select' => true,
+                    'select_from' => true,
+                    'querytype' => 'SELECT',
+                ],
+            ],
+            [
+                'SELECT sum(*) FROM tbl',
+                [
+                    'is_func' => true,
+                    'is_select' => true,
+                    'select_from' => true,
+                    'querytype' => 'SELECT',
+                ],
+            ],
+            [
                 'SELECT (SELECT "foo")',
                 [
                     'is_select' => true,


### PR DESCRIPTION
See https://github.com/phpmyadmin/phpmyadmin/issues/16869

`is_func` and `is_count` were only set when the function is in all upper case.