### PR TITLE
Parse MariaDB comment command

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2472,7 +2472,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
-			count: 30
+			count: 32
 			path: tests/Lexer/IsMethodsTest.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2472,7 +2472,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
-			count: 32
+			count: 34
 			path: tests/Lexer/IsMethodsTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -811,7 +811,7 @@
       <code>$token</code>
       <code>$token</code>
     </PossiblyNullArgument>
-    <PossiblyNullOperand occurrences="24">
+    <PossiblyNullOperand occurrences="25">
       <code>$this-&gt;delimiter</code>
       <code>$this-&gt;str[$this-&gt;last++]</code>
       <code>$this-&gt;str[$this-&gt;last]</code>
@@ -831,6 +831,7 @@
       <code>$this-&gt;str[$this-&gt;last]</code>
       <code>$this-&gt;str[$this-&gt;last]</code>
       <code>$this-&gt;str[$this-&gt;last]</code>
+      <code>$this-&gt;str[++$this-&gt;last]</code>
       <code>$this-&gt;str[++$this-&gt;last]</code>
       <code>$this-&gt;str[++$this-&gt;last]</code>
       <code>$this-&gt;str[++$this-&gt;last]</code>

--- a/src/Context.php
+++ b/src/Context.php
@@ -443,10 +443,19 @@ abstract class Context
             return Token::FLAG_COMMENT_BASH;
         }
 
-        // If comment is opening C style (/*), warning, it could be a MySQL command (/*!)
+        // If comment is opening C style (/*), warning, it could be
+        // - a MySQL command (/*!)
+        // - a MariaDB command (/*M!)
         if (($len > 1) && ($str[0] === '/') && ($str[1] === '*')) {
-            return ($len > 2) && ($str[2] === '!') ?
-                Token::FLAG_COMMENT_MYSQL_CMD : Token::FLAG_COMMENT_C;
+            if ($len > 2 && $str[2] === '!') {
+                return Token::FLAG_COMMENT_MYSQL_CMD;
+            }
+
+            if ($len > 3 && $str[2] === 'M' && $str[3] === '!') {
+                return Token::FLAG_COMMENT_MARIADB_CMD;
+            }
+
+            return Token::FLAG_COMMENT_C;
         }
 
         // If comment is closing C style (*/), warning, it could conflicts with wildcard and a real opening C style.

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -693,10 +693,21 @@ class Lexer extends Core
                     return new Token($token, Token::TYPE_COMMENT, $flags);
                 }
 
