### PR TITLE
fix(builder): preserve whitespace between SELECT and UNION body in CREATE VIEW (#655)

### DIFF
--- a/src/Statements/CreateStatement.php
+++ b/src/Statements/CreateStatement.php
@@ -465,7 +465,7 @@ class CreateStatement extends Statement
             $body = TokensList::buildFromArray($this->body);
             // Body tokens (e.g. trailing `UNION ALL (SELECT ...)` after the
             // primary SELECT) are concatenated raw, so without a separator
-            // the rebuilt SQL collides with the SELECT's last token —
+            // the rebuilt SQL collides with the SELECT's last token,
             // `WHERE 3 = 3union all` instead of `WHERE 3 = 3 union all`.
             // Only insert a space when neither side already has one to
             // avoid double-spacing the WITH...AS path.

--- a/src/Statements/CreateStatement.php
+++ b/src/Statements/CreateStatement.php
@@ -462,11 +462,22 @@ class CreateStatement extends Statement
                 $builtStatement = $this->with->build();
             }
 
+            $body = TokensList::buildFromArray($this->body);
+            // Body tokens (e.g. trailing `UNION ALL (SELECT ...)` after the
+            // primary SELECT) are concatenated raw, so without a separator
+            // the rebuilt SQL collides with the SELECT's last token —
+            // `WHERE 3 = 3union all` instead of `WHERE 3 = 3 union all`.
+            // Only insert a space when neither side already has one to
+            // avoid double-spacing the WITH...AS path.
+            $separator = ($builtStatement !== '' && $body !== ''
+                && substr($builtStatement, -1) !== ' '
+                && $body[0] !== ' ') ? ' ' : '';
+
             return 'CREATE '
                 . $this->options->build() . ' '
                 . $this->name->build() . ' '
                 . $fields . ' AS ' . $builtStatement
-                . TokensList::buildFromArray($this->body) . ' '
+                . $separator . $body . ' '
                 . ($this->entityOptions?->build() ?? '');
         }
 

--- a/tests/Builder/CreateStatementTest.php
+++ b/tests/Builder/CreateStatementTest.php
@@ -897,4 +897,29 @@ SQL;
             $stmt->build(),
         );
     }
+
+    /**
+     * Regression for #655: `CREATE VIEW ... AS SELECT ... WHERE ... UNION ALL (...)`
+     * used to lose the whitespace between the SELECT body and the trailing
+     * UNION clause, producing invalid SQL like `WHERE 3 = 3union all (...)`.
+     */
+    public function testBuilderViewWithUnionPreservesWhitespace(): void
+    {
+        $sql = "CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER "
+            . "VIEW `v1` AS select 1 AS `a` where 3 = 3 union all (select 2 AS `a`)";
+
+        $parser = new Parser($sql);
+        $built = $parser->statements[0]->build();
+
+        $this->assertStringNotContainsString(
+            '3union all',
+            $built,
+            'rebuilt CREATE VIEW must keep the space between WHERE clause and UNION',
+        );
+        $this->assertStringContainsString(
+            '3 union all',
+            // case-insensitive match: builder may upper-case the keyword
+            preg_replace('/UNION\s+ALL/i', 'union all', $built),
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #655. ``CreateStatement::build()`` reconstructed ``CREATE VIEW ... AS SELECT ... UNION ...`` by concatenating ``$builtStatement = $this->select->build()`` directly with ``TokensList::buildFromArray($this->body)``. Neither side carried a separator, so the rebuilt SQL collided the SELECT's last token with the UNION:

```
... WHERE 3 = 3union all (...)
```

This was reported downstream in phpmyadmin/phpmyadmin#19692 (and earlier as #18515), the syntax-invalid output broke phpMyAdmin's exports.

## Change

``src/Statements/CreateStatement.php``, insert a single space when both sides are non-empty *and* neither already ends/begins with a space. The existing ``WITH ... AS ( ... ) SELECT ...`` path already produces a trailing space on ``$builtStatement``, so the conditional avoids double-spacing it.

## Test plan

- [x] ``vendor/bin/phpunit tests/Builder/``, 110/110 pass (including the existing ``testBuilderView`` which already exercised UNION on a different shape)
- [x] New ``testBuilderViewWithUnionPreservesWhitespace`` reproducing the issue's exact ``CREATE ALGORITHM=UNDEFINED ... AS select 1 AS \`a\` where 3 = 3 union all (...)`` input. Asserts:
  - rebuilt SQL does not contain ``3union all`` (collision)
  - rebuilt SQL does contain ``3 union all`` (case-normalised)
- [x] Existing WITH+UNION test (``CREATE view view_name AS WITH aa(col1) AS (...) SELECT ...``) unchanged, the conditional separator preserves its prior trailing-space output