### PR TITLE
Fix hex string literal (x'...') parsing in CREATE TABLE DEFAULT values

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1621,11 +1621,6 @@ parameters:
 			path: src/Token.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\<0, 16\\> given\\.$#"
-			count: 1
-			path: src/Token.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\<0, 2\\> given\\.$#"
 			count: 1
 			path: src/Token.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2096,8 +2096,18 @@ parameters:
 			path: tests/Builder/CreateStatementTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEmpty\\(\\)\\.$#"
+			count: 2
+			path: tests/Builder/CreateStatementTest.php
+
+		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
-			count: 34
+			count: 35
+			path: tests/Builder/CreateStatementTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\)\\.$#"
+			count: 1
 			path: tests/Builder/CreateStatementTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -698,9 +698,17 @@
       <code>$this-&gt;last</code>
       <code>$this-&gt;last</code>
     </LoopInvalidation>
-    <MixedArrayAccess occurrences="43">
+    <MixedArrayAccess occurrences="51">
       <code>$this-&gt;str[$this-&gt;last + 1]</code>
       <code>$this-&gt;str[$this-&gt;last++]</code>
+      <code>$this-&gt;str[$this-&gt;last]</code>
+      <code>$this-&gt;str[$this-&gt;last]</code>
+      <code>$this-&gt;str[$this-&gt;last]</code>
+      <code>$this-&gt;str[$this-&gt;last]</code>
+      <code>$this-&gt;str[$this-&gt;last]</code>
+      <code>$this-&gt;str[$this-&gt;last]</code>
+      <code>$this-&gt;str[$this-&gt;last]</code>
+      <code>$this-&gt;str[$this-&gt;last]</code>
       <code>$this-&gt;str[$this-&gt;last]</code>
       <code>$this-&gt;str[$this-&gt;last]</code>
       <code>$this-&gt;str[$this-&gt;last]</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -698,7 +698,7 @@
       <code>$this-&gt;last</code>
       <code>$this-&gt;last</code>
     </LoopInvalidation>
-    <MixedArrayAccess occurrences="51">
+    <MixedArrayAccess occurrences="52">
       <code>$this-&gt;str[$this-&gt;last + 1]</code>
       <code>$this-&gt;str[$this-&gt;last++]</code>
       <code>$this-&gt;str[$this-&gt;last]</code>

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -833,11 +833,17 @@ class Lexer extends Core
         //
         //      10 -------------------[ 0 to 9 ]-------------------> 4
         //
+        //      11 ----------------------[ ' ]---------------------> 12
+        //
+        //      12 --------[ 0 to 9, A to F, a to f ]--------------> 12
+        //      12 ----------------------[ ' ]---------------------> 13
+        //
         // State 1 may be reached by negative numbers.
         // State 2 is reached only by hex numbers.
         // State 4 is reached only by float numbers.
         // State 5 is reached only by numbers in approximate form.
         // State 7 is reached only by numbers in bit representation.
+        // State 11 is reached only by hex string literals (x'...').
         // State 10 is a forced proxy to state 4 ensuring a starting dot (= "0.something") precedes a digit, and not "e"
         // or "E" causing wrongly interpreted scientific notation (".e[0 to 9]" is invalid). Such invalid notation could
         // break the lexer when table names under a given database context starts with ".e[0-9]".
