### PR TITLE
Micro optimizations and refactorings

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -156,9 +156,6 @@
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[[]]]></code>
     </InvalidPropertyAssignmentValue>
-    <InvalidPropertyFetch>
-      <code><![CDATA[$context::$keywords]]></code>
-    </InvalidPropertyFetch>
     <MixedAssignment>
       <code><![CDATA[self::$keywords]]></code>
     </MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -176,49 +176,6 @@
     <MixedOperand>
       <code><![CDATA[$this->str[$this->last]]]></code>
     </MixedOperand>
-    <PossiblyNullArgument>
-      <code><![CDATA[$this->str[$this->last + 1]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$token]]></code>
-      <code><![CDATA[$token]]></code>
-      <code><![CDATA[$token]]></code>
-      <code><![CDATA[$token]]></code>
-      <code><![CDATA[$token]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullOperand>
-      <code><![CDATA[$this->str[$this->last++]]]></code>
-      <code><![CDATA[$this->str[$this->last++]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[$this->last]]]></code>
-      <code><![CDATA[$this->str[++$this->last]]]></code>
-      <code><![CDATA[$this->str[++$this->last]]]></code>
-      <code><![CDATA[$this->str[++$this->last]]]></code>
-      <code><![CDATA[$this->str[++$this->last]]]></code>
-      <code><![CDATA[$this->str[++$this->last]]]></code>
-    </PossiblyNullOperand>
     <PossiblyNullPropertyFetch>
       <code><![CDATA[$next->type]]></code>
       <code><![CDATA[$next->value]]></code>
@@ -231,9 +188,6 @@
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[! $flags]]></code>
       <code><![CDATA[! $flags]]></code>
-      <code><![CDATA[Context::isComment($token)]]></code>
-      <code><![CDATA[Context::isComment($token)]]></code>
-      <code><![CDATA[Context::isComment($token, $end)]]></code>
       <code><![CDATA[empty($delimiter)]]></code>
     </RiskyTruthyFalsyComparison>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -232,7 +232,6 @@
       <code><![CDATA[! $flags]]></code>
       <code><![CDATA[! $flags]]></code>
       <code><![CDATA[! $flags]]></code>
-      <code><![CDATA[! $flags]]></code>
       <code><![CDATA[Context::isComment($token)]]></code>
       <code><![CDATA[Context::isComment($token)]]></code>
       <code><![CDATA[Context::isComment($token, $end)]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -231,7 +231,6 @@
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[! $flags]]></code>
       <code><![CDATA[! $flags]]></code>
-      <code><![CDATA[! $flags]]></code>
       <code><![CDATA[Context::isComment($token)]]></code>
       <code><![CDATA[Context::isComment($token)]]></code>
       <code><![CDATA[Context::isComment($token, $end)]]></code>

--- a/src/Context.php
+++ b/src/Context.php
@@ -445,25 +445,14 @@ abstract class Context
      *
      * @return int|null the appropriate flag for the symbol type
      */
