### PR TITLE
Fix tyephint on `SelectStatement::$expr`

### DIFF
--- a/src/Statements/SelectStatement.php
+++ b/src/Statements/SelectStatement.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Statements;
 
 use PhpMyAdmin\SqlParser\Components\ArrayObj;
+use PhpMyAdmin\SqlParser\Components\CaseExpression;
 use PhpMyAdmin\SqlParser\Components\Condition;
 use PhpMyAdmin\SqlParser\Components\Expression;
 use PhpMyAdmin\SqlParser\Components\FunctionCall;
@@ -234,7 +235,7 @@ class SelectStatement extends Statement
     /**
      * Expressions that are being selected by this statement.
      *
-     * @var Expression[]
+     * @var (CaseExpression|Expression)[]
      */
     public $expr = [];
 


### PR DESCRIPTION
If you try to parse a query like
```sql
SELECT CASE WHEN `VALUE` = 1 THEN `COLUMN_ONE` END;
```
you will see that `SelectStatement::$expr` is actually containing a `CaseExpression` and not an `Expression`.