-                // Checking if this is a MySQL-specific command.
-                if ($this->last + 1 < $this->len && $this->str[$this->last + 1] === '!') {
-                    $flags |= Token::FLAG_COMMENT_MYSQL_CMD;
+                // Checking if this is a MySQL (/*!) or MariaDB (/*M!) specific command.
+                if (
+                    $this->last + 1 < $this->len &&
+                    ($this->str[$this->last + 1] === '!' ||
+                        ($this->str[$this->last + 1] === 'M' &&
+                            $this->last + 2 < $this->len &&
+                            $this->str[$this->last + 2] === '!'))
+                ) {
                     $token .= $this->str[++$this->last];
+                    if ($this->str[$this->last] === '!') {
+                        $flags |= Token::FLAG_COMMENT_MYSQL_CMD;
+                    } else {
+                        $flags |= Token::FLAG_COMMENT_MARIADB_CMD;
+                        $token .= $this->str[++$this->last];
+                    }
 
                     while (
                         ++$this->last < $this->len

--- a/src/Token.php
+++ b/src/Token.php
@@ -152,6 +152,7 @@ class Token
     public const FLAG_COMMENT_C = 2;
     public const FLAG_COMMENT_SQL = 4;
     public const FLAG_COMMENT_MYSQL_CMD = 8;
+    public const FLAG_COMMENT_MARIADB_CMD = 16;
 
     // Operators related flags.
     public const FLAG_OPERATOR_ARITHMETIC = 1;

--- a/tests/Lexer/IsMethodsTest.php
+++ b/tests/Lexer/IsMethodsTest.php
@@ -61,6 +61,8 @@ class IsMethodsTest extends TestCase
     {
         $this->assertEquals(Token::FLAG_COMMENT_BASH, Context::isComment('#'));
         $this->assertEquals(Token::FLAG_COMMENT_C, Context::isComment('/*'));
+        $this->assertEquals(Token::FLAG_COMMENT_MYSQL_CMD, Context::isComment('/*!'));
+        $this->assertEquals(Token::FLAG_COMMENT_MYSQL_CMD, Context::isComment('/*!50000'));
         $this->assertEquals(Token::FLAG_COMMENT_C, Context::isComment('*/'));
         $this->assertEquals(Token::FLAG_COMMENT_SQL, Context::isComment('-- '));
         $this->assertEquals(Token::FLAG_COMMENT_SQL, Context::isComment("--\t"));

--- a/tests/Lexer/IsMethodsTest.php
+++ b/tests/Lexer/IsMethodsTest.php
@@ -63,6 +63,8 @@ class IsMethodsTest extends TestCase
         $this->assertEquals(Token::FLAG_COMMENT_C, Context::isComment('/*'));
         $this->assertEquals(Token::FLAG_COMMENT_MYSQL_CMD, Context::isComment('/*!'));
         $this->assertEquals(Token::FLAG_COMMENT_MYSQL_CMD, Context::isComment('/*!50000'));
+        $this->assertEquals(Token::FLAG_COMMENT_MARIADB_CMD, Context::isComment('/*M!'));
+        $this->assertEquals(Token::FLAG_COMMENT_MARIADB_CMD, Context::isComment('/*M!100300'));
         $this->assertEquals(Token::FLAG_COMMENT_C, Context::isComment('*/'));
         $this->assertEquals(Token::FLAG_COMMENT_SQL, Context::isComment('-- '));
         $this->assertEquals(Token::FLAG_COMMENT_SQL, Context::isComment("--\t"));

--- a/tests/Parser/CreateStatementTest.php
+++ b/tests/Parser/CreateStatementTest.php
@@ -60,6 +60,7 @@ class CreateStatementTest extends TestCase
             ['parser/parseCreateTableErr5'],
             ['parser/parseCreateTableSelect'],
             ['parser/parseCreateTableAsSelect'],
+            ['parser/parseCreateTableColumnCompressed'],
             ['parser/parseCreateTableLike'],
             ['parser/parseCreateTableSpatial'],
             ['parser/parseCreateTableSRID'],

--- a/tests/data/lexer/lexComment.in
+++ b/tests/data/lexer/lexComment.in
@@ -1,4 +1,5 @@
 # comment
-SELECT /*!50000 STRAIGHT_JOIN */ col1 FROM table1, table2 /* select query */
+SELECT /*!50000 STRAIGHT_JOIN */ col1 FROM table1, table2; /* select query */
 -- comment
 -- comment 2
+SELECT /*M!100300 1, */ 2;

--- a/tests/data/lexer/lexComment.out
+++ b/tests/data/lexer/lexComment.out
@@ -1,10 +1,10 @@
 {
-    "query": "# comment\nSELECT /*!50000 STRAIGHT_JOIN */ col1 FROM table1, table2 /* select query */\n-- comment\n-- comment 2",
+    "query": "# comment\nSELECT /*!50000 STRAIGHT_JOIN */ col1 FROM table1, table2; /* select query */\n-- comment\n-- comment 2\nSELECT /*M!100300 1, */ 2;",
     "lexer": {
         "@type": "PhpMyAdmin\\SqlParser\\Lexer",
-        "str": "# comment\nSELECT /*!50000 STRAIGHT_JOIN */ col1 FROM table1, table2 /* select query */\n-- comment\n-- comment 2",
-        "len": 110,
-        "last": 111,
+        "str": "# comment\nSELECT /*!50000 STRAIGHT_JOIN */ col1 FROM table1, table2; /* select query */\n-- comment\n-- comment 2\nSELECT /*M!100300 1, */ 2;",
+        "len": 138,
+        "last": 138,
         "list": {
             "@type": "PhpMyAdmin\\SqlParser\\TokensList",
             "tokens": [
@@ -172,12 +172,21 @@
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ";",
+                    "value": ";",
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": 67
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
                     "token": " ",
                     "value": " ",
                     "keyword": null,
                     "type": 3,
                     "flags": 0,
-                    "position": 67
+                    "position": 68
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -186,7 +195,7 @@
                     "keyword": null,
                     "type": 4,
                     "flags": 2,
-                    "position": 68
+                    "position": 69
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -195,7 +204,7 @@
                     "keyword": null,
                     "type": 3,
                     "flags": 0,
-                    "position": 86
+                    "position": 87
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -204,7 +213,7 @@
                     "keyword": null,
                     "type": 4,
                     "flags": 4,
-                    "position": 87
+                    "position": 88
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -213,7 +222,7 @@
                     "keyword": null,
                     "type": 3,
                     "flags": 0,
-                    "position": 97
+                    "position": 98
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -222,7 +231,70 @@
                     "keyword": null,
                     "type": 4,
                     "flags": 4,
-                    "position": 98
+                    "position": 99
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "\n",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 111
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "SELECT",
+                    "value": "SELECT",
+                    "keyword": "SELECT",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 112
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 118
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "/*M!100300 1, */",
+                    "value": "/*M!100300 1, */",
+                    "keyword": null,
+                    "type": 4,
+                    "flags": 2,
+                    "position": 119
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 135
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "2",
+                    "value": 2,
+                    "keyword": null,
+                    "type": 6,
+                    "flags": 0,
+                    "position": 136
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ";",
+                    "value": ";",
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": 137
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -234,7 +306,7 @@
                     "position": null
                 }
             ],
-            "count": 25,
+            "count": 33,
             "idx": 0
         },
         "delimiter": ";",

--- a/tests/data/lexer/lexComment.out
+++ b/tests/data/lexer/lexComment.out
@@ -262,12 +262,57 @@
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
-                    "token": "/*M!100300 1, */",
-                    "value": "/*M!100300 1, */",
+                    "token": "/*M!100300",
+                    "value": "/*M!100300",
+                    "keyword": null,
+                    "type": 4,
+                    "flags": 18,
+                    "position": 119
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 129
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "1",
+                    "value": 1,
+                    "keyword": null,
+                    "type": 6,
+                    "flags": 0,
+                    "position": 130
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ",",
+                    "value": ",",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 16,
+                    "position": 131
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 132
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "*/",
+                    "value": "*/",
                     "keyword": null,
                     "type": 4,
                     "flags": 2,
-                    "position": 119
+                    "position": 133
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -306,7 +351,7 @@
                     "position": null
                 }
             ],
-            "count": 33,
+            "count": 38,
             "idx": 0
         },
         "delimiter": ";",

--- a/tests/data/parser/parseCreateTableColumnCompressed.in
+++ b/tests/data/parser/parseCreateTableColumnCompressed.in
@@ -1,0 +1,1 @@
+CREATE TABLE `t` (`c1` longtext /*M!100301 COMPRESSED*/);

--- a/tests/data/parser/parseCreateTableColumnCompressed.out
+++ b/tests/data/parser/parseCreateTableColumnCompressed.out
@@ -1,0 +1,229 @@
+{
+    "query": "CREATE TABLE `t` (`c1` longtext /*M!100301 COMPRESSED*/);",
+    "lexer": {
+        "@type": "PhpMyAdmin\\SqlParser\\Lexer",
+        "str": "CREATE TABLE `t` (`c1` longtext /*M!100301 COMPRESSED*/);",
+        "len": 57,
+        "last": 57,
+        "list": {
+            "@type": "PhpMyAdmin\\SqlParser\\TokensList",
+            "tokens": [
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "CREATE",
+                    "value": "CREATE",
+                    "keyword": "CREATE",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 0
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 6
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "TABLE",
+                    "value": "TABLE",
+                    "keyword": "TABLE",
+                    "type": 1,
+                    "flags": 3,
+                    "position": 7
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 12
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "`t`",
+                    "value": "t",
+                    "keyword": null,
+                    "type": 8,
+                    "flags": 2,
+                    "position": 13
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 16
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "(",
+                    "value": "(",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 16,
+                    "position": 17
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "`c1`",
+                    "value": "c1",
+                    "keyword": null,
+                    "type": 8,
+                    "flags": 2,
+                    "position": 18
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 22
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "longtext",
+                    "value": "LONGTEXT",
+                    "keyword": "LONGTEXT",
+                    "type": 1,
+                    "flags": 11,
+                    "position": 23
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 31
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "/*M!100301 COMPRESSED*/",
+                    "value": "/*M!100301 COMPRESSED*/",
+                    "keyword": null,
+                    "type": 4,
+                    "flags": 2,
+                    "position": 32
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ")",
+                    "value": ")",
+                    "keyword": null,
+                    "type": 2,
+                    "flags": 16,
+                    "position": 55
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": ";",
+                    "value": ";",
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": 56
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": null,
+                    "value": null,
+                    "keyword": null,
+                    "type": 9,
+                    "flags": 0,
+                    "position": null
+                }
+            ],
+            "count": 15,
+            "idx": 15
+        },
+        "delimiter": ";",
+        "delimiterLen": 1,
+        "strict": false,
+        "errors": []
+    },
+    "parser": {
+        "@type": "PhpMyAdmin\\SqlParser\\Parser",
+        "list": {
+            "@type": "@1"
+        },
+        "statements": [
+            {
+                "@type": "PhpMyAdmin\\SqlParser\\Statements\\CreateStatement",
+                "name": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\Expression",
+                    "database": null,
+                    "table": "t",
+                    "column": null,
+                    "expr": "`t`",
+                    "alias": null,
+                    "function": null,
+                    "subquery": null
+                },
+                "entityOptions": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": []
+                },
+                "fields": [
+                    {
+                        "@type": "PhpMyAdmin\\SqlParser\\Components\\CreateDefinition",
+                        "name": "c1",
+                        "isConstraint": null,
+                        "type": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\DataType",
+                            "name": "LONGTEXT",
+                            "parameters": [],
+                            "options": {
+                                "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                                "options": []
+                            }
+                        },
+                        "key": null,
+                        "references": null,
+                        "options": {
+                            "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                            "options": []
+                        }
+                    }
+                ],
+                "with": null,
+                "select": null,
+                "like": null,
+                "partitionBy": null,
+                "partitionsNum": null,
+                "subpartitionBy": null,
+                "subpartitionsNum": null,
+                "partitions": null,
+                "table": null,
+                "return": null,
+                "parameters": null,
+                "body": [],
+                "options": {
+                    "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
+                    "options": {
+                        "6": "TABLE"
+                    }
+                },
+                "first": 0,
+                "last": 13
+            }
+        ],
+        "brackets": 0,
+        "strict": false,
+        "errors": []
+    },
+    "errors": {
+        "lexer": [],
+        "parser": []
+    }
+}