-    public static function isSymbol(string $string): int|null
+    public static function isSymbol(string $character): int|null
     {
-        if ($string === '') {
-            return null;
-        }
-
-        if (str_starts_with($string, '@')) {
-            return Token::FLAG_SYMBOL_VARIABLE;
-        }
-
-        if (str_starts_with($string, '`')) {
-            return Token::FLAG_SYMBOL_BACKTICK;
-        }
-
-        if (str_starts_with($string, ':') || str_starts_with($string, '?')) {
-            return Token::FLAG_SYMBOL_PARAMETER;
-        }
-
-        return null;
+        return match ($character) {
+            '@' => Token::FLAG_SYMBOL_VARIABLE,
+            '`' => Token::FLAG_SYMBOL_BACKTICK,
+            ':', '?' => Token::FLAG_SYMBOL_PARAMETER,
+            default => null,
+        };
     }
 
     /**

--- a/src/Context.php
+++ b/src/Context.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser;
 
 use PhpMyAdmin\SqlParser\Contexts\ContextMySql50700;
 
+use function array_map;
 use function class_exists;
 use function explode;
 use function in_array;
@@ -672,11 +673,7 @@ abstract class Context
      */
     public static function escapeAll(array $strings): array
     {
-        foreach ($strings as $key => $value) {
-            $strings[$key] = static::escape($value);
-        }
-
-        return $strings;
+        return array_map(static::escape(...), $strings);
     }
 
     /**

--- a/src/Context.php
+++ b/src/Context.php
@@ -388,39 +388,20 @@ abstract class Context
      */
     public static function isComment(string $string, bool $end = false): int|null
     {
-        if ($string === '') {
-            return null;
-        }
-
-        // If comment is Bash style (#):
-        if (str_starts_with($string, '#')) {
-            return Token::FLAG_COMMENT_BASH;
-        }
-
-        // If comment is a MySQL command
-        if (str_starts_with($string, '/*!')) {
-            return Token::FLAG_COMMENT_MYSQL_CMD;
-        }
-
-        // If comment is opening C style (/*) or is closing C style (*/), warning, it could conflict
-        // with wildcard and a real opening C style.
-        // It would look like the following valid SQL statement: "SELECT */* comment */ FROM...".
-        if (str_starts_with($string, '/*') || str_starts_with($string, '*/')) {
-            return Token::FLAG_COMMENT_C;
-        }
-
-        // If comment is SQL style (--\s?):
-        if (
+        return match (true) {
+            str_starts_with($string, '#') => Token::FLAG_COMMENT_BASH,
+            str_starts_with($string, '/*!') => Token::FLAG_COMMENT_MYSQL_CMD,
+            // If comment is opening C style (/*) or is closing C style (*/), warning, it could conflict
+            // with wildcard and a real opening C style.
+            // It would look like the following valid SQL statement: "SELECT */* comment */ FROM...".
+            str_starts_with($string, '/*') || str_starts_with($string, '*/') => Token::FLAG_COMMENT_C,
             str_starts_with($string, '-- ')
-            || str_starts_with($string, "--\r")
-            || str_starts_with($string, "--\n")
-            || str_starts_with($string, "--\t")
-            || ($string === '--' && $end)
-        ) {
-            return Token::FLAG_COMMENT_SQL;
-        }
-
-        return null;
+                || str_starts_with($string, "--\r")
+                || str_starts_with($string, "--\n")
+                || str_starts_with($string, "--\t")
+                || ($string === '--' && $end) => Token::FLAG_COMMENT_SQL,
+            default => null,
+        };
     }
 
     /**

--- a/src/Context.php
+++ b/src/Context.php
@@ -79,10 +79,8 @@ abstract class Context
 
     /**
      * List of operators and their flags.
-     *
-     * @var array<string, int>
      */
