### PR TITLE
Refactor getForeignKeys()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -476,6 +476,16 @@ parameters:
 			path: src/Statements/CallStatement.php
 
 		-
+			message: "#^Cannot access property \\$database on PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|null\\.$#"
+			count: 1
+			path: src/Statements/CreateStatement.php
+
+		-
+			message: "#^Cannot access property \\$table on PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|null\\.$#"
+			count: 1
+			path: src/Statements/CreateStatement.php
+
+		-
 			message: "#^Cannot access property \\$value on PhpMyAdmin\\\\SqlParser\\\\Token\\|null\\.$#"
 			count: 2
 			path: src/Statements/CreateStatement.php
@@ -497,12 +507,17 @@ parameters:
 
 		-
 			message: "#^Cannot call method has\\(\\) on PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
-			count: 8
+			count: 11
 			path: src/Statements/CreateStatement.php
 
 		-
 			message: "#^Parameter \\#1 \\$component of static method PhpMyAdmin\\\\SqlParser\\\\Parsers\\\\ParameterDefinitions\\:\\:buildAll\\(\\) expects array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\>, array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\ParameterDefinition\\>\\|null given\\.$#"
 			count: 1
+			path: src/Statements/CreateStatement.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, mixed given\\.$#"
+			count: 2
 			path: src/Statements/CreateStatement.php
 
 		-
@@ -876,28 +891,13 @@ parameters:
 			path: src/Utils/Query.php
 
 		-
-			message: "#^Cannot access property \\$database on PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|null\\.$#"
-			count: 1
-			path: src/Utils/Table.php
-
-		-
-			message: "#^Cannot access property \\$table on PhpMyAdmin\\\\SqlParser\\\\Components\\\\Expression\\|null\\.$#"
-			count: 1
-			path: src/Utils/Table.php
-
-		-
 			message: "#^Cannot call method has\\(\\) on PhpMyAdmin\\\\SqlParser\\\\Components\\\\OptionsArray\\|null\\.$#"
-			count: 4
+			count: 1
 			path: src/Utils/Table.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\SqlParser\\\\Utils\\\\Table\\:\\:getFields\\(\\) should return array\\<string, array\\{type\\: string, timestamp_not_null\\: bool, default_value\\?\\: mixed, default_current_timestamp\\?\\: true, on_update_current_timestamp\\?\\: true, expr\\?\\: mixed\\}\\> but returns array\\<string, array\\{default_current_timestamp\\?\\: true, default_value\\?\\: mixed, expr\\?\\: mixed, on_update_current_timestamp\\?\\: true, timestamp_not_null\\: bool, type\\: string\\|null\\}\\>\\.$#"
 			count: 1
-			path: src/Utils/Table.php
-
-		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, mixed given\\.$#"
-			count: 2
 			path: src/Utils/Table.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -679,8 +679,14 @@
   </file>
   <file src="src/Statements/CreateStatement.php">
     <MixedArgument>
+      <code><![CDATA[$opt]]></code>
+      <code><![CDATA[$opt]]></code>
       <code><![CDATA[$this->$field]]></code>
     </MixedArgument>
+    <MixedAssignment>
+      <code><![CDATA[$opt]]></code>
+      <code><![CDATA[$opt]]></code>
+    </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$this->$field]]></code>
     </MixedOperand>
@@ -688,10 +694,16 @@
       <code><![CDATA[$brackets]]></code>
       <code><![CDATA[$brackets]]></code>
     </PossiblyFalseOperand>
+    <PossiblyInvalidPropertyAssignmentValue>
+      <code><![CDATA[str_replace(' ', '_', $opt)]]></code>
+      <code><![CDATA[str_replace(' ', '_', $opt)]]></code>
+    </PossiblyInvalidPropertyAssignmentValue>
     <PossiblyNullArgument>
       <code><![CDATA[$this->parameters]]></code>
     </PossiblyNullArgument>
     <PossiblyNullPropertyFetch>
