### PR TITLE
Refactoring formatter

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1753,15 +1753,15 @@ parameters:
 			path: src/Utils/CLI.php
 
 		-
-			message: '#^Parameter \#1 \$query of static method PhpMyAdmin\\SqlParser\\Utils\\Formatter\:\:format\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Utils/CLI.php
-
-		-
 			message: '#^Parameter \#1 \$str of class PhpMyAdmin\\SqlParser\\Lexer constructor expects PhpMyAdmin\\SqlParser\\UtfString\|string, string\|false given\.$#'
 			identifier: argument.type
 			count: 2
+			path: src/Utils/CLI.php
+
+		-
+			message: '#^Parameter \$type of class PhpMyAdmin\\SqlParser\\Utils\\FormattingOptions constructor expects ''cli''\|''html''\|''text'', string\|false given\.$#'
+			identifier: argument.type
+			count: 1
 			path: src/Utils/CLI.php
 
 		-
@@ -1771,51 +1771,9 @@ parameters:
 			path: src/Utils/Error.php
 
 		-
-			message: '#^Argument of an invalid type array\<int, array\<string, int\|string\>\>\|bool\|string supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: src/Utils/Formatter.php
-
-		-
-			message: '#^Binary operation "&" between int and int\|string results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Utils/Formatter.php
-
-		-
-			message: '#^Binary operation "&\=" between array\<int, array\<string, int\|string\>\>\|bool\|string\|null and array\<int, array\<string, int\|string\>\>\|bool\|string\|null results in an error\.$#'
-			identifier: assignOp.invalid
-			count: 1
-			path: src/Utils/Formatter.php
-
-		-
-			message: '#^Binary operation "\." between array\<int, array\<string, int\|string\>\>\|bool\|string and string results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Utils/Formatter.php
-
-		-
-			message: '#^Binary operation "\.\=" between string and mixed results in an error\.$#'
-			identifier: assignOp.invalid
-			count: 1
-			path: src/Utils/Formatter.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: src/Utils/Formatter.php
-
-		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 4
-			path: src/Utils/Formatter.php
-
-		-
-			message: '#^Method PhpMyAdmin\\SqlParser\\Utils\\Formatter\:\:getMergedOptions\(\) should return array\<string, array\<int, array\<string, int\|string\>\>\|bool\|string\> but returns array\<string, mixed\>\.$#'
-			identifier: return.type
-			count: 1
+			count: 3
 			path: src/Utils/Formatter.php
 
 		-
@@ -1825,26 +1783,8 @@ parameters:
 			path: src/Utils/Formatter.php
 
 		-
-			message: '#^Only booleans are allowed in &&, array\<int, array\<string, int\|string\>\>\|bool\|string given on the left side\.$#'
-			identifier: booleanAnd.leftNotBoolean
-			count: 2
-			path: src/Utils/Formatter.php
-
-		-
-			message: '#^Only booleans are allowed in &&, array\<int, array\<string, int\|string\>\>\|bool\|string given on the right side\.$#'
-			identifier: booleanAnd.rightNotBoolean
-			count: 2
-			path: src/Utils/Formatter.php
-
-		-
 			message: '#^Only booleans are allowed in an if condition, bool\|int given\.$#'
 			identifier: if.condNotBoolean
-			count: 1
-			path: src/Utils/Formatter.php
-
-		-
-			message: '#^Only booleans are allowed in \|\|, array\<int, array\<string, int\|string\>\>\|bool\|string given on the right side\.$#'
-			identifier: booleanOr.rightNotBoolean
 			count: 1
 			path: src/Utils/Formatter.php
 
@@ -1867,21 +1807,9 @@ parameters:
 			path: src/Utils/Formatter.php
 
 		-
-			message: '#^Parameter \#1 \$string of function str_repeat expects string, array\<int, array\<string, int\|string\>\>\|bool\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Utils/Formatter.php
-
-		-
 			message: '#^Parameter \#1 \$string of method PhpMyAdmin\\SqlParser\\Utils\\Formatter\:\:escapeConsole\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 4
-			path: src/Utils/Formatter.php
-
-		-
-			message: '#^Parameter \#2 \$newFormats of static method PhpMyAdmin\\SqlParser\\Utils\\Formatter\:\:mergeFormats\(\) expects array\<int, array\<string, int\|string\>\>, array\<int, array\<string, int\|string\>\>\|bool\|string given\.$#'
-			identifier: argument.type
-			count: 1
 			path: src/Utils/Formatter.php
 
 		-
@@ -1891,7 +1819,7 @@ parameters:
 			path: src/Utils/Formatter.php
 
 		-
-			message: '#^Trying to invoke int\<min, \-1\>\|int\<1, max\>\|non\-falsy\-string but it might not be a callable\.$#'
+			message: '#^Trying to invoke non\-empty\-string but it might not be a callable\.$#'
 			identifier: callable.nonCallable
 			count: 1
 			path: src/Utils/Formatter.php
@@ -2736,7 +2664,7 @@ parameters:
 		-
 			message: '#^Dynamic call to static method PHPUnit\\Framework\\Assert\:\:assertEquals\(\)\.$#'
 			identifier: staticMethod.dynamicCall
-			count: 4
+			count: 3
 			path: tests/Utils/FormatterTest.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1819,12 +1819,6 @@ parameters:
 			path: src/Utils/Formatter.php
 
 		-
