### PR TITLE
Fix #578: lexer wrongly interprets ".e[0-9]" as a number with scientific notation.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -671,9 +671,11 @@
       <code>$this-&gt;last</code>
       <code>$this-&gt;last</code>
     </LoopInvalidation>
-    <MixedArrayAccess occurrences="41">
+    <MixedArrayAccess occurrences="43">
       <code>$this-&gt;str[$this-&gt;last + 1]</code>
       <code>$this-&gt;str[$this-&gt;last++]</code>
+      <code>$this-&gt;str[$this-&gt;last]</code>
+      <code>$this-&gt;str[$this-&gt;last]</code>
       <code>$this-&gt;str[$this-&gt;last]</code>
       <code>$this-&gt;str[$this-&gt;last]</code>
       <code>$this-&gt;str[$this-&gt;last]</code>

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -264,7 +264,6 @@ class Lexer extends Core
                 $token = $this->$method();
 
                 if ($token) {
-                    var_dump($token, $method);
                     break;
                 }
             }

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -948,8 +948,10 @@ class Lexer extends Core
                 break;
             } elseif ($state === 10) {
                 $flags |= Token::FLAG_NUMBER_FLOAT;
-                if ($this->str[$this->last] < '0' || $this->str[$this->last] > '9') {
+                if ($this->str[$this->last] >= '0' && $this->str[$this->last] <= '9') {
                     // Just digits are valid characters.
+                    $state = 4;
+                } else {
                     break;
                 }
             }

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -948,12 +948,11 @@ class Lexer extends Core
                 break;
             } elseif ($state === 10) {
                 $flags |= Token::FLAG_NUMBER_FLOAT;
-                if ($this->str[$this->last] >= '0' && $this->str[$this->last] <= '9') {
-                    // Just digits are valid characters.
-                    $state = 4;
-                } else {
+                if ($this->str[$this->last] < '0' || $this->str[$this->last] > '9') {
                     break;
                 }
+
+                $state = 4;
             }
 
             $token .= $this->str[$this->last];

--- a/tests/Parser/LoadStatementTest.php
+++ b/tests/Parser/LoadStatementTest.php
@@ -38,6 +38,7 @@ class LoadStatementTest extends TestCase
             ['parser/parseLoad5'],
             ['parser/parseLoad6'],
             ['parser/parseLoad7'],
+            ['parser/parseLoad8'],
             ['parser/parseLoadErr1'],
             ['parser/parseLoadErr2'],
             ['parser/parseLoadErr3'],

--- a/tests/data/lexer/lexNumber.in
+++ b/tests/data/lexer/lexNumber.in
@@ -1,3 +1,3 @@
 SELECT 12, 34, 5.67, 0x89, -10, --11, +12, .15, 0xFFa, 0xfFA, +0xfFA, -0xFFa, -0xfFA, 1e-10, 1e10, .5e10, b'10';
 -- invalid numbers
-SELECT 12ex10, b'15', 0XFfA, -0XFfA, +0XFfA;
+SELECT 12ex10, b'15', 0XFfA, -0XFfA, +0XFfA, .e4;

--- a/tests/data/lexer/lexNumber.out
+++ b/tests/data/lexer/lexNumber.out
@@ -217,12 +217,21 @@
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
-                    "token": ".15",
-                    "value": 0.15,
+                    "token": ".",
+                    "value": ".",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 16,
+                    "position": 43
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "15",
+                    "value": 15,
                     "keyword": null,
                     "type": 6,
-                    "flags": 2,
-                    "position": 43
+                    "flags": 0,
+                    "position": 44
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -433,12 +442,21 @@
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
-                    "token": ".5e10",
-                    "value": 5000000000.0,
+                    "token": ".",
+                    "value": ".",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 16,
+                    "position": 99
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "5e10",
+                    "value": 50000000000.0,
                     "keyword": null,
                     "type": 6,
-                    "flags": 6,
-                    "position": 99
+                    "flags": 4,
+                    "position": 100
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -685,12 +703,21 @@
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
-                    "token": ".e4",
-                    "value": 0.0,
+                    "token": ".",
+                    "value": ".",
                     "keyword": null,
-                    "type": 6,
-                    "flags": 6,
+                    "type": 2,
+                    "flags": 16,
                     "position": 177
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "e4",
+                    "value": "e4",
+                    "keyword": null,
+                    "type": 0,
+                    "flags": 0,
+                    "position": 178
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -720,7 +747,7 @@
                     "position": null
                 }
             ],
