### PR TITLE
Fix #434 - No error when using `UPDATE ... SET`

### DIFF
--- a/src/Components/SetOperation.php
+++ b/src/Components/SetOperation.php
@@ -139,6 +139,11 @@ class SetOperation extends Component
             $parser->error('Unexpected token.', $commaLastSeenAt);
         }
 
+        // We got a SET operation without any assignment
+        if ($ret === []) {
+            $parser->error('Missing assignment in SET operation.', $list->tokens[$list->idx]);
+        }
+
         return $ret;
     }
 

--- a/src/Components/SetOperation.php
+++ b/src/Components/SetOperation.php
@@ -139,11 +139,6 @@ class SetOperation extends Component
             $parser->error('Unexpected token.', $commaLastSeenAt);
         }
 
-        // We got a SET operation without any assignment
-        if ($ret === []) {
-            $parser->error('Missing assignment in SET operation.', $list->tokens[$list->idx]);
-        }
-
         return $ret;
     }
 

--- a/src/Statements/UpdateStatement.php
+++ b/src/Statements/UpdateStatement.php
@@ -145,7 +145,8 @@ class UpdateStatement extends Statement
      * In the update statement, this is used to check that at least one assignment has been set to throw an error if a
      * query like `UPDATE acme SET WHERE 1;` is parsed.
      *
-     * @throws ParserException
+     * @throws ParserException throws the exception, if strict mode is enabled.
+     * @return void
      */
     public function after(Parser $parser, TokensList $list, Token $token)
     {

--- a/src/Statements/UpdateStatement.php
+++ b/src/Statements/UpdateStatement.php
@@ -145,9 +145,9 @@ class UpdateStatement extends Statement
      * In the update statement, this is used to check that at least one assignment has been set to throw an error if a
      * query like `UPDATE acme SET WHERE 1;` is parsed.
      *
-     * @throws ParserException throws the exception, if strict mode is enabled.
-     *
      * @return void
+     *
+     * @throws ParserException throws the exception, if strict mode is enabled.
      */
     public function after(Parser $parser, TokensList $list, Token $token)
     {

--- a/src/Statements/UpdateStatement.php
+++ b/src/Statements/UpdateStatement.php
@@ -10,7 +10,11 @@ use PhpMyAdmin\SqlParser\Components\JoinKeyword;
 use PhpMyAdmin\SqlParser\Components\Limit;
 use PhpMyAdmin\SqlParser\Components\OrderKeyword;
 use PhpMyAdmin\SqlParser\Components\SetOperation;
+use PhpMyAdmin\SqlParser\Exceptions\ParserException;
+use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
+use PhpMyAdmin\SqlParser\Token;
+use PhpMyAdmin\SqlParser\TokensList;
 
 /**
  * `UPDATE` statement.
@@ -135,4 +139,23 @@ class UpdateStatement extends Statement
      * @var JoinKeyword[]|null
      */
     public $join;
+
+    /**
+     * Function called after the token was processed.
+     * In the update statement, this is used to check that at least one assignment has been set to throw an error if a
+     * query like `UPDATE acme SET WHERE 1;` is parsed.
+     *
+     * @throws ParserException
+     */
+    public function after(Parser $parser, TokensList $list, Token $token)
+    {
+        /** @psalm-var string $tokenValue */
+        $tokenValue = $token->value;
+        // Ensure we finished to parse the "SET" token, and if yes, ensure that assignments are defined.
+        if ($this->set !== [] || (Parser::$KEYWORD_PARSERS[$tokenValue]['field'] ?? null) !== 'set') {
+            return;
+        }
+
+        $parser->error('Missing assignment in SET operation.', $list->tokens[$list->idx]);
+    }
 }

--- a/src/Statements/UpdateStatement.php
+++ b/src/Statements/UpdateStatement.php
@@ -146,6 +146,7 @@ class UpdateStatement extends Statement
      * query like `UPDATE acme SET WHERE 1;` is parsed.
      *
      * @throws ParserException throws the exception, if strict mode is enabled.
+     *
      * @return void
      */
     public function after(Parser $parser, TokensList $list, Token $token)

--- a/tests/Parser/UpdateStatementTest.php
+++ b/tests/Parser/UpdateStatementTest.php
@@ -30,6 +30,7 @@ class UpdateStatementTest extends TestCase
             ['parser/parseUpdate6'],
             ['parser/parseUpdate7'],
             ['parser/parseUpdateErr'],
+            ['parser/parseUpdateEmptySet'],
         ];
     }
 }

