### PR TITLE
Exclude tests from published package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 *.out linguist-language=json
 
 /tools export-ignore
-/tests/benchmarks export-ignore
+/tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .editorconfig export-ignore


### PR DESCRIPTION
Currently the test folder is a whopping 12MB. This is downloaded in every CI while not being used. Any chance in excluding this from the package when publishing?

![image](https://github.com/user-attachments/assets/4874c99a-d80f-4a18-8e24-5206676eae17)