-            "count": 79,
+            "count": 82,
             "idx": 0
         },
         "delimiter": ";",

--- a/tests/data/lexer/lexNumber.out
+++ b/tests/data/lexer/lexNumber.out
@@ -217,21 +217,12 @@
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
-                    "token": ".",
-                    "value": ".",
-                    "keyword": null,
-                    "type": 2,
-                    "flags": 16,
-                    "position": 43
-                },
-                {
-                    "@type": "PhpMyAdmin\\SqlParser\\Token",
-                    "token": "15",
-                    "value": 15,
+                    "token": ".15",
+                    "value": 0.15,
                     "keyword": null,
                     "type": 6,
-                    "flags": 0,
-                    "position": 44
+                    "flags": 2,
+                    "position": 43
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -442,21 +433,12 @@
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
-                    "token": ".",
-                    "value": ".",
-                    "keyword": null,
-                    "type": 2,
-                    "flags": 16,
-                    "position": 99
-                },
-                {
-                    "@type": "PhpMyAdmin\\SqlParser\\Token",
-                    "token": "5e10",
-                    "value": 50000000000.0,
+                    "token": ".5e10",
+                    "value": 5000000000.0,
                     "keyword": null,
                     "type": 6,
-                    "flags": 4,
-                    "position": 100
+                    "flags": 6,
+                    "position": 99
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -747,7 +729,7 @@
                     "position": null
                 }
             ],
-            "count": 82,
+            "count": 80,
             "idx": 0
         },
         "delimiter": ";",

--- a/tests/data/lexer/lexNumber.out
+++ b/tests/data/lexer/lexNumber.out
@@ -1,10 +1,10 @@
 {
-    "query": "SELECT 12, 34, 5.67, 0x89, -10, --11, +12, .15, 0xFFa, 0xfFA, +0xfFA, -0xFFa, -0xfFA, 1e-10, 1e10, .5e10, b'10';\n-- invalid numbers\nSELECT 12ex10, b'15', 0XFfA, -0XFfA, +0XFfA;",
+    "query": "SELECT 12, 34, 5.67, 0x89, -10, --11, +12, .15, 0xFFa, 0xfFA, +0xfFA, -0xFFa, -0xfFA, 1e-10, 1e10, .5e10, b'10';\n-- invalid numbers\nSELECT 12ex10, b'15', 0XFfA, -0XFfA, +0XFfA, .e4;\n",
     "lexer": {
         "@type": "PhpMyAdmin\\SqlParser\\Lexer",
-        "str": "SELECT 12, 34, 5.67, 0x89, -10, --11, +12, .15, 0xFFa, 0xfFA, +0xfFA, -0xFFa, -0xfFA, 1e-10, 1e10, .5e10, b'10';\n-- invalid numbers\nSELECT 12ex10, b'15', 0XFfA, -0XFfA, +0XFfA;",
-        "len": 176,
-        "last": 176,
+        "str": "SELECT 12, 34, 5.67, 0x89, -10, --11, +12, .15, 0xFFa, 0xfFA, +0xfFA, -0xFFa, -0xfFA, 1e-10, 1e10, .5e10, b'10';\n-- invalid numbers\nSELECT 12ex10, b'15', 0XFfA, -0XFfA, +0XFfA, .e4;\n",
+        "len": 182,
+        "last": 182,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
             "tokens": [
@@ -667,12 +667,48 @@
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ",",
+                    "value": ",",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 16,
+                    "position": 175
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 176
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ".e4",
+                    "value": 0.0,
+                    "keyword": null,
+                    "type": 6,
+                    "flags": 6,
+                    "position": 177
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": ";",
                     "value": ";",
                     "keyword": null,
                     "type": 9,
                     "flags": 0,
-                    "position": 175
+                    "position": 180
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 181
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -684,7 +720,7 @@
                     "position": null
                 }
             ],
-            "count": 75,
+            "count": 79,
             "idx": 0
         },
         "delimiter": ";",