+      <code><![CDATA[$field->references->table->database]]></code>
+      <code><![CDATA[$field->references->table->table]]></code>
       <code><![CDATA[$token->value]]></code>
       <code><![CDATA[$token->value]]></code>
     </PossiblyNullPropertyFetch>
@@ -713,6 +725,8 @@
       <code><![CDATA[build]]></code>
       <code><![CDATA[has]]></code>
       <code><![CDATA[has]]></code>
+      <code><![CDATA[has]]></code>
+      <code><![CDATA[has]]></code>
     </PossiblyNullReference>
     <PropertyTypeCoercion>
       <code><![CDATA[$token->value]]></code>
@@ -725,6 +739,7 @@
       <code><![CDATA[ArrayObjs::parse($parser, $list)]]></code>
     </PropertyTypeCoercion>
     <RiskyTruthyFalsyComparison>
+      <code><![CDATA[empty($this->fields)]]></code>
       <code><![CDATA[empty($this->partitionBy)]]></code>
       <code><![CDATA[empty($this->partitionBy)]]></code>
       <code><![CDATA[empty($this->partitions)]]></code>
@@ -1022,6 +1037,17 @@
       <code><![CDATA[$obj instanceof Parser]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
+  <file src="src/Utils/ForeignKeyData.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$constraint]]></code>
+      <code><![CDATA[$indexList]]></code>
+      <code><![CDATA[$onDelete]]></code>
+      <code><![CDATA[$onUpdate]]></code>
+      <code><![CDATA[$refDbName]]></code>
+      <code><![CDATA[$refIndexList]]></code>
+      <code><![CDATA[$refTableName]]></code>
+    </PossiblyUnusedProperty>
+  </file>
   <file src="src/Utils/Formatter.php">
     <InvalidArrayOffset>
       <code><![CDATA[JoinKeyword::JOINS[$list->tokens[$list->idx - 2]->value]]]></code>
@@ -1165,13 +1191,7 @@
     <LessSpecificReturnStatement>
       <code><![CDATA[$ret]]></code>
     </LessSpecificReturnStatement>
-    <MixedArgument>
-      <code><![CDATA[$opt]]></code>
-      <code><![CDATA[$opt]]></code>
-    </MixedArgument>
     <MixedAssignment>
-      <code><![CDATA[$opt]]></code>
-      <code><![CDATA[$opt]]></code>
       <code><![CDATA[$option]]></code>
       <code><![CDATA[$option]]></code>
       <code><![CDATA[$option]]></code>
@@ -1196,17 +1216,10 @@
       <code><![CDATA[$ret]]></code>
       <code><![CDATA[$ret]]></code>
     </PossiblyNullArrayOffset>
-    <PossiblyNullPropertyFetch>
-      <code><![CDATA[$field->references->table->database]]></code>
-      <code><![CDATA[$field->references->table->table]]></code>
-    </PossiblyNullPropertyFetch>
     <PossiblyNullReference>
-      <code><![CDATA[has]]></code>
-      <code><![CDATA[has]]></code>
       <code><![CDATA[has]]></code>
     </PossiblyNullReference>
     <RiskyTruthyFalsyComparison>
-      <code><![CDATA[empty($statement->fields)]]></code>
       <code><![CDATA[empty($statement->fields)]]></code>
     </RiskyTruthyFalsyComparison>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1037,7 +1037,7 @@
       <code><![CDATA[$obj instanceof Parser]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="src/Utils/ForeignKeyData.php">
+  <file src="src/Utils/ForeignKey.php">
     <PossiblyUnusedProperty>
       <code><![CDATA[$constraint]]></code>
       <code><![CDATA[$indexList]]></code>

--- a/src/Statements/CreateStatement.php
+++ b/src/Statements/CreateStatement.php
@@ -23,7 +23,7 @@ use PhpMyAdmin\SqlParser\Statement;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
 use PhpMyAdmin\SqlParser\TokenType;
-use PhpMyAdmin\SqlParser\Utils\ForeignKeyData;
+use PhpMyAdmin\SqlParser\Utils\ForeignKey;
 
 use function is_array;
 use function str_replace;
@@ -778,7 +778,7 @@ class CreateStatement extends Statement
         }
     }
 
