### PR TITLE
Simplify ON keyword check to only needed case

### DIFF
--- a/src/Components/SetOperation.php
+++ b/src/Components/SetOperation.php
@@ -113,12 +113,21 @@ class SetOperation extends Component
                     $commaLastSeenAt = $token;
                 }
             } elseif ($state === 1) {
+                // Reserved keywords like ON are valid values in SET statements
+                // (e.g. SET @@sql_log_bin = ON). Try parsing as expression first,
+                // and if that fails, accept reserved keywords as literal values.
                 $tmp = Expression::parse(
                     $parser,
                     $list,
                     ['breakOnAlias' => true]
                 );
-                if ($tmp === null) {
+                if (
+                    $tmp === null
+                    && $token->type === Token::TYPE_KEYWORD
+                    && $token->value === 'ON'
+                ) {
+                    $tmp = new Expression($token->token);
+                } elseif ($tmp === null) {
                     $parser->error('Missing expression.', $token);
                     break;
                 }

--- a/src/Components/SetOperation.php
+++ b/src/Components/SetOperation.php
@@ -121,11 +121,7 @@ class SetOperation extends Component
                     $list,
                     ['breakOnAlias' => true]
                 );
-                if (
-                    $tmp === null
-                    && $token->type === Token::TYPE_KEYWORD
-                    && $token->value === 'ON'
-                ) {
+                if ($tmp === null && $token->type === Token::TYPE_KEYWORD && $token->value === 'ON') {
                     $tmp = new Expression($token->token);
                 } elseif ($tmp === null) {
                     $parser->error('Missing expression.', $token);


### PR DESCRIPTION
## Summary                                                                                                         
  - `SET @@variable = ON` failed with "Missing expression" because `ON` is a reserved keyword that
  `Expression::parse()` rejected                                                                                     
  - `OFF` worked because it is not a reserved keyword
  - Fix: in `SetOperation::parse()`, after `Expression::parse()` returns null, accept `ON` as a literal value since  
  it is valid in SET statements                                                                                      
                                                                                                                                                                      
                                                                                                                     
  Fixes #627