--- a/tests/data/parser/parseLoad8.in
+++ b/tests/data/parser/parseLoad8.in
@@ -1,0 +1,8 @@
+-- Query from https://github.com/phpmyadmin/sql-parser/issues/578
+-- Issue was that Lexer detected ".e1" as number token.
+
+LOAD DATA LOCAL INFILE '/home/user/myloadfile.csv'
+IGNORE INTO TABLE erp.e1_table
+FIELDS TERMINATED BY '\t'
+LINES TERMINATED BY '\n'
+IGNORE 0 LINES;

--- a/tests/data/parser/parseLoad8.out
+++ b/tests/data/parser/parseLoad8.out
@@ -1,0 +1,502 @@
+{
+    "query": "-- Query from https://github.com/phpmyadmin/sql-parser/issues/578\n-- Issue was that Lexer detected \".e1\" as number token.\n\nLOAD DATA LOCAL INFILE '/home/user/myloadfile.csv'\nIGNORE INTO TABLE erp.e1_table\nFIELDS TERMINATED BY '\\t'\nLINES TERMINATED BY '\\n'\nIGNORE 0 LINES;\n",
+    "lexer": {
+        "@type": "PhpMyAdmin\\SqlParser\\Lexer",
+        "str": "-- Query from https://github.com/phpmyadmin/sql-parser/issues/578\n-- Issue was that Lexer detected \".e1\" as number token.\n\nLOAD DATA LOCAL INFILE '/home/user/myloadfile.csv'\nIGNORE INTO TABLE erp.e1_table\nFIELDS TERMINATED BY '\\t'\nLINES TERMINATED BY '\\n'\nIGNORE 0 LINES;\n",
+        "len": 272,
+        "last": 272,
+        "list": {
+            "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "tokens": [
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "-- Query from https://github.com/phpmyadmin/sql-parser/issues/578",
+                    "value": "-- Query from https://github.com/phpmyadmin/sql-parser/issues/578",
+                    "keyword": null,
+                    "type": 4,
+                    "flags": 4,
+                    "position": 0
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 65
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "-- Issue was that Lexer detected \".e1\" as number token.",
+                    "value": "-- Issue was that Lexer detected \".e1\" as number token.",
+                    "keyword": null,
+                    "type": 4,
+                    "flags": 4,
+                    "position": 66
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 121
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "LOAD DATA",
+                    "value": "LOAD DATA",
+                    "keyword": "LOAD DATA",
+                    "type": 1,
+                    "flags": 7,
+                    "position": 123
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 132
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "LOCAL",
+                    "value": "LOCAL",
+                    "keyword": "LOCAL",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 133
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 138
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "INFILE",
+                    "value": "INFILE",
+                    "keyword": "INFILE",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 139
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 145
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "'/home/user/myloadfile.csv'",
+                    "value": "/home/user/myloadfile.csv",
+                    "keyword": null,
+                    "type": 7,
+                    "flags": 1,
+                    "position": 146
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 173
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "IGNORE",
+                    "value": "IGNORE",
+                    "keyword": "IGNORE",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 174
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 180
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "INTO",
+                    "value": "INTO",
+                    "keyword": "INTO",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 181
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 185
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "TABLE",
+                    "value": "TABLE",
+                    "keyword": "TABLE",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 186
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 191
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "erp",
+                    "value": "erp",
+                    "keyword": null,
+                    "type": 0,
+                    "flags": 0,
+                    "position": 192
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ".",
+                    "value": ".",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 16,
+                    "position": 195
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "e1_table",
+                    "value": "e1_table",
+                    "keyword": null,
+                    "type": 0,
+                    "flags": 0,
+                    "position": 196
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 204
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "FIELDS",
+                    "value": "FIELDS",
+                    "keyword": "FIELDS",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 205
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 211
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "TERMINATED BY",
+                    "value": "TERMINATED BY",
+                    "keyword": "TERMINATED BY",
+                    "type": 1,
+                    "flags": 7,
+                    "position": 212
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 225
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "'\\t'",
+                    "value": "\t",
+                    "keyword": null,
+                    "type": 7,
+                    "flags": 1,
+                    "position": 226
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 230
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "LINES",
+                    "value": "LINES",
+                    "keyword": "LINES",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 231
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 236
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "TERMINATED BY",
+                    "value": "TERMINATED BY",
+                    "keyword": "TERMINATED BY",
+                    "type": 1,
+                    "flags": 7,
+                    "position": 237
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 250
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "'\\n'",
+                    "value": "\n",
+                    "keyword": null,
+                    "type": 7,
+                    "flags": 1,
+                    "position": 251
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 255
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "IGNORE",
+                    "value": "IGNORE",
+                    "keyword": "IGNORE",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 256
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 262
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "0",
+                    "value": 0,
+                    "keyword": null,
+                    "type": 6,
+                    "flags": 0,
+                    "position": 263
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 264
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "LINES",
+                    "value": "LINES",
+                    "keyword": "LINES",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 265
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ";",
+                    "value": ";",
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": 270
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 271
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": null,
+                    "value": null,
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": null
+                }
+            ],
+            "count": 42,
+            "idx": 42
+        },
+        "delimiter": ";",
+        "delimiterLen": 1,
+        "strict": false,
+        "errors": []
+    },
+    "parser": {
+        "@type": "PhpMyAdmin\\SqlParser\\Parser",
+        "list": {
+            "@type": "@1"
+        },
+        "statements": [
+            {
+                "@type": "PhpMyAdmin\\SqlParser\\Statements\\LoadStatement",
+                "file_name": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                    "database": null,
+                    "table": null,
+                    "column": null,
+                    "expr": "'/home/user/myloadfile.csv'",
+                    "alias": null,
+                    "function": null,
+                    "subquery": null,
+                    "file": "/home/user/myloadfile.csv"
+                },
+                "table": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                    "database": "erp",
+                    "table": "e1_table",
+                    "column": null,
+                    "expr": "erp.e1_table",
+                    "alias": null,
+                    "function": null,
+                    "subquery": null
+                },
+                "partition": null,
+                "charset_name": null,
+                "fields_options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": {
+                        "1": {
+                            "name": "TERMINATED BY",
+                            "equals": false,
+                            "expr": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                                "database": null,
+                                "table": null,
+                                "column": "\t",
+                                "expr": "'\\t'",
+                                "alias": null,
+                                "function": null,
+                                "subquery": null
+                            },
+                            "value": "'\\t'"
+                        }
+                    }
+                },
+                "fields_keyword": "FIELDS",
+                "lines_options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": {
+                        "2": {
+                            "name": "TERMINATED BY",
+                            "equals": false,
+                            "expr": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                                "database": null,
+                                "table": null,
+                                "column": "\n",
+                                "expr": "'\\n'",
+                                "alias": null,
+                                "function": null,
+                                "subquery": null
+                            },
+                            "value": "'\\n'"
+                        }
+                    }
+                },
+                "col_name_or_user_var": null,
+                "set": null,
+                "ignore_number": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                    "database": null,
+                    "table": null,
+                    "column": null,
+                    "expr": "0",
+                    "alias": null,
+                    "function": null,
+                    "subquery": null
+                },
+                "replace_ignore": "IGNORE",
+                "lines_rows": "LINES",
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": {
+                        "2": "LOCAL"
+                    }
+                },
+                "first": 0,
+                "last": 40
+            }
+        ],
+        "brackets": 0,
+        "strict": false,
+        "errors": []
+    },
+    "errors": {
+        "lexer": [],
+        "parser": []
+    }
+}


### PR DESCRIPTION
@williamdes Here is my fix about #578.

On the first and fourth (because I forgot to move from state 10 to state 4) commits, you can see that token ".e4" is parsed as is and wrongly considered as a number, causing the effect of not being able to detect the "." in "database_name.table_name" as an operator, and cascading to a failure in the parser.

On the second commit, with the fix, you can see ".e4" is no longer a token, but instead "." is a token, and "e4" is another one, which is not a number.

On the third commit… eh, please don't look, I just forgot to remove a debuging stuff 😓