### PR TITLE
ELSE expressions terminate early when encountering an END token

### DIFF
--- a/src/Components/Expression.php
+++ b/src/Components/Expression.php
@@ -275,8 +275,10 @@ class Expression extends Component
 
                     $isExpr = true;
                 } elseif (
-                    $brackets === 0 && strlen((string) $ret->expr) > 0 && ! $alias
-                    && ($ret->table === null || $ret->table === '')
+                    $token->value === "END" || (
+                        $brackets === 0 && strlen((string) $ret->expr) > 0 && ! $alias
+                        && ($ret->table === null || $ret->table === '')
+                    )
                 ) {
                     /* End of expression */
                     break;


### PR DESCRIPTION
CASE statements with an ELSE returning a value with the "tablename.columnname" format fail due to encountering an END token and parsing it as if it were a column instead. This fixes the issue by checking to see if the current token is an END and breaks before column processing.