### PR TITLE
Fix PHP 8.5 deprecations

### DIFF
--- a/src/Tools/CustomJsonSerializer.php
+++ b/src/Tools/CustomJsonSerializer.php
@@ -10,6 +10,8 @@ use Zumba\JsonSerializer\JsonSerializer;
 
 use function in_array;
 
+use const PHP_VERSION_ID;
+
 /**
  * Used for .out files generation
  */
@@ -64,7 +66,10 @@ class CustomJsonSerializer extends JsonSerializer
 
             try {
                 $propRef = $ref->getProperty($property);
-                $propRef->setAccessible(true);
+                if (PHP_VERSION_ID < 80100) {
+                    $propRef->setAccessible(true);
+                }
+
                 $data[$property] = $propRef->getValue($value);
             } catch (ReflectionException $e) {
                 $data[$property] = $value->$property;

--- a/tests/Misc/TranslatorTest.php
+++ b/tests/Misc/TranslatorTest.php
@@ -13,16 +13,24 @@ use ReflectionProperty;
 
 use function realpath;
 
+use const PHP_VERSION_ID;
+
 /** @covers \PhpMyAdmin\SqlParser\Translator */
 final class TranslatorTest extends TestCase
 {
     public static function tearDownAfterClass(): void
     {
         $loaderProperty = new ReflectionProperty(Translator::class, 'loader');
-        $loaderProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $loaderProperty->setAccessible(true);
+        }
+
         $loaderProperty->setValue(null, null);
         $translatorProperty = new ReflectionProperty(Translator::class, 'translator');
-        $translatorProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $translatorProperty->setAccessible(true);
+        }
+
         $translatorProperty->setValue(null, null);
         Translator::setLocale('en');
     }
@@ -46,10 +54,16 @@ final class TranslatorTest extends TestCase
     public function testLoad(?string $globalLang, string $locale, string $expectedLocale): void
     {
         $loaderProperty = new ReflectionProperty(Translator::class, 'loader');
-        $loaderProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $loaderProperty->setAccessible(true);
+        }
+
         $loaderProperty->setValue(null, null);
         $translatorProperty = new ReflectionProperty(Translator::class, 'translator');
-        $translatorProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $translatorProperty->setAccessible(true);
+        }
+
         $translatorProperty->setValue(null, null);
         $GLOBALS['lang'] = $globalLang;
         Translator::setLocale($locale);
@@ -62,16 +76,25 @@ final class TranslatorTest extends TestCase
         self::assertInstanceOf(Loader::class, $loader);
         $loaderClass = new ReflectionClass(Loader::class);
         $localeProperty = $loaderClass->getProperty('locale');
-        $localeProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $localeProperty->setAccessible(true);
+        }
+
         self::assertSame($expectedLocale, $localeProperty->getValue($loader));
         // Compatibility with MoTranslator < 5
         $defaultDomainProperty = $loaderClass->hasProperty('default_domain')
             ? $loaderClass->getProperty('default_domain')
             : $loaderClass->getProperty('defaultDomain');
-        $defaultDomainProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $defaultDomainProperty->setAccessible(true);
+        }
+
         self::assertSame('sqlparser', $defaultDomainProperty->getValue($loader));
         $pathsProperty = $loaderClass->getProperty('paths');
-        $pathsProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $pathsProperty->setAccessible(true);
+        }
+
         self::assertSame(
             ['' => './', 'sqlparser' => realpath(__DIR__ . '/../../src/') . '/../locale/'],
             $pathsProperty->getValue($loader)
@@ -81,10 +104,16 @@ final class TranslatorTest extends TestCase
     public function testGettext(): void
     {
         $loaderProperty = new ReflectionProperty(Translator::class, 'loader');
-        $loaderProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $loaderProperty->setAccessible(true);
+        }
+
         $loaderProperty->setValue(null, null);
         $translatorProperty = new ReflectionProperty(Translator::class, 'translator');
-        $translatorProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $translatorProperty->setAccessible(true);
+        }
+
         $translatorProperty->setValue(null, null);
         Translator::setLocale('pt_BR');
         self::assertSame(
@@ -93,10 +122,16 @@ final class TranslatorTest extends TestCase
         );
 
         $loaderProperty = new ReflectionProperty(Translator::class, 'loader');
-        $loaderProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $loaderProperty->setAccessible(true);
+        }
+
         $loaderProperty->setValue(null, null);
         $translatorProperty = new ReflectionProperty(Translator::class, 'translator');
-        $translatorProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $translatorProperty->setAccessible(true);
+        }
+
         $translatorProperty->setValue(null, null);
         Translator::setLocale('en');
         self::assertSame(

--- a/tests/Utils/FormatterTest.php
+++ b/tests/Utils/FormatterTest.php
@@ -8,6 +8,8 @@ use PhpMyAdmin\SqlParser\Tests\TestCase;
 use PhpMyAdmin\SqlParser\Utils\Formatter;
 use ReflectionMethod;
 
+use const PHP_VERSION_ID;
+
 class FormatterTest extends TestCase
 {
     /**
@@ -54,7 +56,10 @@ class FormatterTest extends TestCase
         ];
 
         $reflectionMethod = new ReflectionMethod($formatter, 'getMergedOptions');
-        $reflectionMethod->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionMethod->setAccessible(true);
+        }
+
         $this->assertEquals($expectedOptions, $reflectionMethod->invoke($formatter, $overridingOptions));
     }
 


### PR DESCRIPTION
This should fix:

```
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\src\Tools\CustomJsonSerializer.php on line 67
Deprecated: Method ReflectionMethod::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\tests\Utils\FormatterTest.php on line 57
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\tests\Misc\TranslatorTest.php on line 22
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\tests\Misc\TranslatorTest.php on line 25
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\tests\Misc\TranslatorTest.php on line 49
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\tests\Misc\TranslatorTest.php on line 52
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\tests\Misc\TranslatorTest.php on line 65
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\tests\Misc\TranslatorTest.php on line 71
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\tests\Misc\TranslatorTest.php on line 74
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\tests\Misc\TranslatorTest.php on line 84
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\tests\Misc\TranslatorTest.php on line 87
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\tests\Misc\TranslatorTest.php on line 96
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in E:\GitHub\sql-parser\tests\Misc\TranslatorTest.php on line 99
```