--- a/tests/data/parser/parseUpdate3.out
+++ b/tests/data/parser/parseUpdate3.out
@@ -243,6 +243,13 @@
                     "@type": "@12"
                 },
                 0
+            ],
+            [
+                "Missing assignment in SET operation.",
+                {
+                    "@type": "@11"
+                },
+                0
             ]
         ]
     }

--- a/tests/data/parser/parseUpdateEmptySet.in
+++ b/tests/data/parser/parseUpdateEmptySet.in
@@ -1,0 +1,1 @@
+UPDATE test SET WHERE 1;

--- a/tests/data/parser/parseUpdateEmptySet.out
+++ b/tests/data/parser/parseUpdateEmptySet.out
@@ -171,6 +171,14 @@
     },
     "errors": {
         "lexer": [],
-        "parser": []
+        "parser": [
+            [
+                "Missing assignment in SET operation.",
+                {
+                    "@type": "@7"
+                },
+                0
+            ]
+        ]
     }
 }

--- a/tests/data/parser/parseUpdateEmptySet.out
+++ b/tests/data/parser/parseUpdateEmptySet.out
@@ -1,0 +1,176 @@
+{
+    "query": "UPDATE test SET WHERE 1;\n",
+    "lexer": {
+        "@type": "PhpMyAdmin\\SqlParser\\Lexer",
+        "str": "UPDATE test SET WHERE 1;\n",
+        "len": 25,
+        "last": 25,
+        "list": {
+            "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "tokens": [
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "UPDATE",
+                    "value": "UPDATE",
+                    "keyword": "UPDATE",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 0
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 6
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "test",
+                    "value": "test",
+                    "keyword": null,
+                    "type": 0,
+                    "flags": 0,
+                    "position": 7
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 11
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "SET",
+                    "value": "SET",
+                    "keyword": "SET",
+                    "type": 1,
+                    "flags": 11,
+                    "position": 12
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 15
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "WHERE",
+                    "value": "WHERE",
+                    "keyword": "WHERE",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 16
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 21
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "1",
+                    "value": 1,
+                    "keyword": null,
+                    "type": 6,
+                    "flags": 0,
+                    "position": 22
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ";",
+                    "value": ";",
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": 23
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 24
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": null,
+                    "value": null,
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": null
+                }
+            ],
+            "count": 12,
+            "idx": 12
+        },
+        "delimiter": ";",
+        "delimiterLen": 1,
+        "strict": false,
+        "errors": []
+    },
+    "parser": {
+        "@type": "PhpMyAdmin\\SqlParser\\Parser",
+        "list": {
+            "@type": "@1"
+        },
+        "statements": [
+            {
+                "@type": "PhpMyAdmin\\SqlParser\\Statements\\UpdateStatement",
+                "tables": [
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                        "database": null,
+                        "table": "test",
+                        "column": null,
+                        "expr": "test",
+                        "alias": null,
+                        "function": null,
+                        "subquery": null
+                    }
+                ],
+                "set": [],
+                "where": [
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\Condition",
+                        "identifiers": [],
+                        "isOperator": false,
+                        "expr": "1"
+                    }
+                ],
+                "order": null,
+                "limit": null,
+                "join": null,
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "first": 0,
+                "last": 8
+            }
+        ],
+        "brackets": 0,
+        "strict": false,
+        "errors": []
+    },
+    "errors": {
+        "lexer": [],
+        "parser": []
+    }
+}


### PR DESCRIPTION
Fixes #434 

@williamdes / @iifawzi / @MauricioFauth / @liviuconcioiu 

This should also be fixed in 5.10.x and master. How do you want me to proceed to perform this?