### PR TITLE
benchmarks: decreasing benchmarks average time assertions

### DIFF
--- a/tests/benchmarks/UtfStringBench.php
+++ b/tests/benchmarks/UtfStringBench.php
@@ -20,7 +20,7 @@ class UtfStringBench
      * @Revs(4)
      * @OutputTimeUnit("milliseconds")
      * @Assert("mode(variant.time.avg) < 100 milliseconds +/- 10%")
-     * @Assert("mode(variant.time.avg) > 30 milliseconds +/- 10%")
+     * @Assert("mode(variant.time.avg) > 25 milliseconds +/- 10%")
      */
     public function benchBuildUtfString(): void
     {
@@ -36,7 +36,7 @@ class UtfStringBench
      * @Revs(2)
      * @OutputTimeUnit("microseconds")
      * @Assert("mode(variant.time.avg) < 800 microseconds +/- 20%")
-     * @Assert("mode(variant.time.avg) > 100 microseconds +/- 10%")
+     * @Assert("mode(variant.time.avg) > 60 microseconds +/- 10%")
      */
     public function benchGetCharLength(): void
     {


### PR DESCRIPTION
I updated the highest based on the average run on my machine (m1 max)

```
  ✘ \PhpMyAdmin\SqlParser\Tests\benchmarks\UtfStringBench::benchBuildUtfString # 

    1) mode(variant[time][avg]) > 30 milliseconds ± 10
       = 26195.816536203 > 30000 ± 3000
       = false

  ✘ \PhpMyAdmin\SqlParser\Tests\benchmarks\UtfStringBench::benchGetCharLength # 

    1) mode(variant[time][avg]) > 100 microseconds ± 10
       = 60.75 > 100 ± 10
       = false


```