-    /** @return list<ForeignKeyData> */
+    /** @return list<ForeignKey> */
     public function getForeignKeys(): array
     {
         if (empty($this->fields) || (! is_array($this->fields)) || (! $this->options->has('TABLE'))) {
@@ -801,7 +801,7 @@ class CreateStatement extends Statement
                 $columns[] = $column['name'];
             }
 
-            $foreignKey = new ForeignKeyData();
+            $foreignKey = new ForeignKey();
             $foreignKey->constraint = $field->name;
             $foreignKey->indexList = $columns;
 

--- a/src/Utils/ForeignKey.php
+++ b/src/Utils/ForeignKey.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Utils;
 
-final class ForeignKeyData
+final class ForeignKey
 {
     /**
      * @param (int|string)[] $indexList

--- a/src/Utils/ForeignKeyData.php
+++ b/src/Utils/ForeignKeyData.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\SqlParser\Utils;
+
+final class ForeignKeyData
+{
+    /**
+     * @param (int|string)[] $indexList
+     * @param string[]       $refIndexList
+     */
+    public function __construct(
+        public string|null $constraint = null,
+        public array $indexList = [],
+        public string|null $refDbName = null,
+        public string|null $refTableName = null,
+        public array $refIndexList = [],
+        public string|null $onUpdate = null,
+        public string|null $onDelete = null,
+    ) {
+    }
+}

--- a/src/Utils/Table.php
+++ b/src/Utils/Table.php
@@ -7,78 +7,12 @@ namespace PhpMyAdmin\SqlParser\Utils;
 use PhpMyAdmin\SqlParser\Statements\CreateStatement;
 
 use function is_array;
-use function str_replace;
 
 /**
  * Table utilities.
  */
 class Table
 {
-    /**
-     * Gets the foreign keys of the table.
-     *
-     * @return list<(string|string[]|null)[]>
-     * @psalm-return list<array{
-     *  constraint: string|null,
-     *  index_list: (int|string)[],
-     *  ref_db_name?: string|null,
-     *  ref_table_name?: string|null,
-     *  ref_index_list?: string[],
-     *  on_update?: string|string[],
-     *  on_delete?: string|string[],
-     * }>
-     */
-    public static function getForeignKeys(CreateStatement $statement): array
-    {
-        if (empty($statement->fields) || (! is_array($statement->fields)) || (! $statement->options->has('TABLE'))) {
-            return [];
-        }
-
-        $ret = [];
-
-        foreach ($statement->fields as $field) {
-            if (empty($field->key) || ($field->key->type !== 'FOREIGN KEY')) {
-                continue;
-            }
-
-            $columns = [];
-            foreach ($field->key->columns as $column) {
-                if (! isset($column['name'])) {
-                    continue;
-                }
-
-                $columns[] = $column['name'];
-            }
-
-            $tmp = [
-                'constraint' => $field->name,
-                'index_list' => $columns,
-            ];
-
-            if (! empty($field->references)) {
-                $tmp['ref_db_name'] = $field->references->table->database;
-                $tmp['ref_table_name'] = $field->references->table->table;
-                $tmp['ref_index_list'] = $field->references->columns;
-
-                $opt = $field->references->options->has('ON UPDATE');
-
-                if ($opt) {
-                    $tmp['on_update'] = str_replace(' ', '_', $opt);
-                }
-
-                $opt = $field->references->options->has('ON DELETE');
-
-                if ($opt) {
-                    $tmp['on_delete'] = str_replace(' ', '_', $opt);
-                }
-            }
-
-            $ret[] = $tmp;
-        }
-
-        return $ret;
-    }
-
     /**
      * Gets fields of the table.
      *

--- a/tests/Utils/TableTest.php
+++ b/tests/Utils/TableTest.php
@@ -7,43 +7,24 @@ namespace PhpMyAdmin\SqlParser\Tests\Utils;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statements\CreateStatement;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PhpMyAdmin\SqlParser\Utils\ForeignKeyData;
 use PhpMyAdmin\SqlParser\Utils\Table;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class TableTest extends TestCase
 {
-    /**
-     * @param array<string, string|string[]|null>[] $expected
-     * @psalm-param list<array{
-     *   constraint: string,
-     *   index_list: string[],
-     *   ref_db_name: null,
-     *   ref_table_name: string,
-     *   ref_index_list: string[],
-     *   on_update: string,
-     *   on_delete?: string
-     * }> $expected
-     */
+    /** @param list<ForeignKeyData> $expected */
     #[DataProvider('getForeignKeysProvider')]
     public function testGetForeignKeys(string $query, array $expected): void
     {
         $parser = new Parser($query);
         $this->assertInstanceOf(CreateStatement::class, $parser->statements[0]);
-        $this->assertEquals($expected, Table::getForeignKeys($parser->statements[0]));
+
+        $result = $parser->statements[0]->getForeignKeys();
+        $this->assertEquals($expected, $result);
     }
 
-    /**
-     * @return array<int, array<int, string|array<string, string|string[]|null>[]>>
-     * @psalm-return list<array{string, list<array{
-     *   constraint: string,
-     *   index_list: string[],
-     *   ref_db_name: null,
-     *   ref_table_name: string,
-     *   ref_index_list: string[],
-     *   on_update: string,
-     *   on_delete?: string
-     * }>}>
-     */
+    /** @return list<array{string, list<ForeignKeyData>}> */
     public static function getForeignKeysProvider(): array
     {
         return [
@@ -72,31 +53,28 @@ class TableTest extends TestCase
                       REFERENCES `staff` (`staff_id`) ON UPDATE CASCADE
                 ) ENGINE=InnoDB AUTO_INCREMENT=16050 DEFAULT CHARSET=utf8',
                 [
-                    [
-                        'constraint' => 'fk_payment_customer',
-                        'index_list' => ['customer_id'],
-                        'ref_db_name' => null,
-                        'ref_table_name' => 'customer',
-                        'ref_index_list' => ['customer_id'],
-                        'on_update' => 'CASCADE',
-                    ],
-                    [
-                        'constraint' => 'fk_payment_rental',
-                        'index_list' => ['rental_id'],
-                        'ref_db_name' => null,
-                        'ref_table_name' => 'rental',
-                        'ref_index_list' => ['rental_id'],
-                        'on_delete' => 'SET_NULL',
-                        'on_update' => 'CASCADE',
-                    ],
-                    [
-                        'constraint' => 'fk_payment_staff',
-                        'index_list' => ['staff_id'],
-                        'ref_db_name' => null,
-                        'ref_table_name' => 'staff',
-                        'ref_index_list' => ['staff_id'],
-                        'on_update' => 'CASCADE',
-                    ],
+                    new ForeignKeyData(
+                        constraint: 'fk_payment_customer',
+                        indexList: ['customer_id'],
+                        refTableName: 'customer',
+                        refIndexList: ['customer_id'],
+                        onUpdate: 'CASCADE',
+                    ),
+                    new ForeignKeyData(
+                        constraint: 'fk_payment_rental',
+                        indexList: ['rental_id'],
+                        refTableName: 'rental',
+                        refIndexList: ['rental_id'],
+                        onDelete: 'SET_NULL',
+                        onUpdate: 'CASCADE',
+                    ),
+                    new ForeignKeyData(
+                        constraint: 'fk_payment_staff',
+                        indexList: ['staff_id'],
+                        refTableName: 'staff',
+                        refIndexList: ['staff_id'],
+                        onUpdate: 'CASCADE',
+                    ),
                 ],
             ],
             [
@@ -125,14 +103,13 @@ class TableTest extends TestCase
                   CONSTRAINT `fk_address_city` FOREIGN KEY (`city_id`) REFERENCES `city` (`city_id`) ON UPDATE CASCADE
                 ) ENGINE=InnoDB AUTO_INCREMENT=606 DEFAULT CHARSET=utf8',
                 [
-                    [
-                        'constraint' => 'fk_address_city',
-                        'index_list' => ['city_id'],
-                        'ref_db_name' => null,
-                        'ref_table_name' => 'city',
-                        'ref_index_list' => ['city_id'],
-                        'on_update' => 'CASCADE',
-                    ],
+                    new ForeignKeyData(
+                        constraint: 'fk_address_city',
+                        indexList: ['city_id'],
+                        refTableName: 'city',
+                        refIndexList: ['city_id'],
+                        onUpdate: 'CASCADE',
+                    ),
                 ],
             ],
         ];

