### PR TITLE
Add handling of index hints on join clauses too. Fixes #593 and #497.

### DIFF
--- a/src/Components/JoinKeyword.php
+++ b/src/Components/JoinKeyword.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\SqlParser\Components;
 
 use PhpMyAdmin\SqlParser\Component;
 use PhpMyAdmin\SqlParser\Parsers\Conditions;
+use PhpMyAdmin\SqlParser\Parsers\IndexHints;
 
 use function array_search;
 
@@ -60,28 +61,39 @@ final class JoinKeyword implements Component
     public ArrayObj|null $using = null;
 
     /**
+     * Index hints
+     *
+     * @var IndexHint[]
+     */
+    public array $indexHints = [];
+
+    /**
      * @see JoinKeyword::JOINS
      *
-     * @param string|null      $type  Join type
-     * @param Expression|null  $expr  join expression
-     * @param Condition[]|null $on    join conditions
-     * @param ArrayObj|null    $using columns joined
+     * @param string|null      $type       Join type
+     * @param Expression|null  $expr       join expression
+     * @param Condition[]|null $on         join conditions
+     * @param ArrayObj|null    $using      columns joined
+     * @param IndexHint[]      $indexHints index hints
      */
     public function __construct(
         string|null $type = null,
         Expression|null $expr = null,
         array|null $on = null,
         ArrayObj|null $using = null,
+        array $indexHints = [],
     ) {
         $this->type = $type;
         $this->expr = $expr;
         $this->on = $on;
         $this->using = $using;
+        $this->indexHints = $indexHints;
     }
 
     public function build(): string
     {
         return array_search($this->type, self::JOINS) . ' ' . $this->expr
+            . ($this->indexHints !== [] ? ' ' . IndexHints::buildAll($this->indexHints) : '')
             . (! empty($this->on) ? ' ON ' . Conditions::buildAll($this->on) : '')
             . (! empty($this->using) ? ' USING ' . $this->using->build() : '');
     }

--- a/src/Parsers/JoinKeywords.php
+++ b/src/Parsers/JoinKeywords.php
@@ -31,6 +31,7 @@ final class JoinKeywords implements Parseable
         $expr = new JoinKeyword();
 
         /**
+         * TODO: OLD
          * The state of the parser.
          *
          * Below are the states of the parser.
@@ -39,6 +40,24 @@ final class JoinKeywords implements Parseable
          *
          *      1 -----------------------[ expr ]----------------------> 2
          *
+         *      2 ------------------------[ ON ]-----------------------> 3
+         *      2 -----------------------[ USING ]---------------------> 4
+         *
+         *      3 --------------------[ conditions ]-------------------> 0
+         *
+         *      4 ----------------------[ columns ]--------------------> 0
+         */
+        /**
+         * TODO: NEW
+         * The state of the parser.
+         *
+         * Below are the states of the parser.
+         *
+         *      0 -----------------------[ JOIN ]----------------------> 1
+         *
+         *      1 -----------------------[ expr ]----------------------> 2
+         *
+         *      2 -------------------[ index_hints ]-------------------> 2
          *      2 ------------------------[ ON ]-----------------------> 3
          *      2 -----------------------[ USING ]---------------------> 4
          *
@@ -89,6 +108,12 @@ final class JoinKeywords implements Parseable
                             break;
                         case 'USING':
                             $state = 4;
+                            break;
+                        case 'USE':
+                        case 'IGNORE':
+                        case 'FORCE':
+                            // Adding index hint on the JOIN clause.
+                            $expr->indexHints = IndexHints::parse($parser, $list);
                             break;
                         default:
                             if (empty(JoinKeyword::JOINS[$token->keyword])) {

--- a/src/Parsers/JoinKeywords.php
+++ b/src/Parsers/JoinKeywords.php
@@ -31,24 +31,6 @@ final class JoinKeywords implements Parseable
         $expr = new JoinKeyword();
 
         /**
-         * TODO: OLD
-         * The state of the parser.
-         *
-         * Below are the states of the parser.
-         *
-         *      0 -----------------------[ JOIN ]----------------------> 1
-         *
-         *      1 -----------------------[ expr ]----------------------> 2
-         *
-         *      2 ------------------------[ ON ]-----------------------> 3
-         *      2 -----------------------[ USING ]---------------------> 4
-         *
-         *      3 --------------------[ conditions ]-------------------> 0
-         *
-         *      4 ----------------------[ columns ]--------------------> 0
-         */
-        /**
-         * TODO: NEW
          * The state of the parser.
          *
          * Below are the states of the parser.

--- a/tests/Builder/SelectStatementTest.php
+++ b/tests/Builder/SelectStatementTest.php
@@ -353,4 +353,65 @@ class SelectStatementTest extends TestCase
             $stmt->build(),
         );
     }
+
+    public function testBuilderSelectFromWithForceIndex(): void
+    {
+        $query = 'SELECT *'
+            . ' FROM uno FORCE INDEX (id)';
+        $parser = new Parser($query);
+        $stmt = $parser->statements[0];
+
+        self::assertSame($query, $stmt->build());
+    }
+
+    /**
+     * Ensures issue #497 is fixed.
+     */
+    public function testBuilderSelectFromJoinWithForceIndex(): void
+    {
+        $query = 'SELECT *'
+            . ' FROM uno'
+            . ' JOIN dos FORCE INDEX (two_id) ON dos.id = uno.id';
+        $parser = new Parser($query);
+        $stmt = $parser->statements[0];
+
+        self::assertSame($query, $stmt->build());
+    }
+
+    /**
+     * Ensures issue #593 is fixed.
+     */
+    public function testBuilderSelectFromInnerJoinWithForceIndex(): void
+    {
+        $query = 'SELECT a.id, a.name, b.order_id, b.total'
+            . ' FROM customers a'
+            . ' INNER JOIN orders b FORCE INDEX (idx_customer_id)'
+            . ' ON a.id = b.customer_id'
+            . " WHERE a.status = 'active'";
+
+        $parser = new Parser($query);
+        $stmt = $parser->statements[0];
+
+        $expectedQuery = 'SELECT a.id, a.name, b.order_id, b.total'
+            . ' FROM customers AS `a`'
+            . ' INNER JOIN orders AS `b` FORCE INDEX (idx_customer_id)'
+            . ' ON a.id = b.customer_id'
+            . " WHERE a.status = 'active'";
+
+        self::assertSame($expectedQuery, $stmt->build());
+    }
+
+    public function testBuilderSelectAllFormsOfIndexHints(): void
+    {
+        $query = 'SELECT *'
+            . ' FROM one USE INDEX (col1) IGNORE INDEX (col1, col2) FORCE INDEX (col1, col2, col3)'
+            . ' INNER JOIN two USE INDEX (col3) IGNORE INDEX (col2, col3) FORCE INDEX (col1, col2, col3)'
+            . ' ON one.col1 = two.col2'
+            . ' WHERE 1 = 1';
+
+        $parser = new Parser($query);
+        $stmt = $parser->statements[0];
+
+        self::assertSame($query, $stmt->build());
+    }
 }


### PR DESCRIPTION
Fixes #593 
Fixes #497 

This is to be merged in the `master` branch. After taking another look, it does not seem to be a BC Break as I thought in #593, as the indexHints should just be added from the JOIN clause handling, not being removed from the SELECT statement.

I'll do another PR for the 5.10.x and 5.11.x versions, as this one uses new features from v6 the v5 doesn't have yet.