### PR TITLE
Allow using ::class keyword to load a context.

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -599,8 +599,13 @@ abstract class Context
         }
 
         if ($context[0] !== '\\') {
-            // Short context name (must be formatted into class name).
-            $context = self::$contextPrefix . $context;
+            // Could be the fully qualified class name was given, like `ContextDBMS::class`.
+            if (class_exists('\\' . $context)) {
+                $context = '\\' . $context;
+            } else {
+                // Short context name (must be formatted into class name).
+                $context = self::$contextPrefix . $context;
+            }
         }
 
         if (! class_exists($context)) {

--- a/tests/Lexer/ContextTest.php
+++ b/tests/Lexer/ContextTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Lexer;
 
 use PhpMyAdmin\SqlParser\Context;
+use PhpMyAdmin\SqlParser\Contexts;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use Throwable;
 
@@ -110,10 +111,73 @@ class ContextTest extends TestCase
             ['MySql50600'],
             ['MySql50700'],
             ['MySql80000'],
+            ['MySql80100'],
+            ['MySql80200'],
+            ['MySql80300'],
             ['MariaDb100000'],
             ['MariaDb100100'],
             ['MariaDb100200'],
             ['MariaDb100300'],
+            ['MariaDb100400'],
+            ['MariaDb100500'],
+            ['MariaDb100600'],
+            ['MariaDb100700'],
+            ['MariaDb100800'],
+            ['MariaDb100900'],
+            ['MariaDb101000'],
+            ['MariaDb101100'],
+            ['MariaDb110000'],
+            ['MariaDb110100'],
+            ['MariaDb110200'],
+            ['MariaDb110300'],
+            ['MariaDb110400'],
+        ];
+    }
+
+    /**
+     * @dataProvider contextClassesProvider
+     */
+    public function testLoadAllByClass(string $context): void
+    {
+        Context::load($context);
+        $this->assertEquals('\\' . $context, Context::$loadedContext);
+
+        // Restoring context.
+        Context::load('');
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function contextClassesProvider(): array
+    {
+        return [
+            [Contexts\ContextMySql50000::class],
+            [Contexts\ContextMySql50100::class],
+            [Contexts\ContextMySql50500::class],
+            [Contexts\ContextMySql50600::class],
+            [Contexts\ContextMySql50700::class],
+            [Contexts\ContextMySql80000::class],
+            [Contexts\ContextMySql80100::class],
+            [Contexts\ContextMySql80200::class],
+            [Contexts\ContextMySql80300::class],
+            [Contexts\ContextMariaDb100000::class],
+            [Contexts\ContextMariaDb100100::class],
+            [Contexts\ContextMariaDb100200::class],
+            [Contexts\ContextMariaDb100300::class],
+            [Contexts\ContextMariaDb100400::class],
+            [Contexts\ContextMariaDb100500::class],
+            [Contexts\ContextMariaDb100600::class],
+            [Contexts\ContextMariaDb100700::class],
+            [Contexts\ContextMariaDb100800::class],
+            [Contexts\ContextMariaDb100900::class],
+            [Contexts\ContextMariaDb101000::class],
+            [Contexts\ContextMariaDb101100::class],
+            [Contexts\ContextMariaDb110000::class],
+            [Contexts\ContextMariaDb110100::class],
+            [Contexts\ContextMariaDb110200::class],
+            [Contexts\ContextMariaDb110300::class],
+            [Contexts\ContextMariaDb110400::class],
         ];
     }
 


### PR DESCRIPTION
I noticed that you cannot use the `::class` keyword on contexts to load them.

I updated the Context loaded to manage it, and upgraded the unit tests in charge.