--- a/tests/Utils/TableTest.php
+++ b/tests/Utils/TableTest.php
@@ -7,13 +7,13 @@ namespace PhpMyAdmin\SqlParser\Tests\Utils;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statements\CreateStatement;
 use PhpMyAdmin\SqlParser\Tests\TestCase;
-use PhpMyAdmin\SqlParser\Utils\ForeignKeyData;
+use PhpMyAdmin\SqlParser\Utils\ForeignKey;
 use PhpMyAdmin\SqlParser\Utils\Table;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class TableTest extends TestCase
 {
-    /** @param list<ForeignKeyData> $expected */
+    /** @param list<ForeignKey> $expected */
     #[DataProvider('getForeignKeysProvider')]
     public function testGetForeignKeys(string $query, array $expected): void
     {
@@ -24,7 +24,7 @@ class TableTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    /** @return list<array{string, list<ForeignKeyData>}> */
+    /** @return list<array{string, list<ForeignKey>}> */
     public static function getForeignKeysProvider(): array
     {
         return [
@@ -53,14 +53,14 @@ class TableTest extends TestCase
                       REFERENCES `staff` (`staff_id`) ON UPDATE CASCADE
                 ) ENGINE=InnoDB AUTO_INCREMENT=16050 DEFAULT CHARSET=utf8',
                 [
-                    new ForeignKeyData(
+                    new ForeignKey(
                         constraint: 'fk_payment_customer',
                         indexList: ['customer_id'],
                         refTableName: 'customer',
                         refIndexList: ['customer_id'],
                         onUpdate: 'CASCADE',
                     ),
-                    new ForeignKeyData(
+                    new ForeignKey(
                         constraint: 'fk_payment_rental',
                         indexList: ['rental_id'],
                         refTableName: 'rental',
@@ -68,7 +68,7 @@ class TableTest extends TestCase
                         onDelete: 'SET_NULL',
                         onUpdate: 'CASCADE',
                     ),
-                    new ForeignKeyData(
+                    new ForeignKey(
                         constraint: 'fk_payment_staff',
                         indexList: ['staff_id'],
                         refTableName: 'staff',
@@ -103,7 +103,7 @@ class TableTest extends TestCase
                   CONSTRAINT `fk_address_city` FOREIGN KEY (`city_id`) REFERENCES `city` (`city_id`) ON UPDATE CASCADE
                 ) ENGINE=InnoDB AUTO_INCREMENT=606 DEFAULT CHARSET=utf8',
                 [
-                    new ForeignKeyData(
+                    new ForeignKey(
                         constraint: 'fk_address_city',
                         indexList: ['city_id'],
                         refTableName: 'city',


### PR DESCRIPTION
Changed from static to instance and introduced a DTO to help with type inference in PMA. I named it `ForeignKeyData` to avoid clash with `ForeignKey` in PMA. 