@@ -866,6 +872,8 @@ class Lexer extends Core
                     $state = 10;
                 } elseif ($this->str[$this->last] === 'b') {
                     $state = 7;
+                } elseif ($this->str[$this->last] === 'x' || $this->str[$this->last] === 'X') {
+                    $state = 11;
                 } elseif ($this->str[$this->last] !== '+') {
                     // `+` is a valid character in a number.
                     break;
@@ -949,6 +957,29 @@ class Lexer extends Core
                 }
             } elseif ($state === 9) {
                 break;
+            } elseif ($state === 11) {
+                // x'...' hex string literal - expect opening quote
+                $flags |= Token::FLAG_NUMBER_HEX_STRING;
+                if ($this->str[$this->last] !== '\'') {
+                    break;
+                }
+
+                $state = 12;
+            } elseif ($state === 12) {
+                // x'...' hex string literal - hex digits or closing quote
+                if ($this->str[$this->last] === '\'') {
+                    $state = 13;
+                } elseif (
+                    ! (
+                        ($this->str[$this->last] >= '0' && $this->str[$this->last] <= '9')
+                        || ($this->str[$this->last] >= 'A' && $this->str[$this->last] <= 'F')
+                        || ($this->str[$this->last] >= 'a' && $this->str[$this->last] <= 'f')
+                    )
+                ) {
+                    break;
+                }
+            } elseif ($state === 13) {
+                break;
             } elseif ($state === 10) {
                 $flags |= Token::FLAG_NUMBER_FLOAT;
                 if ($this->str[$this->last] < '0' || $this->str[$this->last] > '9') {
@@ -961,7 +992,7 @@ class Lexer extends Core
             $token .= $this->str[$this->last];
         }
 
-        if ($state === 2 || $state === 3 || ($token !== '.' && $state === 4) || $state === 6 || $state === 9) {
+        if ($state === 2 || $state === 3 || ($token !== '.' && $state === 4) || $state === 6 || $state === 9 || $state === 13) {
             --$this->last;
 
             return new Token($token, Token::TYPE_NUMBER, $flags);

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -992,7 +992,10 @@ class Lexer extends Core
             $token .= $this->str[$this->last];
         }
 
-        if ($state === 2 || $state === 3 || ($token !== '.' && $state === 4) || $state === 6 || $state === 9 || $state === 13) {
+        if (
+            $state === 2 || $state === 3 || ($token !== '.' && $state === 4)
+            || $state === 6 || $state === 9 || $state === 13
+        ) {
             --$this->last;
 
             return new Token($token, Token::TYPE_NUMBER, $flags);

--- a/src/Token.php
+++ b/src/Token.php
@@ -264,7 +264,10 @@ class Token
                     }
                 } elseif (($this->flags & self::FLAG_NUMBER_APPROXIMATE) || ($this->flags & self::FLAG_NUMBER_FLOAT)) {
                     $ret = (float) $ret;
-                } elseif (! ($this->flags & self::FLAG_NUMBER_BINARY) && ! ($this->flags & self::FLAG_NUMBER_HEX_STRING)) {
+                } elseif (
+                    ($this->flags & self::FLAG_NUMBER_BINARY) === 0
+                    && ($this->flags & self::FLAG_NUMBER_HEX_STRING) === 0
+                ) {
                     $ret = (int) $ret;
                 }
 

--- a/src/Token.php
+++ b/src/Token.php
@@ -142,6 +142,7 @@ class Token
     public const FLAG_NUMBER_APPROXIMATE = 4;
     public const FLAG_NUMBER_NEGATIVE = 8;
     public const FLAG_NUMBER_BINARY = 16;
+    public const FLAG_NUMBER_HEX_STRING = 32;
 
     // Strings related flags.
     public const FLAG_STRING_SINGLE_QUOTES = 1;
@@ -263,7 +264,7 @@ class Token
                     }
                 } elseif (($this->flags & self::FLAG_NUMBER_APPROXIMATE) || ($this->flags & self::FLAG_NUMBER_FLOAT)) {
                     $ret = (float) $ret;
-                } elseif (! ($this->flags & self::FLAG_NUMBER_BINARY)) {
+                } elseif (! ($this->flags & self::FLAG_NUMBER_BINARY) && ! ($this->flags & self::FLAG_NUMBER_HEX_STRING)) {
                     $ret = (int) $ret;
                 }
 

--- a/tests/Builder/CreateStatementTest.php
+++ b/tests/Builder/CreateStatementTest.php
@@ -871,4 +871,26 @@ SQL;
             $stmt->build()
         );
     }
+
+    public function testBuildCreateTableWithHexDefault(): void
+    {
+        $sql = "CREATE TABLE `test` (\n"
+            . "  `IP` binary(16) NOT NULL DEFAULT x'00000000000000000000000000000000'\n"
+            . ') ENGINE=InnoDB';
+
+        $parser = new Parser($sql);
+        $this->assertEmpty($parser->errors);
+        $this->assertEquals($sql, $parser->statements[0]->build());
+    }
+
+    public function testBuildCreateTableWithUppercaseHexDefault(): void
+    {
+        $sql = "CREATE TABLE `test` (\n"
+            . "  `IP` binary(16) NOT NULL DEFAULT X'FF'\n"
+            . ')';
+
+        $parser = new Parser($sql);
+        $this->assertEmpty($parser->errors);
+        $this->assertStringContainsString("DEFAULT X'FF'", $parser->statements[0]->build());
+    }
 }


### PR DESCRIPTION
## Summary                                                                                                          
  - The lexer incorrectly tokenized `x'...'` hex string literals as two separate tokens (keyword `x` + string
  `'...'`), producing invalid SQL `x AS '...'` on rebuild                                                             
  - Added states 11-13 to the number parsing state machine (analogous to states 7-9 for `b'...'` binary literals) to
  recognize `x'...'` and `X'...'` as single hex string literal tokens                                                 
  - Added `FLAG_NUMBER_HEX_STRING` to prevent incorrect `hexdec()` conversion of the token value
                                                                                                                                                                                         
                                                            
  Fixes #649