### PR TITLE
Remove nullability from IndexHint

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -745,7 +745,7 @@ parameters:
 			path: src/Parsers/GroupKeywords.php
 
 		-
-			message: '#^Property PhpMyAdmin\\SqlParser\\Components\\IndexHint\:\:\$type \(string\|null\) does not accept mixed\.$#'
+			message: '#^Property PhpMyAdmin\\SqlParser\\Components\\IndexHint\:\:\$type \(string\) does not accept mixed\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Parsers/IndexHints.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.0.0@b8e96bb617bf59382113b1b56cef751f648a7dc9">
+<files psalm-version="6.1.0@827971f8bc7a28bb4f842f34bf8901521de1cea3">
   <file src="src/Components/AlterOperation.php">
     <PossiblyNullReference>
       <code><![CDATA[has]]></code>
@@ -44,12 +44,6 @@
     <PossiblyUnusedProperty>
       <code><![CDATA[$type]]></code>
     </PossiblyUnusedProperty>
-  </file>
-  <file src="src/Components/IndexHint.php">
-    <PossiblyNullOperand>
-      <code><![CDATA[$this->indexOrKey]]></code>
-      <code><![CDATA[$this->type]]></code>
-    </PossiblyNullOperand>
   </file>
   <file src="src/Components/IntoKeyword.php">
     <PossiblyNullOperand>

--- a/src/Components/IndexHint.php
+++ b/src/Components/IndexHint.php
@@ -13,43 +13,17 @@ use PhpMyAdmin\SqlParser\Parsers\Expressions;
 final class IndexHint implements Component
 {
     /**
-     * The type of hint (USE/FORCE/IGNORE)
-     */
-    public string|null $type;
-
-    /**
-     * What the hint is for (INDEX/KEY)
-     */
-    public string|null $indexOrKey;
-
-    /**
-     * The clause for which this hint is (JOIN/ORDER BY/GROUP BY)
-     */
-    public string|null $for;
-
-    /**
-     * List of indexes in this hint
-     *
-     * @var Expression[]
-     */
-    public array $indexes = [];
-
-    /**
-     * @param string       $type       the type of hint (USE/FORCE/IGNORE)
+     * @param string       $type       The type of hint (USE/FORCE/IGNORE)
      * @param string       $indexOrKey What the hint is for (INDEX/KEY)
-     * @param string       $for        the clause for which this hint is (JOIN/ORDER BY/GROUP BY)
+     * @param string|null  $for        The clause for which this hint is (JOIN/ORDER BY/GROUP BY)
      * @param Expression[] $indexes    List of indexes in this hint
      */
     public function __construct(
-        string|null $type = null,
-        string|null $indexOrKey = null,
-        string|null $for = null,
-        array $indexes = [],
+        public string $type = '',
+        public string $indexOrKey = '',
+        public string|null $for = null,
+        public array $indexes = [],
     ) {
-        $this->type = $type;
-        $this->indexOrKey = $indexOrKey;
-        $this->for = $for;
-        $this->indexes = $indexes;
     }
 
     public function build(): string

--- a/src/Parsers/IndexHints.php
+++ b/src/Parsers/IndexHints.php
@@ -28,7 +28,7 @@ final class IndexHints implements Parseable
     {
         $ret = [];
         $expr = new IndexHint();
-        $expr->type = $options['type'] ?? null;
+        $expr->type = $options['type'] ?? '';
         /**
          * The state of the parser.
          *

--- a/tests/data/parser/parseSelectIndexHintErr1.out
+++ b/tests/data/parser/parseSelectIndexHintErr1.out
@@ -252,7 +252,7 @@
                     {
                         "@type": "PhpMyAdmin\\SqlParser\\Components\\IndexHint",
                         "type": "FORCE",
-                        "indexOrKey": null,
+                        "indexOrKey": "",
                         "for": null,
                         "indexes": [
                             {


### PR DESCRIPTION
This confused me but I checked the documentation and it turns out that neither $type nor $indexOrKey can be null. https://dev.mysql.com/doc/refman/8.4/en/index-hints.html