-			message: '#^Trying to invoke non\-empty\-string but it might not be a callable\.$#'
-			identifier: callable.nonCallable
-			count: 1
-			path: src/Utils/Formatter.php
-
-		-
 			message: '''
 				#^Access to deprecated property \$isDelete of class PhpMyAdmin\\SqlParser\\Utils\\StatementFlags\:
 				Use \{@see self\:\:\$queryType\} instead\.$#

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
+<files psalm-version="6.15.1@28dc127af1b5aecd52314f6f645bafc10d0e11f9">
   <file src="src/Components/AlterOperation.php">
     <PossiblyNullReference>
       <code><![CDATA[has]]></code>
@@ -951,6 +951,9 @@
     </PossiblyNullOperand>
   </file>
   <file src="src/Utils/CLI.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$params['f']]]></code>
+    </ArgumentTypeCoercion>
     <InvalidReturnStatement>
       <code><![CDATA[getopt($opt, $long)]]></code>
     </InvalidReturnStatement>
@@ -962,7 +965,7 @@
     </MixedArgumentTypeCoercion>
     <PossiblyFalseArgument>
       <code><![CDATA[$params['c']]]></code>
-      <code><![CDATA[$params['q']]]></code>
+      <code><![CDATA[$params['f']]]></code>
       <code><![CDATA[$params['q']]]></code>
       <code><![CDATA[$params['q']]]></code>
     </PossiblyFalseArgument>
@@ -1008,16 +1011,6 @@
       <code><![CDATA[$text]]></code>
       <code><![CDATA[$text]]></code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$format['cli']]]></code>
-      <code><![CDATA[$format['cli']]]></code>
-      <code><![CDATA[$format['cli']]]></code>
-      <code><![CDATA[$format['flags']]]></code>
-      <code><![CDATA[$format['flags']]]></code>
-      <code><![CDATA[$format['function']]]></code>
-      <code><![CDATA[$format['html']]]></code>
-      <code><![CDATA[$format['type']]]></code>
-    </MixedArrayAccess>
     <MixedArrayOffset>
       <code><![CDATA[self::$inlineClauses[$lastClause]]]></code>
       <code><![CDATA[self::$inlineClauses[$lastClause]]]></code>
@@ -1030,32 +1023,16 @@
     </MixedArrayTypeCoercion>
     <MixedAssignment>
       <code><![CDATA[$blocksLineEndings[]]]></code>
-      <code><![CDATA[$format]]></code>
-      <code><![CDATA[$func]]></code>
       <code><![CDATA[$lineEnded]]></code>
-      <code><![CDATA[$prev]]></code>
       <code><![CDATA[$text]]></code>
     </MixedAssignment>
-    <MixedFunctionCall>
-      <code><![CDATA[$func($text)]]></code>
-    </MixedFunctionCall>
     <MixedOperand>
-      <code><![CDATA[$format['cli']]]></code>
-      <code><![CDATA[$format['flags']]]></code>
-      <code><![CDATA[$format['html']]]></code>
       <code><![CDATA[$lineEnded]]></code>
     </MixedOperand>
     <MixedReturnStatement>
       <code><![CDATA[$text]]></code>
       <code><![CDATA[$text]]></code>
     </MixedReturnStatement>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options['formats']]]></code>
-      <code><![CDATA[$this->options['indentation']]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidIterator>
-      <code><![CDATA[$this->options['formats']]]></code>
-    </PossiblyInvalidIterator>
     <PossiblyNullArrayOffset>
       <code><![CDATA[Parser::KEYWORD_PARSERS]]></code>
       <code><![CDATA[Parser::STATEMENT_PARSERS]]></code>
@@ -1068,11 +1045,6 @@
     </PossiblyNullOperand>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$lineEnded]]></code>
-      <code><![CDATA[$this->options['clause_newline']]]></code>
-      <code><![CDATA[$this->options['parts_newline']]]></code>
-      <code><![CDATA[$this->options['parts_newline']]]></code>
-      <code><![CDATA[$this->options['parts_newline']]]></code>
-      <code><![CDATA[$this->options['remove_comments']]]></code>
     </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Utils/Query.php">

--- a/src/Utils/CLI.php
+++ b/src/Utils/CLI.php
@@ -139,11 +139,13 @@ class CLI
             Context::setMode(Context::SQL_MODE_ANSI_QUOTES);
         }
 
-        if (isset($params['q'])) {
+        if (isset($params['q']) && $params['q'] !== false) {
+            // $params['f'] is guaranteed to be set and valid at this point. @see parseHighlight()
             echo Formatter::format(
                 $params['q'],
-                ['type' => $params['f']],
+                new FormattingOptions(type: $params['f']),
             );
+
             echo "\n";
 
             return 0;

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -11,7 +11,6 @@ use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\TokensList;
 use PhpMyAdmin\SqlParser\TokenType;
 
-use function array_merge;
 use function array_pop;
 use function end;
 use function htmlspecialchars;
@@ -23,20 +22,12 @@ use function str_replace;
 use function strtoupper;
 
 use const ENT_NOQUOTES;
-use const PHP_SAPI;
 
 /**
  * Utilities that are used for formatting queries.
  */
 class Formatter
 {
-    /**
-     * The formatting options.
-     *
-     * @var array<string, bool|string|array<int, array<string, int|string>>>
-     */
-    public array $options;
-
     /**
      * Clauses that are usually short.
      *
@@ -83,122 +74,15 @@ class Formatter
         'SUBPARTITION BY',
     ];
 
-    /** @param array<string, bool|string|array<int, array<string, int|string>>> $options the formatting options */
-    public function __construct(array $options = [])
+    protected function __construct(protected FormattingOptions $options = new FormattingOptions())
     {
-        $this->options = $this->getMergedOptions($options);
-    }
-
-    /**
-     * The specified formatting options are merged with the default values.
-     *
-     * @param array<string, bool|string|array<int, array<string, int|string>>> $options
-     *
-     * @return array<string, bool|string|array<int, array<string, int|string>>>
-     */
-    protected function getMergedOptions(array $options): array
-    {
-        $options = array_merge(
-            $this->getDefaultOptions(),
-            $options,
-        );
-
-        if (isset($options['formats'])) {
-            $options['formats'] = self::mergeFormats($this->getDefaultFormats(), $options['formats']);
-        } else {
-            $options['formats'] = $this->getDefaultFormats();
-        }
-
-        if ($options['line_ending'] === null) {
-            $options['line_ending'] = $options['type'] === 'html' ? '<br/>' : "\n";
-        }
-
-        if ($options['indentation'] === null) {
-            $options['indentation'] = $options['type'] === 'html' ? '&nbsp;&nbsp;&nbsp;&nbsp;' : '    ';
-        }
-
-        // `parts_newline` requires `clause_newline`
-        $options['parts_newline'] &= $options['clause_newline'];
-
-        return $options;
-    }
-
-    /**
-     * The default formatting options.
-     *
-     * @return array<string, bool|string|null>
-     * @psalm-return array{
-     *   type: ('cli'|'text'),
-     *   line_ending: null,
-     *   indentation: null,
-     *   remove_comments: false,
-     *   clause_newline: true,
-     *   parts_newline: true,
-     *   indent_parts: true
-     * }
-     */
-    protected function getDefaultOptions(): array
-    {
-        return [
-            /*
-             * The format of the result.
-             *
-             * @var string The type ('text', 'cli' or 'html')
-             */
-            'type' => PHP_SAPI === 'cli' ? 'cli' : 'text',
-
-            /*
-             * The line ending used.
-             * By default, for text this is "\n" and for HTML this is "<br/>".
-             *
-             * @var string
-             */
-            'line_ending' => null,
-
-            /*
-             * The string used for indentation.
-             *
-             * @var string
-             */
-            'indentation' => null,
-
-            /*
-             * Whether comments should be removed or not.
-             *
-             * @var bool
-             */
-            'remove_comments' => false,
-
-            /*
-             * Whether each clause should be on a new line.
-             *
-             * @var bool
-             */
-            'clause_newline' => true,
-
-            /*
-             * Whether each part should be on a new line.
-             * Parts are delimited by brackets and commas.
-             *
-             * @var bool
-             */
-            'parts_newline' => true,
-
-            /*
-             * Whether each part of each clause should be indented.
-             *
-             * @var bool
-             */
-            'indent_parts' => true,
-        ];
     }
 
     /**
      * The styles used for HTML formatting.
      * [$type, $flags, $span, $callback].
      *
-     * @return array<int, array<string, int|string>>
-     * @psalm-return list<array{type: int, flags: int, html: string, cli: string, function: string}>
+     * @return list<array{type: int, flags: int, html: string, cli: string, function: string}>
      */
     protected function getDefaultFormats(): array
     {
@@ -260,68 +144,6 @@ class Formatter
                 'function' => '',
             ],
         ];
-    }
-
-    /**
-     * @param array<int, array<string, int|string>> $formats
-     * @param array<int, array<string, int|string>> $newFormats
-     *
-     * @return array<int, array<string, int|string>>
-     */
-    private static function mergeFormats(array $formats, array $newFormats): array
-    {
-        $added = [];
-        $integers = [
-            'flags',
-            'type',
-        ];
-        $strings = [
-            'html',
-            'cli',
-            'function',
-        ];
-
-        /* Sanitize the array so that we do not have to care later */
-        foreach ($newFormats as $j => $new) {
-            foreach ($integers as $name) {
-                if (isset($new[$name])) {
-                    continue;
-                }
-
-                $newFormats[$j][$name] = 0;
-            }
-
-            foreach ($strings as $name) {
-                if (isset($new[$name])) {
-                    continue;
-                }
-
-                $newFormats[$j][$name] = '';
-            }
-        }
-
-        /* Process changes to existing formats */
-        foreach ($formats as $i => $original) {
-            foreach ($newFormats as $j => $new) {
-                if ($new['type'] !== $original['type'] || $original['flags'] !== $new['flags']) {
-                    continue;
-                }
-
-                $formats[$i] = $new;
-                $added[] = $j;
-            }
-        }
-
-        /* Add not already handled formats */
-        foreach ($newFormats as $j => $new) {
-            if (in_array($j, $added)) {
-                continue;
-            }
-
-            $formats[] = $new;
-        }
-
-        return $formats;
     }
 
     /**
@@ -408,7 +230,7 @@ class Formatter
                 continue;
             }
 
-            if ($curr->type === TokenType::Comment && $this->options['remove_comments']) {
+            if ($curr->type === TokenType::Comment && $this->options->removeComments) {
                 // Skip Comments if option `remove_comments` is enabled
                 continue;
             }
@@ -423,7 +245,7 @@ class Formatter
 
                 // The options of a clause should stay on the same line and everything that follows.
                 if (
-                    $this->options['parts_newline']
+                    $this->options->clauseNewline
                     && ! $formattedOptions
                     && empty(self::$inlineClauses[$lastClause])
                     && (
@@ -440,12 +262,9 @@ class Formatter
                 $isClause = static::isClause($curr);
 
                 if ($isClause !== false) {
-                    if (
-                        ($isClause === 2 || $this->options['clause_newline'])
-                        && empty(self::$shortClauses[$lastClause])
-                    ) {
+                    if (($isClause === 2 || $this->options->clauseNewline) && empty(self::$shortClauses[$lastClause])) {
                         $lineEnded = true;
-                        if ($this->options['parts_newline'] && $indent > 0) {
+                        if ($this->options->clauseNewline && $indent > 0) {
                             --$indent;
                         }
                     }
@@ -482,7 +301,7 @@ class Formatter
                         || (
                             empty(self::$inlineClauses[$lastClause])
                             && ! $shortGroup
-                            && $this->options['parts_newline']
+                            && $this->options->clauseNewline
                         )
                     ) {
                         $lineEnded = true;
@@ -513,7 +332,7 @@ class Formatter
 
                 // Finishing the line.
                 if ($lineEnded) {
-                    $ret .= $this->options['line_ending'] . str_repeat($this->options['indentation'], (int) $indent);
+                    $ret .= $this->options->lineEnding . str_repeat($this->options->indentation, (int) $indent);
                     $lineEnded = false;
                 } elseif (
                     $prev->keyword === 'DELIMITER'
@@ -541,7 +360,7 @@ class Formatter
             $prev = $curr;
         }
 
-        if ($this->options['type'] === 'cli') {
+        if ($this->options->type === 'cli') {
             return $ret . "\x1b[0m";
         }
 
@@ -633,7 +452,7 @@ class Formatter
         $text = $token->token;
         static $prev;
 
-        foreach ($this->options['formats'] as $format) {
+        foreach ($this->getDefaultFormats() as $format) {
             if (
                 $token->type->value !== $format['type'] || ! (($token->flags & $format['flags']) === $format['flags'])
             ) {
@@ -641,17 +460,17 @@ class Formatter
             }
 
             // Running transformation function.
-            if (! empty($format['function'])) {
+            if ($format['function'] !== '') {
                 $func = $format['function'];
                 $text = $func($text);
             }
 
             // Formatting HTML.
-            if ($this->options['type'] === 'html') {
+            if ($this->options->type === 'html') {
                 return '<span ' . $format['html'] . '>' . htmlspecialchars($text, ENT_NOQUOTES) . '</span>';
             }
 
-            if ($this->options['type'] === 'cli') {
+            if ($this->options->type === 'cli') {
                 if ($prev !== $format['cli']) {
                     $prev = $format['cli'];
 
@@ -664,7 +483,7 @@ class Formatter
             break;
         }
 
-        if ($this->options['type'] === 'cli') {
+        if ($this->options->type === 'cli') {
             if ($prev !== "\x1b[39m") {
                 $prev = "\x1b[39m";
 
@@ -674,7 +493,7 @@ class Formatter
             return $this->escapeConsole($text);
         }
 
-        if ($this->options['type'] === 'html') {
+        if ($this->options->type === 'html') {
             return htmlspecialchars($text, ENT_NOQUOTES);
         }
 
@@ -684,12 +503,12 @@ class Formatter
     /**
      * Formats a query.
      *
-     * @param string                                                           $query   The query to be formatted
-     * @param array<string, bool|string|array<int, array<string, int|string>>> $options the formatting options
+     * @param string            $query   The query to be formatted
+     * @param FormattingOptions $options the formatting options
      *
      * @return string the formatted string
      */
-    public static function format(string $query, array $options = []): string
+    public static function format(string $query, FormattingOptions $options = new FormattingOptions()): string
     {
         $lexer = new Lexer($query);
         $formatter = new self($options);

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -19,7 +19,6 @@ use function mb_strlen;
 use function str_contains;
 use function str_repeat;
 use function str_replace;
-use function strtolower;
 use function strtoupper;
 
 use const ENT_NOQUOTES;
@@ -77,74 +76,6 @@ class Formatter
 
     protected function __construct(protected FormattingOptions $options = new FormattingOptions())
     {
-    }
-
-    /**
-     * The styles used for HTML formatting.
-     * [$type, $flags, $span, $callback].
-     *
-     * @return list<array{type: TokenType, flags: int, html: string, cli: string, function: callable|''}>
-     */
-    protected function getDefaultFormats(): array
-    {
-        return [
-            [
-                'type' => TokenType::Keyword,
-                'flags' => Token::FLAG_KEYWORD_RESERVED,
-                'html' => 'sql-reserved',
-                'cli' => "\x1b[35m",
-                'function' => strtoupper(...),
-            ],
-            [
-                'type' => TokenType::Keyword,
-                'flags' => 0,
-                'html' => 'sql-keyword',
-                'cli' => "\x1b[95m",
-                'function' => strtoupper(...),
-            ],
-            [
-                'type' => TokenType::Comment,
-                'flags' => 0,
-                'html' => 'sql-comment',
-                'cli' => "\x1b[37m",
-                'function' => '',
-            ],
-            [
-                'type' => TokenType::Bool,
-                'flags' => 0,
-                'html' => 'sql-atom',
-                'cli' => "\x1b[36m",
-                'function' => strtoupper(...),
-            ],
-            [
-                'type' => TokenType::Number,
-                'flags' => 0,
-                'html' => 'sql-number',
-                'cli' => "\x1b[92m",
-                'function' => strtolower(...),
-            ],
-            [
-                'type' => TokenType::String,
-                'flags' => 0,
-                'html' => 'sql-string',
-                'cli' => "\x1b[91m",
-                'function' => '',
-            ],
-            [
-                'type' => TokenType::Symbol,
-                'flags' => Token::FLAG_SYMBOL_PARAMETER,
-                'html' => 'sql-parameter',
-                'cli' => "\x1b[31m",
-                'function' => '',
-            ],
-            [
-                'type' => TokenType::Symbol,
-                'flags' => 0,
-                'html' => 'sql-variable',
-                'cli' => "\x1b[36m",
-                'function' => '',
-            ],
-        ];
     }
 
     /**
@@ -453,7 +384,7 @@ class Formatter
         $text = $token->token;
         static $prev;
 
-        foreach ($this->getDefaultFormats() as $format) {
+        foreach ($this->options->formats as $format) {
             if ($token->type !== $format['type'] || ! (($token->flags & $format['flags']) === $format['flags'])) {
                 continue;
             }

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -83,64 +83,64 @@ class Formatter
      * The styles used for HTML formatting.
      * [$type, $flags, $span, $callback].
      *
-     * @return list<array{type: int, flags: int, html: string, cli: string, function: callable|''}>
+     * @return list<array{type: TokenType, flags: int, html: string, cli: string, function: callable|''}>
      */
     protected function getDefaultFormats(): array
     {
         return [
             [
-                'type' => TokenType::Keyword->value,
+                'type' => TokenType::Keyword,
                 'flags' => Token::FLAG_KEYWORD_RESERVED,
-                'html' => 'class="sql-reserved"',
+                'html' => 'sql-reserved',
                 'cli' => "\x1b[35m",
                 'function' => strtoupper(...),
             ],
             [
-                'type' => TokenType::Keyword->value,
+                'type' => TokenType::Keyword,
                 'flags' => 0,
-                'html' => 'class="sql-keyword"',
+                'html' => 'sql-keyword',
                 'cli' => "\x1b[95m",
                 'function' => strtoupper(...),
             ],
             [
-                'type' => TokenType::Comment->value,
+                'type' => TokenType::Comment,
                 'flags' => 0,
-                'html' => 'class="sql-comment"',
+                'html' => 'sql-comment',
                 'cli' => "\x1b[37m",
                 'function' => '',
             ],
             [
-                'type' => TokenType::Bool->value,
+                'type' => TokenType::Bool,
                 'flags' => 0,
-                'html' => 'class="sql-atom"',
+                'html' => 'sql-atom',
                 'cli' => "\x1b[36m",
                 'function' => strtoupper(...),
             ],
             [
-                'type' => TokenType::Number->value,
+                'type' => TokenType::Number,
                 'flags' => 0,
-                'html' => 'class="sql-number"',
+                'html' => 'sql-number',
                 'cli' => "\x1b[92m",
                 'function' => strtolower(...),
             ],
             [
-                'type' => TokenType::String->value,
+                'type' => TokenType::String,
                 'flags' => 0,
-                'html' => 'class="sql-string"',
+                'html' => 'sql-string',
                 'cli' => "\x1b[91m",
                 'function' => '',
             ],
             [
-                'type' => TokenType::Symbol->value,
+                'type' => TokenType::Symbol,
                 'flags' => Token::FLAG_SYMBOL_PARAMETER,
-                'html' => 'class="sql-parameter"',
+                'html' => 'sql-parameter',
                 'cli' => "\x1b[31m",
                 'function' => '',
             ],
             [
-                'type' => TokenType::Symbol->value,
+                'type' => TokenType::Symbol,
                 'flags' => 0,
-                'html' => 'class="sql-variable"',
+                'html' => 'sql-variable',
                 'cli' => "\x1b[36m",
                 'function' => '',
             ],
@@ -454,21 +454,16 @@ class Formatter
         static $prev;
 
         foreach ($this->getDefaultFormats() as $format) {
-            if (
-                $token->type->value !== $format['type'] || ! (($token->flags & $format['flags']) === $format['flags'])
-            ) {
+            if ($token->type !== $format['type'] || ! (($token->flags & $format['flags']) === $format['flags'])) {
                 continue;
             }
 
-            // Running transformation function.
             if ($format['function'] !== '') {
-                $func = $format['function'];
-                $text = $func($text);
+                $text = $format['function']($text);
             }
 
-            // Formatting HTML.
             if ($this->options->type === 'html') {
-                return '<span ' . $format['html'] . '>' . htmlspecialchars($text, ENT_NOQUOTES) . '</span>';
+                return '<span class="' . $format['html'] . '">' . htmlspecialchars($text, ENT_NOQUOTES) . '</span>';
             }
 
             if ($this->options->type === 'cli') {

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -19,6 +19,7 @@ use function mb_strlen;
 use function str_contains;
 use function str_repeat;
 use function str_replace;
+use function strtolower;
 use function strtoupper;
 
 use const ENT_NOQUOTES;
@@ -82,7 +83,7 @@ class Formatter
      * The styles used for HTML formatting.
      * [$type, $flags, $span, $callback].
      *
-     * @return list<array{type: int, flags: int, html: string, cli: string, function: string}>
+     * @return list<array{type: int, flags: int, html: string, cli: string, function: callable|''}>
      */
     protected function getDefaultFormats(): array
     {
@@ -92,14 +93,14 @@ class Formatter
                 'flags' => Token::FLAG_KEYWORD_RESERVED,
                 'html' => 'class="sql-reserved"',
                 'cli' => "\x1b[35m",
-                'function' => 'strtoupper',
+                'function' => strtoupper(...),
             ],
             [
                 'type' => TokenType::Keyword->value,
                 'flags' => 0,
                 'html' => 'class="sql-keyword"',
                 'cli' => "\x1b[95m",
-                'function' => 'strtoupper',
+                'function' => strtoupper(...),
             ],
             [
                 'type' => TokenType::Comment->value,
@@ -113,14 +114,14 @@ class Formatter
                 'flags' => 0,
                 'html' => 'class="sql-atom"',
                 'cli' => "\x1b[36m",
-                'function' => 'strtoupper',
+                'function' => strtoupper(...),
             ],
             [
                 'type' => TokenType::Number->value,
                 'flags' => 0,
                 'html' => 'class="sql-number"',
                 'cli' => "\x1b[92m",
-                'function' => 'strtolower',
+                'function' => strtolower(...),
             ],
             [
                 'type' => TokenType::String->value,

--- a/src/Utils/FormattingOptions.php
+++ b/src/Utils/FormattingOptions.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\SqlParser\Utils;
 
+use PhpMyAdmin\SqlParser\Token;
+use PhpMyAdmin\SqlParser\TokenType;
+
+use function strtolower;
+use function strtoupper;
+
 use const PHP_SAPI;
 
 final class FormattingOptions
@@ -11,15 +17,111 @@ final class FormattingOptions
     public string $lineEnding;
     public string $indentation;
 
-    /** @param 'cli'|'text'|'html' $type */
+    /**
+     * @param 'cli'|'text'|'html'                                                                        $type
+     * @param list<array{type: TokenType, flags: int, html: string, cli: string, function: callable|''}> $formats
+     */
     public function __construct(
         public readonly string $type = PHP_SAPI === 'cli' ? 'cli' : 'text',
         string|null $lineEnding = null,
         string|null $indentation = null,
         public bool $removeComments = false,
         public bool $clauseNewline = true,
+        public array $formats = [],
     ) {
         $this->lineEnding = $lineEnding ?? ($this->type === 'html' ? '<br/>' : "\n");
         $this->indentation = $indentation ?? ($this->type === 'html' ? '&nbsp;&nbsp;&nbsp;&nbsp;' : '    ');
+        $this->formats = self::mergeFormats(self::getDefaultFormats(), $this->formats);
+    }
+
+    /**
+     * @param list<array{type: TokenType, flags: int, html: string, cli: string, function: callable|''}> $formats
+     * @param list<array{type: TokenType, flags: int, html: string, cli: string, function: callable|''}> $newFormats
+     *
+     * @return list<array{type: TokenType, flags: int, html: string, cli: string, function: callable|''}>
+     */
+    private static function mergeFormats(array $formats, array $newFormats): array
+    {
+        foreach ($newFormats as $new) {
+            foreach ($formats as $i => $original) {
+                if ($new['type'] !== $original['type'] || $original['flags'] !== $new['flags']) {
+                    continue;
+                }
+
+                $formats[$i] = $new;
+                continue 2;
+            }
+
+            $formats[] = $new;
+        }
+
+        return $formats;
+    }
+
+    /**
+     * The styles used for HTML formatting.
+     *
+     * @return list<array{type: TokenType, flags: int, html: string, cli: string, function: callable|''}>
+     */
+    public static function getDefaultFormats(): array
+    {
+        return [
+            [
+                'type' => TokenType::Keyword,
+                'flags' => Token::FLAG_KEYWORD_RESERVED,
+                'html' => 'sql-reserved',
+                'cli' => "\x1b[35m",
+                'function' => strtoupper(...),
+            ],
+            [
+                'type' => TokenType::Keyword,
+                'flags' => 0,
+                'html' => 'sql-keyword',
+                'cli' => "\x1b[95m",
+                'function' => strtoupper(...),
+            ],
+            [
+                'type' => TokenType::Comment,
+                'flags' => 0,
+                'html' => 'sql-comment',
+                'cli' => "\x1b[37m",
+                'function' => '',
+            ],
+            [
+                'type' => TokenType::Bool,
+                'flags' => 0,
+                'html' => 'sql-atom',
+                'cli' => "\x1b[36m",
+                'function' => strtoupper(...),
+            ],
+            [
+                'type' => TokenType::Number,
+                'flags' => 0,
+                'html' => 'sql-number',
+                'cli' => "\x1b[92m",
+                'function' => strtolower(...),
+            ],
+            [
+                'type' => TokenType::String,
+                'flags' => 0,
+                'html' => 'sql-string',
+                'cli' => "\x1b[91m",
+                'function' => '',
+            ],
+            [
+                'type' => TokenType::Symbol,
+                'flags' => Token::FLAG_SYMBOL_PARAMETER,
+                'html' => 'sql-parameter',
+                'cli' => "\x1b[31m",
+                'function' => '',
+            ],
+            [
+                'type' => TokenType::Symbol,
+                'flags' => 0,
+                'html' => 'sql-variable',
+                'cli' => "\x1b[36m",
+                'function' => '',
+            ],
+        ];
     }
 }

--- a/src/Utils/FormattingOptions.php
+++ b/src/Utils/FormattingOptions.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\SqlParser\Utils;
+
+use const PHP_SAPI;
+
+final class FormattingOptions
+{
+    public string $lineEnding;
+    public string $indentation;
+
+    /** @param 'cli'|'text'|'html' $type */
+    public function __construct(
+        public readonly string $type = PHP_SAPI === 'cli' ? 'cli' : 'text',
+        string|null $lineEnding = null,
+        string|null $indentation = null,
+        public bool $removeComments = false,
+        public bool $clauseNewline = true,
+    ) {
+        $this->lineEnding = $lineEnding ?? ($this->type === 'html' ? '<br/>' : "\n");
+        $this->indentation = $indentation ?? ($this->type === 'html' ? '&nbsp;&nbsp;&nbsp;&nbsp;' : '    ');
+    }
+}

--- a/tests/Utils/FormatterTest.php
+++ b/tests/Utils/FormatterTest.php
@@ -5,12 +5,71 @@ declare(strict_types=1);
 namespace PhpMyAdmin\SqlParser\Tests\Utils;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
+use PhpMyAdmin\SqlParser\Token;
+use PhpMyAdmin\SqlParser\TokenType;
 use PhpMyAdmin\SqlParser\Utils\Formatter;
 use PhpMyAdmin\SqlParser\Utils\FormattingOptions;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+use function strtoupper;
+
 class FormatterTest extends TestCase
 {
+    public function testMergeFormats(): void
+    {
+        $object = new FormattingOptions(formats: []);
+        self::assertEquals($object->formats, FormattingOptions::getDefaultFormats());
+
+        $object = new FormattingOptions(formats: [
+            [
+                'type' => TokenType::Keyword,
+                'flags' => Token::FLAG_KEYWORD_RESERVED,
+                'html' => 'sql-foo',
+                'cli' => "\x1b[35m",
+                'function' => strtoupper(...),
+            ],
+            [
+                'type' => TokenType::Keyword,
+                'flags' => 0,
+                'html' => 'sql-bar',
+                'cli' => "\x1b[95m",
+                'function' => strtoupper(...),
+            ],
+            [
+                'type' => TokenType::Keyword,
+                'flags' => Token::FLAG_KEYWORD_COMPOSED,
+                'html' => 'sql-baz',
+                'cli' => "\x1b[95m",
+                'function' => strtoupper(...),
+            ],
+
+        ]);
+
+        self::assertContainsEquals([
+            'type' => TokenType::Keyword,
+            'flags' => Token::FLAG_KEYWORD_RESERVED,
+            'html' => 'sql-foo',
+            'cli' => "\x1b[35m",
+            'function' => strtoupper(...),
+        ], $object->formats);
+
+        self::assertContainsEquals([
+            'type' => TokenType::Keyword,
+            'flags' => 0,
+            'html' => 'sql-bar',
+            'cli' => "\x1b[95m",
+            'function' => strtoupper(...),
+        ], $object->formats);
+
+        self::assertContainsEquals([
+            'type' => TokenType::Keyword,
+            'flags' => Token::FLAG_KEYWORD_COMPOSED,
+            'html' => 'sql-baz',
+            'cli' => "\x1b[95m",
+            'function' => strtoupper(...),
+        ], $object->formats);
+    }
+
     /** @param array{removeComments?: bool, lineEnding?: string, indentation?: string} $options */
     #[DataProvider('formatQueriesProviders')]
     public function testFormat(

--- a/tests/Utils/FormatterTest.php
+++ b/tests/Utils/FormatterTest.php
@@ -6,276 +6,49 @@ namespace PhpMyAdmin\SqlParser\Tests\Utils;
 
 use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Utils\Formatter;
+use PhpMyAdmin\SqlParser\Utils\FormattingOptions;
 use PHPUnit\Framework\Attributes\DataProvider;
-use ReflectionMethod;
 
 class FormatterTest extends TestCase
 {
-    /**
-     * @param array<int, array<string, int|string>> $default
-     * @param array<int, array<string, int|string>> $overriding
-     * @param array<int, array<string, int|string>> $expected
-     * @psalm-param list<array{type: int, flags: int, html: string, cli: string, function?: string}> $default
-     * @psalm-param list<array{type?: int, flags?: int, html?: string, cli?: string, function?: string}> $overriding
-     * @psalm-param list<array{type: int, flags: int, html: string, cli: string, function?: string}> $expected
-     */
-    #[DataProvider('mergeFormatsProvider')]
-    public function testMergeFormats(array $default, array $overriding, array $expected): void
-    {
-        $formatter = $this->createPartialMock(Formatter::class, ['getDefaultOptions', 'getDefaultFormats']);
-
-        $formatter->expects($this->once())
-            ->method('getDefaultOptions')
-            ->willReturn([
-                'type' => 'text',
-                'line_ending' => null,
-                'indentation' => null,
-                'clause_newline' => null,
-                'parts_newline' => null,
-            ]);
-
-        $formatter->expects($this->once())
-            ->method('getDefaultFormats')
-            ->willReturn($default);
-
-        $expectedOptions = [
-            'type' => 'test-type',
-            'line_ending' => '<br>',
-            'indentation' => '    ',
-            'clause_newline' => null,
-            'parts_newline' => 0,
-            'formats' => $expected,
-        ];
-
-        $overridingOptions = [
-            'type' => 'test-type',
-            'line_ending' => '<br>',
-            'formats' => $overriding,
-        ];
-
-        $reflectionMethod = new ReflectionMethod($formatter, 'getMergedOptions');
-        $this->assertEquals($expectedOptions, $reflectionMethod->invoke($formatter, $overridingOptions));
-    }
-
-    /**
-     * @return array<string, array<string, array<int, array<string, int|string>>>>
-     * @psalm-return array<string, array{
-     *     default: list<array{type: int, flags: int, html: string, cli: string, function?: string}>,
-     *     overriding: list<array{type?: int, flags?: int, html?: string, cli?: string, function?: string}>,
-     *     expected: list<array{type: int, flags: int, html: string, cli: string, function?: string}>
-     * }>
-     */
-    public static function mergeFormatsProvider(): array
-    {
-        // [default[], overriding[], expected[]]
-        return [
-            'empty formats' => [
-                'default' => [
-                    [
-                        'type' => 0,
-                        'flags' => 0,
-                        'html' => '',
-                        'cli' => '',
-                        'function' => '',
-                    ],
-                ],
-                'overriding' => [
-                    [],
-                ],
-                'expected' => [
-                    [
-                        'type' => 0,
-                        'flags' => 0,
-                        'html' => '',
-                        'cli' => '',
-                        'function' => '',
-                    ],
-                ],
-            ],
-            'no flags' => [
-                'default' => [
-                    [
-                        'type' => 0,
-                        'flags' => 0,
-                        'html' => 'html',
-                        'cli' => 'cli',
-                    ],
-                    [
-                        'type' => 0,
-                        'flags' => 1,
-                        'html' => 'html',
-                        'cli' => 'cli',
-                    ],
-                ],
-                'overriding' => [
-                    [
-                        'type' => 0,
-                        'html' => 'new html',
-                        'cli' => 'new cli',
-                    ],
-                ],
-                'expected' => [
-                    [
-                        'type' => 0,
-                        'flags' => 0,
-                        'html' => 'new html',
-                        'cli' => 'new cli',
-                        'function' => '',
-                    ],
-                    [
-                        'type' => 0,
-                        'flags' => 1,
-                        'html' => 'html',
-                        'cli' => 'cli',
-                    ],
-                ],
-            ],
-            'with flags' => [
-                'default' => [
-                    [
-                        'type' => -1,
-                        'flags' => 0,
-                        'html' => 'html',
-                        'cli' => 'cli',
-                    ],
-                    [
-                        'type' => 0,
-                        'flags' => 0,
-                        'html' => 'html',
-                        'cli' => 'cli',
-                    ],
-                    [
-                        'type' => 0,
-                        'flags' => 1,
-                        'html' => 'html',
-                        'cli' => 'cli',
-                    ],
-                ],
-                'overriding' => [
-                    [
-                        'type' => 0,
-                        'flags' => 0,
-                        'html' => 'new html',
-                        'cli' => 'new cli',
-                    ],
-                ],
-                'expected' => [
-                    [
-                        'type' => -1,
-                        'flags' => 0,
-                        'html' => 'html',
-                        'cli' => 'cli',
-                    ],
-                    [
-                        'type' => 0,
-                        'flags' => 0,
-                        'html' => 'new html',
-                        'cli' => 'new cli',
-                        'function' => '',
-                    ],
-                    [
-                        'type' => 0,
-                        'flags' => 1,
-                        'html' => 'html',
-                        'cli' => 'cli',
-                    ],
-                ],
-            ],
-            'with extra formats' => [
-                'default' => [
-                    [
-                        'type' => 0,
-                        'flags' => 0,
-                        'html' => 'html',
-                        'cli' => 'cli',
-                    ],
-                ],
-                'overriding' => [
-                    [
-                        'type' => 0,
-                        'flags' => 1,
-                        'html' => 'new html',
-                        'cli' => 'new cli',
-                    ],
-                    [
-                        'type' => 1,
-                        'html' => 'new html',
-                        'cli' => 'new cli',
-                    ],
-                    [
-                        'type' => 1,
-                        'flags' => 1,
-                        'html' => 'new html',
-                        'cli' => 'new cli',
-                    ],
-                ],
-                'expected' => [
-                    [
-                        'type' => 0,
-                        'flags' => 0,
-                        'html' => 'html',
-                        'cli' => 'cli',
-                    ],
-                    [
-                        'type' => 0,
-                        'flags' => 1,
-                        'html' => 'new html',
-                        'cli' => 'new cli',
-                        'function' => '',
-                    ],
-                    [
-                        'type' => 1,
-                        'flags' => 0,
-                        'html' => 'new html',
-                        'cli' => 'new cli',
-                        'function' => '',
-                    ],
-                    [
-                        'type' => 1,
-                        'flags' => 1,
-                        'html' => 'new html',
-                        'cli' => 'new cli',
-                        'function' => '',
-                    ],
-                ],
-            ],
-        ];
-    }
-
-    /** @param array<string, bool> $options */
+    /** @param array{removeComments?: bool, lineEnding?: string, indentation?: string} $options */
     #[DataProvider('formatQueriesProviders')]
-    public function testFormat(string $query, string $text, string $cli, string $html, array $options = []): void
-    {
-        // Test TEXT format
+    public function testFormat(
+        string $query,
+        string $text,
+        string $cli,
+        string $html,
+        array $options = [],
+    ): void {
+        $options['type'] = 'text';
         $this->assertEquals(
             $text,
-            Formatter::format($query, ['type' => 'text'] + $options),
+            Formatter::format($query, new FormattingOptions(...$options)),
             'Text formatting failed.',
         );
 
-        // Test CLI format
+        $options['type'] = 'cli';
         $this->assertEquals(
             $cli,
-            Formatter::format($query, ['type' => 'cli'] + $options),
+            Formatter::format($query, new FormattingOptions(...$options)),
             'CLI formatting failed.',
         );
 
-        // Test HTML format
+        $options['type'] = 'html';
         $this->assertEquals(
             $html,
-            Formatter::format($query, ['type' => 'html'] + $options),
+            Formatter::format($query, new FormattingOptions(...$options)),
             'HTML formatting failed.',
         );
     }
 
     /**
-     * @return array<string, array<string, string|array<string, string|bool>>>
-     * @psalm-return array<string, array{
+     * @return array<string, array{
      *     query: string,
      *     text: string,
      *     cli: string,
      *     html: string,
-     *     options?: array<string, bool>
+     *     options?: array{removeComments?: bool, lineEnding?: string, indentation?: string}
      * }>
      */
     public static function formatQueriesProviders(): array
@@ -440,7 +213,7 @@ class FormatterTest extends TestCase
                     '&nbsp;&nbsp;&nbsp;&nbsp;tbl<br/>' .
                     '<span class="sql-reserved">WHERE</span><br/>' .
                     '&nbsp;&nbsp;&nbsp;&nbsp;<span class="sql-number">1</span>',
-                'options' => ['remove_comments' => true],
+                'options' => ['removeComments' => true],
             ],
             'keywords' => [
                 'query' => 'select hex("1")',
@@ -633,6 +406,30 @@ class FormatterTest extends TestCase
                     '&nbsp;&nbsp;&nbsp;&nbsp;tbl<br/>' .
                     '<span class="sql-reserved">WHERE</span><br/>' .
                     '&nbsp;&nbsp;&nbsp;&nbsp;col = <span class="sql-parameter">?</span>',
+            ],
+            'single line' => [
+                'query' => 'select *' . "\n" .
+                    'from tbl # Comment' . "\n" .
+                    'where 1 -- Comment',
+                'text' => 'SELECT ' .
+                    '* ' .
+                    'FROM ' .
+                    'tbl ' .
+                    'WHERE ' .
+                    '1',
+                'cli' => "\x1b[35mSELECT " .
+                    "\x1b[39m* " .
+                    "\x1b[35mFROM " .
+                    "\x1b[39mtbl " .
+                    "\x1b[35mWHERE " .
+                    "\x1b[92m1\x1b[0m",
+                'html' => '<span class="sql-reserved">SELECT</span> ' .
+                    '* ' .
+                    '<span class="sql-reserved">FROM</span> ' .
+                    'tbl ' .
+                    '<span class="sql-reserved">WHERE</span> ' .
+                    '<span class="sql-number">1</span>',
+                'options' => ['lineEnding' => ' ', 'indentation' => '', 'removeComments' => true],
             ],
         ];
     }


### PR DESCRIPTION
These PR adds DTO for formatting options. In this repo, it seems that only type is ever provided. In the main repo only 

> $this->response->addJSON(['sql' => Formatter::format($query, ['line_ending' => ' ', 'indentation' => ''])]);

This PR removes the ability to provide custom formats. I don't know if any other project relies on it and I can add it back, but I removed it to make the code simpler. I think it would be better to keep that option even if it's not used in PMA, but please let me know which is better. 

The options `parts_newline` and `indent_parts` were removed as I could not see them being used anywhere. 