-    public static array $operators = [
+    private const OPERATORS = [
         // Some operators (*, =) may have ambiguous flags, because they depend on
         // the context they are being used in.
         // For example: 1. SELECT * FROM table; # SQL specific (wildcard)
@@ -367,7 +365,7 @@ abstract class Context
      */
     public static function isOperator(string $string): int|null
     {
-        return static::$operators[$string] ?? null;
+        return self::OPERATORS[$string] ?? null;
     }
 
     /**

--- a/src/Context.php
+++ b/src/Context.php
@@ -372,9 +372,12 @@ abstract class Context
     /**
      * Checks if the given character is a whitespace.
      */
-    public static function isWhitespace(string $string): bool
+    public static function isWhitespace(string $character): bool
     {
-        return $string === ' ' || $string === "\r" || $string === "\n" || $string === "\t";
+        return match ($character) {
+            ' ', "\r", "\n", "\t" => true,
+            default => false,
+        };
     }
 
     /**

--- a/src/Context.php
+++ b/src/Context.php
@@ -469,25 +469,17 @@ abstract class Context
     /**
      * Checks if the given character is the beginning of a string.
      *
-     * @param string $string string to be checked
+     * @param string $character a character to be checked
      *
      * @return int|null the appropriate flag for the string type
      */
-    public static function isString(string $string): int|null
+    public static function isString(string $character): int|null
     {
-        if ($string === '') {
-            return null;
-        }
-
-        if (str_starts_with($string, '\'')) {
-            return Token::FLAG_STRING_SINGLE_QUOTES;
-        }
-
-        if (str_starts_with($string, '"')) {
-            return Token::FLAG_STRING_DOUBLE_QUOTES;
-        }
-
-        return null;
+        return match ($character) {
+            '\'' => Token::FLAG_STRING_SINGLE_QUOTES,
+            '"' => Token::FLAG_STRING_DOUBLE_QUOTES,
+            default => null,
+        };
     }
 
     /**

--- a/src/Context.php
+++ b/src/Context.php
@@ -27,7 +27,7 @@ use function substr;
  *
  * Holds the configuration of the context that is currently used.
  */
-abstract class Context
+final class Context
 {
     /**
      * The maximum length of a keyword.
@@ -55,7 +55,7 @@ abstract class Context
      * The prefix concatenated to the context name when an incomplete class name
      * is specified.
      */
-    public static string $contextPrefix = 'PhpMyAdmin\\SqlParser\\Contexts\\Context';
+    private const CONTEXT_PREFIX = 'PhpMyAdmin\\SqlParser\\Contexts\\Context';
 
     /**
      * List of keywords.
@@ -486,22 +486,19 @@ abstract class Context
             $context = ContextMySql50700::class;
         }
 
-        if (! class_exists($context)) {
-            if (! class_exists(self::$contextPrefix . $context)) {
-                return false;
-            }
-
-            // Could be the fully qualified class name was given, like `ContextDBMS::class`.
-            if (class_exists('\\' . $context)) {
-                $context = '\\' . $context;
-            } else {
-                // Short context name (must be formatted into class name).
-                $context = self::$contextPrefix . $context;
+        $contextClass = $context;
+        if (! class_exists($contextClass)) {
+            $contextClass = self::CONTEXT_PREFIX . $context;
+            if (! class_exists($contextClass)) {
+                $contextClass = '\\' . $context;
+                if (! class_exists($contextClass)) {
+                    return false;
+                }
             }
         }
 
-        self::$loadedContext = $context;
-        self::$keywords = $context::$keywords;
+        self::$loadedContext = $contextClass;
+        self::$keywords = $contextClass::KEYWORDS;
 
         return true;
     }

--- a/src/Contexts/ContextMariaDb100000.php
+++ b/src/Contexts/ContextMariaDb100000.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb100000 extends Context
+final class ContextMariaDb100000
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb100000 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,
         'AGGREGATE' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb100100.php
+++ b/src/Contexts/ContextMariaDb100100.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb100100 extends Context
+final class ContextMariaDb100100
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb100100 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb100200.php
+++ b/src/Contexts/ContextMariaDb100200.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb100200 extends Context
+final class ContextMariaDb100200
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb100200 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb100300.php
+++ b/src/Contexts/ContextMariaDb100300.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb100300 extends Context
+final class ContextMariaDb100300
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb100300 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb100400.php
+++ b/src/Contexts/ContextMariaDb100400.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb100400 extends Context
+final class ContextMariaDb100400
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb100400 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb100500.php
+++ b/src/Contexts/ContextMariaDb100500.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb100500 extends Context
+final class ContextMariaDb100500
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb100500 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb100600.php
+++ b/src/Contexts/ContextMariaDb100600.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb100600 extends Context
+final class ContextMariaDb100600
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb100600 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb100700.php
+++ b/src/Contexts/ContextMariaDb100700.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb100700 extends Context
+final class ContextMariaDb100700
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb100700 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb100800.php
+++ b/src/Contexts/ContextMariaDb100800.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb100800 extends Context
+final class ContextMariaDb100800
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb100800 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb100900.php
+++ b/src/Contexts/ContextMariaDb100900.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb100900 extends Context
+final class ContextMariaDb100900
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb100900 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb101000.php
+++ b/src/Contexts/ContextMariaDb101000.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb101000 extends Context
+final class ContextMariaDb101000
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb101000 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb101100.php
+++ b/src/Contexts/ContextMariaDb101100.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb101100 extends Context
+final class ContextMariaDb101100
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb101100 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb110000.php
+++ b/src/Contexts/ContextMariaDb110000.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb110000 extends Context
+final class ContextMariaDb110000
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb110000 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb110100.php
+++ b/src/Contexts/ContextMariaDb110100.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb110100 extends Context
+final class ContextMariaDb110100
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb110100 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb110200.php
+++ b/src/Contexts/ContextMariaDb110200.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb110200 extends Context
+final class ContextMariaDb110200
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb110200 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb110300.php
+++ b/src/Contexts/ContextMariaDb110300.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb110300 extends Context
+final class ContextMariaDb110300
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb110300 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb110400.php
+++ b/src/Contexts/ContextMariaDb110400.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb110400 extends Context
+final class ContextMariaDb110400
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb110400 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMariaDb110500.php
+++ b/src/Contexts/ContextMariaDb110500.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://mariadb.com/kb/en/reserved-words/
  */
-class ContextMariaDb110500 extends Context
+final class ContextMariaDb110500
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMariaDb110500 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMySql50000.php
+++ b/src/Contexts/ContextMySql50000.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://dev.mysql.com/doc/refman/5.0/en/keywords.html
  */
-class ContextMySql50000 extends Context
+final class ContextMySql50000
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMySql50000 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,
         'AGGREGATE' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMySql50100.php
+++ b/src/Contexts/ContextMySql50100.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://dev.mysql.com/doc/refman/5.1/en/keywords.html
  */
-class ContextMySql50100 extends Context
+final class ContextMySql50100
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMySql50100 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,
         'AGGREGATE' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMySql50500.php
+++ b/src/Contexts/ContextMySql50500.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://dev.mysql.com/doc/refman/5.5/en/keywords.html
  */
-class ContextMySql50500 extends Context
+final class ContextMySql50500
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMySql50500 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,
         'AGGREGATE' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMySql50600.php
+++ b/src/Contexts/ContextMySql50600.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://dev.mysql.com/doc/refman/5.6/en/keywords.html
  */
-class ContextMySql50600 extends Context
+final class ContextMySql50600
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMySql50600 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,
         'AGGREGATE' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMySql50700.php
+++ b/src/Contexts/ContextMySql50700.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://dev.mysql.com/doc/refman/5.7/en/keywords.html
  */
-class ContextMySql50700 extends Context
+final class ContextMySql50700
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMySql50700 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMySql80000.php
+++ b/src/Contexts/ContextMySql80000.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://dev.mysql.com/doc/refman/8.0/en/keywords.html
  */
-class ContextMySql80000 extends Context
+final class ContextMySql80000
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMySql80000 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMySql80100.php
+++ b/src/Contexts/ContextMySql80100.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://dev.mysql.com/doc/refman/8.1/en/keywords.html
  */
-class ContextMySql80100 extends Context
+final class ContextMySql80100
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMySql80100 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMySql80200.php
+++ b/src/Contexts/ContextMySql80200.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://dev.mysql.com/doc/refman/8.2/en/keywords.html
  */
-class ContextMySql80200 extends Context
+final class ContextMySql80200
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMySql80200 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMySql80300.php
+++ b/src/Contexts/ContextMySql80300.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://dev.mysql.com/doc/refman/8.3/en/keywords.html
  */
-class ContextMySql80300 extends Context
+final class ContextMySql80300
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMySql80300 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMySql80400.php
+++ b/src/Contexts/ContextMySql80400.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://dev.mysql.com/doc/refman/8.4/en/keywords.html
  */
-class ContextMySql80400 extends Context
+final class ContextMySql80400
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMySql80400 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Contexts/ContextMySql90000.php
+++ b/src/Contexts/ContextMySql90000.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://dev.mysql.com/doc/refman/9.0/en/keywords.html
  */
-class ContextMySql90000 extends Context
+final class ContextMySql90000
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class ContextMySql90000 extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'ACCOUNT' => Token::FLAG_KEYWORD,
         'ACTION' => Token::FLAG_KEYWORD,
         'AFTER' => Token::FLAG_KEYWORD,

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -546,7 +546,7 @@ class Lexer
         $token = $this->str[$this->last];
 
         // Bash style comments. (#comment\n)
-        if (Context::isComment($token)) {
+        if (Context::isComment($token) !== null) {
             while (++$this->last < $this->len && $this->str[$this->last] !== "\n") {
                 $token .= $this->str[$this->last];
             }
@@ -562,7 +562,7 @@ class Lexer
         // C style comments. (/*comment*\/)
         if (++$this->last < $this->len) {
             $token .= $this->str[$this->last];
-            if (Context::isComment($token)) {
+            if (Context::isComment($token) !== null) {
                 // There might be a conflict with "*" operator here, when string is "*/*".
                 // This can occurs in the following statements:
                 // - "SELECT */* comment */ FROM ..."
@@ -633,7 +633,7 @@ class Lexer
             $end = true;
         }
 
-        if (Context::isComment($token, $end)) {
+        if (Context::isComment($token, $end) !== null) {
             // Checking if this comment did not end already (```--\n```).
             if ($this->str[$this->last] !== "\n") {
                 while (++$this->last < $this->len && $this->str[$this->last] !== "\n") {

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -918,7 +918,7 @@ class Lexer
         $token = $this->str[$this->last];
         $flags = Context::isSymbol($token);
 
-        if (! $flags) {
+        if ($flags === null) {
             return null;
         }
 

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -868,7 +868,7 @@ class Lexer
         $token = $this->str[$this->last];
         $flags = Context::isString($token);
 
-        if (! $flags && $token !== $quote) {
+        if ($flags === null && $token !== $quote) {
             return null;
         }
 

--- a/src/Tools/ContextGenerator.php
+++ b/src/Tools/ContextGenerator.php
@@ -116,7 +116,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -127,7 +126,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see %3$s
  */
-class %2$s extends Context
+final class %2$s
 {
     /**
      * List of keywords.
@@ -136,11 +135,10 @@ class %2$s extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
 %4$s    ];
 }
 

--- a/src/UtfString.php
+++ b/src/UtfString.php
@@ -61,9 +61,9 @@ class UtfString implements ArrayAccess, Stringable
      *
      * @param int $offset the offset to be returned
      */
-    public function offsetGet(mixed $offset): string|null
+    public function offsetGet(mixed $offset): string
     {
-        return $this->characters[$offset] ?? null;
+        return $this->characters[$offset] ?? '';
     }
 
     /**

--- a/tests/Lexer/IsMethodsTest.php
+++ b/tests/Lexer/IsMethodsTest.php
@@ -115,12 +115,11 @@ class IsMethodsTest extends TestCase
     {
         $this->assertEquals(Token::FLAG_SYMBOL_VARIABLE, Context::isSymbol('@'));
         $this->assertEquals(Token::FLAG_SYMBOL_BACKTICK, Context::isSymbol('`'));
-
-        $this->assertEquals(Token::FLAG_SYMBOL_VARIABLE, Context::isSymbol('@id'));
-        $this->assertEquals(Token::FLAG_SYMBOL_BACKTICK, Context::isSymbol('`id`'));
+        $this->assertEquals(Token::FLAG_SYMBOL_PARAMETER, Context::isSymbol(':'));
+        $this->assertEquals(Token::FLAG_SYMBOL_PARAMETER, Context::isSymbol('?'));
 
         $this->assertNull(Context::isSymbol(''));
-        $this->assertNull(Context::isSymbol('id'));
+        $this->assertNull(Context::isSymbol('i'));
     }
 
     public function testisSeparator(): void

--- a/tests/Lexer/IsMethodsTest.php
+++ b/tests/Lexer/IsMethodsTest.php
@@ -107,11 +107,8 @@ class IsMethodsTest extends TestCase
         $this->assertEquals(Token::FLAG_STRING_SINGLE_QUOTES, Context::isString("'"));
         $this->assertEquals(Token::FLAG_STRING_DOUBLE_QUOTES, Context::isString('"'));
 
-        $this->assertEquals(Token::FLAG_STRING_SINGLE_QUOTES, Context::isString("'foo bar'"));
-        $this->assertEquals(Token::FLAG_STRING_DOUBLE_QUOTES, Context::isString('"foo bar"'));
-
         $this->assertNull(Context::isString(''));
-        $this->assertNull(Context::isString('foo bar'));
+        $this->assertNull(Context::isString('f'));
     }
 
     public function testIsSymbol(): void

--- a/tests/Misc/UtfStringTest.php
+++ b/tests/Misc/UtfStringTest.php
@@ -33,8 +33,8 @@ class UtfStringTest extends TestCase
 
         // offsetGet
         $this->assertEquals('.', $str[self::TEST_PHRASE_LEN - 1]);
-        $this->assertNull($str[-1]);
-        $this->assertNull($str[self::TEST_PHRASE_LEN]);
+        $this->assertEquals('', $str[-1]);
+        $this->assertEquals('', $str[self::TEST_PHRASE_LEN]);
     }
 
     public function testSet(): void

--- a/tests/Tools/templates/TestContext.php
+++ b/tests/Tools/templates/TestContext.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Contexts;
 
-use PhpMyAdmin\SqlParser\Context;
 use PhpMyAdmin\SqlParser\Token;
 
 /**
@@ -15,7 +14,7 @@ use PhpMyAdmin\SqlParser\Token;
  *
  * @see https://www.phpmyadmin.net/contribute
  */
-class TestContext extends Context
+final class TestContext
 {
     /**
      * List of keywords.
@@ -24,11 +23,10 @@ class TestContext extends Context
      *
      * @see Token
      *
-     * @var array<string,int>
      * @psalm-var non-empty-array<string,Token::FLAG_KEYWORD_*|int>
      * @phpstan-var non-empty-array<non-empty-string,Token::FLAG_KEYWORD_*|int>
      */
-    public static array $keywords = [
+    public const KEYWORDS = [
         'NO_FLAG' => Token::FLAG_KEYWORD,
         'RESERVED' => Token::FLAG_KEYWORD | Token::FLAG_KEYWORD_RESERVED,
         'RESERVED2' => Token::FLAG_KEYWORD | Token::FLAG_KEYWORD_RESERVED,


### PR DESCRIPTION
`match` is better optimized than multiple `if` statements, especially when JIT is in use. 