### PR TITLE
Remove `/tests` folder from pull

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 *.out linguist-language=json
 
 /tools export-ignore
-/tests/benchmarks export-ignore
+/tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .editorconfig export-ignore


### PR DESCRIPTION
The `/tests` folder is several MBs big. It sounds like developers don't need this folder when they depend on this package and install it through Composer, so I have excluded it in `.gitattributes`.