--- a/tests/data/parser/parseCreateTableColumnCompressed.out
+++ b/tests/data/parser/parseCreateTableColumnCompressed.out
@@ -109,12 +109,39 @@
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
-                    "token": "/*M!100301 COMPRESSED*/",
-                    "value": "/*M!100301 COMPRESSED*/",
+                    "token": "/*M!100301",
+                    "value": "/*M!100301",
+                    "keyword": null,
+                    "type": 4,
+                    "flags": 18,
+                    "position": 32
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": " ",
+                    "value": " ",
+                    "keyword": null,
+                    "type": 3,
+                    "flags": 0,
+                    "position": 42
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "COMPRESSED",
+                    "value": "COMPRESSED",
+                    "keyword": "COMPRESSED",
+                    "type": 1,
+                    "flags": 1,
+                    "position": 43
+                },
+                {
+                    "@type": "PhpMyAdmin\\SqlParser\\Token",
+                    "token": "*/",
+                    "value": "*/",
                     "keyword": null,
                     "type": 4,
                     "flags": 2,
-                    "position": 32
+                    "position": 53
                 },
                 {
                     "@type": "PhpMyAdmin\\SqlParser\\Token",
@@ -144,8 +171,8 @@
                     "position": null
                 }
             ],
-            "count": 15,
-            "idx": 15
+            "count": 18,
+            "idx": 18
         },
         "delimiter": ";",
         "delimiterLen": 1,
@@ -192,7 +219,9 @@
                         "references": null,
                         "options": {
                             "@type": "PhpMyAdmin\\SqlParser\\Components\\OptionsArray",
-                            "options": []
+                            "options": {
+                                "16": "COMPRESSED"
+                            }
                         }
                     }
                 ],
@@ -215,7 +244,7 @@
                     }
                 },
                 "first": 0,
-                "last": 13
+                "last": 16
             }
         ],
         "brackets": 0,


### PR DESCRIPTION
Adds a new comment flag for MariaDB specific comment commands.
Parses tokens inside comments like `/*M!100300 COMPRESSED */`

MySQL specific comments are also handled unconditionally (no version check), so I kept it the same for the new comment type.

Fixes phpmyadmin/phpmyadmin/issues/20332
